### PR TITLE
Fix overnight Claude workflow permissions

### DIFF
--- a/.github/workflows/overnight-claude.yml
+++ b/.github/workflows/overnight-claude.yml
@@ -2,7 +2,7 @@
 name: Overnight Claude Work
 on:
   schedule:
-    - cron: "0 10 * * *"  # 2 AM PST (San Francisco winter time)
+    - cron: "29 10 * * *"  # 2:29 AM PST (San Francisco winter time)
   workflow_dispatch:  # Allow manual trigger for testing
 
 permissions:

--- a/.github/workflows/overnight-claude.yml
+++ b/.github/workflows/overnight-claude.yml
@@ -5,6 +5,12 @@ on:
     - cron: "0 10 * * *"  # 2 AM PST (San Francisco winter time)
   workflow_dispatch:  # Allow manual trigger for testing
 
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  id-token: write
+
 jobs:
   claude-work:
     runs-on: ubuntu-latest
@@ -16,7 +22,8 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          target_branch: dev
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          base_branch: dev
           prompt: |
             Read the WISHLIST.md file in the repository root.
 


### PR DESCRIPTION
## Summary
- Add required permissions: `contents`, `pull-requests`, `issues`, `id-token`
- Fix invalid input: `target_branch` → `base_branch`
- Add `github_token` for PR creation capability

## Fixes
- "Could not fetch an OIDC token" error
- "Unexpected input 'target_branch'" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)