### PR TITLE
Move Firebase config to environment variables

### DIFF
--- a/ProjectCode/client/.env.example
+++ b/ProjectCode/client/.env.example
@@ -2,3 +2,13 @@
 # Copy this file to .env and update values as needed
 
 REACT_APP_API_BASE_URL=http://localhost:8000
+
+# Firebase Configuration
+# Get these values from Firebase Console > Project Settings
+REACT_APP_FIREBASE_API_KEY=your-api-key
+REACT_APP_FIREBASE_AUTH_DOMAIN=your-project.firebaseapp.com
+REACT_APP_FIREBASE_PROJECT_ID=your-project-id
+REACT_APP_FIREBASE_STORAGE_BUCKET=your-project.appspot.com
+REACT_APP_FIREBASE_MESSAGING_SENDER_ID=your-sender-id
+REACT_APP_FIREBASE_APP_ID=your-app-id
+REACT_APP_FIREBASE_MEASUREMENT_ID=G-XXXXXXXXXX

--- a/ProjectCode/client/src/firebase/config.js
+++ b/ProjectCode/client/src/firebase/config.js
@@ -2,13 +2,13 @@ import { initializeApp } from 'firebase/app';
 import { getAuth } from 'firebase/auth';
 
 const firebaseConfig = {
-  apiKey: "AIzaSyCV9AnOPulBSvWEBfBGprBVk7kFLmwDWnk",
-  authDomain: "newbee-running-club-website.firebaseapp.com",
-  projectId: "newbee-running-club-website",
-  storageBucket: "newbee-running-club-website.firebasestorage.app",
-  messagingSenderId: "577206570730",
-  appId: "1:577206570730:web:169fb9e168168983695193",
-  measurementId: "G-YC22KHNK43"
+  apiKey: process.env.REACT_APP_FIREBASE_API_KEY,
+  authDomain: process.env.REACT_APP_FIREBASE_AUTH_DOMAIN,
+  projectId: process.env.REACT_APP_FIREBASE_PROJECT_ID,
+  storageBucket: process.env.REACT_APP_FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: process.env.REACT_APP_FIREBASE_MESSAGING_SENDER_ID,
+  appId: process.env.REACT_APP_FIREBASE_APP_ID,
+  measurementId: process.env.REACT_APP_FIREBASE_MEASUREMENT_ID
 };
 
 // Initialize Firebase


### PR DESCRIPTION
## Summary
- Remove hardcoded Firebase API keys from config.js
- Use environment variables (REACT_APP_FIREBASE_*) instead
- Update .env.example with Firebase variable template
- Prevents GitHub secret scanning alerts

## Setup Required
After pulling, copy `.env.example` to `.env` and add your Firebase credentials.

## Test plan
- [ ] Verify Firebase auth still works after restart
- [ ] Confirm no hardcoded keys in committed code

🤖 Generated with [Claude Code](https://claude.com/claude-code)