### PR TITLE
Fix overnight Claude workflow permissions and add tech stack context

### DIFF
--- a/.github/workflows/overnight-claude.yml
+++ b/.github/workflows/overnight-claude.yml
@@ -26,7 +26,13 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           base_branch: dev
+          claude_args: |
+            --allowedTools "Edit,Write,Bash(git checkout -b *),Bash(git add *),Bash(git commit *),Bash(git push *),Bash(pip install *),Bash(python *)"
           prompt: |
+            IMPORTANT: This project has a React frontend (client/) and Python/FastAPI backend (server/).
+            There is NO package.json in the server directory - it uses requirements.txt for Python dependencies.
+            Read CLAUDE.md for full project context before starting any work.
+
             Read the WISHLIST.md file in the repository root.
 
             For each uncompleted task (marked with `- [ ]`):


### PR DESCRIPTION
- Add claude_args with --allowedTools to enable Edit, Write, and Bash operations
- Add explicit tech stack info (Python/FastAPI backend, not Node.js)
- Instruct Claude to read CLAUDE.md before starting work

Fixes permission errors that were blocking file writes and git operations.