### PR TITLE
Redesign login/register pages: remove GitHub auth, add member-type routing

### DIFF
--- a/ProjectCode/client/src/api/members.js
+++ b/ProjectCode/client/src/api/members.js
@@ -105,6 +105,18 @@ export async function submitJoinApplication(applicationData) {
 }
 
 /**
+ * Submit existing member account request
+ * Sends a notification to the committee for approval
+ * @param {Object} data - Request data
+ * @param {string} data.name - Member's name
+ * @param {string} data.email - Member's email
+ * @returns {Promise<Object>} Response
+ */
+export async function submitExistingMemberAccountRequest(data) {
+  return api.post('/api/members/existing-member-account-request', data);
+}
+
+/**
  * Helper to create auth headers for admin endpoints
  * @param {string} firebaseUid - Firebase UID of the admin user
  * @returns {Object} Headers object

--- a/ProjectCode/client/src/firebase/auth.js
+++ b/ProjectCode/client/src/firebase/auth.js
@@ -4,7 +4,6 @@ import {
     signInWithPopup,
     GoogleAuthProvider,
     FacebookAuthProvider,
-    GithubAuthProvider,
     updateProfile,
     sendPasswordResetEmail,
     signOut
@@ -115,22 +114,6 @@ import {
   export const signInWithFacebook = async () => {
     try {
       const provider = new FacebookAuthProvider();
-      const userCredential = await signInWithPopup(auth, provider);
-      // Sync user to MySQL database and check status
-      const { error: statusError } = await syncUserToDatabase(userCredential.user);
-      if (statusError) {
-        return { user: null, error: statusError };
-      }
-      return { user: userCredential.user, error: null };
-    } catch (error) {
-      return { user: null, error: error.message };
-    }
-  };
-  
-  // GitHub sign in
-  export const signInWithGithub = async () => {
-    try {
-      const provider = new GithubAuthProvider();
       const userCredential = await signInWithPopup(auth, provider);
       // Sync user to MySQL database and check status
       const { error: statusError } = await syncUserToDatabase(userCredential.user);

--- a/ProjectCode/client/src/pages/LoginPage.js
+++ b/ProjectCode/client/src/pages/LoginPage.js
@@ -1,22 +1,20 @@
-import GitHubIcon from '@mui/icons-material/GitHub';
 import GoogleIcon from '@mui/icons-material/Google';
+import GroupAddIcon from '@mui/icons-material/GroupAdd';
+import PersonAddIcon from '@mui/icons-material/PersonAdd';
 import {
     Alert,
     Box,
     Button,
     Container,
     Divider,
-    Grid,
     Paper,
     TextField,
     Typography
 } from '@mui/material';
 import { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-// import { useAuth } from '../context/AuthContext';
 import {
     loginWithEmailAndPassword,
-    signInWithGithub,
     signInWithGoogle
 } from '../firebase/auth';
 
@@ -31,7 +29,7 @@ const LoginPage = () => {
     e.preventDefault();
     setError('');
     setLoading(true);
-    
+
     try {
       const { error } = await loginWithEmailAndPassword(email, password);
       if (error) {
@@ -42,14 +40,14 @@ const LoginPage = () => {
     } catch (err) {
       setError('Failed to sign in');
     }
-    
+
     setLoading(false);
   };
 
   const handleGoogleSignIn = async () => {
     setError('');
     setLoading(true);
-    
+
     try {
       const { user, error } = await signInWithGoogle();
       if (error) {
@@ -60,25 +58,7 @@ const LoginPage = () => {
     } catch (err) {
       setError('Failed to sign in with Google');
     }
-    
-    setLoading(false);
-  };
 
-  const handleGithubSignIn = async () => {
-    setError('');
-    setLoading(true);
-    
-    try {
-      const { user, error } = await signInWithGithub();
-      if (error) {
-        setError(error);
-      } else {
-        navigate('/');
-      }
-    } catch (err) {
-      setError('Failed to sign in with GitHub');
-    }
-    
     setLoading(false);
   };
 
@@ -86,14 +66,14 @@ const LoginPage = () => {
     <Container maxWidth="sm" sx={{ mt: 8 }}>
       <Paper elevation={3} sx={{ p: 4 }}>
         <Typography variant="h4" component="h1" align="center" gutterBottom sx={{ color: 'black' }}>
-          Sign In
+          Sign In 登录
         </Typography>
-        
+
         {error && <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>}
-        
+
         <form onSubmit={handleEmailPasswordLogin}>
           <TextField
-            label="Email"
+            label="Email 邮箱"
             type="email"
             variant="outlined"
             fullWidth
@@ -103,7 +83,7 @@ const LoginPage = () => {
             required
           />
           <TextField
-            label="Password"
+            label="Password 密码"
             type="password"
             variant="outlined"
             fullWidth
@@ -112,14 +92,14 @@ const LoginPage = () => {
             onChange={(e) => setPassword(e.target.value)}
             required
           />
-          
-          <Button 
-            type="submit" 
-            variant="contained" 
-            fullWidth 
+
+          <Button
+            type="submit"
+            variant="contained"
+            fullWidth
             size="large"
             disabled={loading}
-            sx={{ 
+            sx={{
               mt: 2,
               backgroundColor: '#FFB84D',
               color: 'white',
@@ -143,82 +123,106 @@ const LoginPage = () => {
             Sign In 登录
           </Button>
         </form>
-        
+
         <Box sx={{ mt: 2, mb: 2 }}>
           <Divider sx={{ '&::before, &::after': { borderColor: '#FFB84D' } }}>
             <Typography sx={{ color: '#FFB84D' }}>OR</Typography>
           </Divider>
         </Box>
-        
-        <Grid container spacing={2}>
-          <Grid item xs={6}>
-            <Button 
-              variant="outlined" 
-              startIcon={<GoogleIcon />}
-              fullWidth
-              onClick={handleGoogleSignIn}
-              disabled={loading}
-              sx={{
-                borderColor: '#FFB84D',
-                color: '#FFB84D',
-                textTransform: 'none',
-                fontSize: '16px',
-                px: 2,
-                py: 1.5,
-                borderRadius: '12px',
-                '&:hover': {
-                  borderColor: '#FFA833',
-                  backgroundColor: 'rgba(255, 184, 77, 0.04)',
-                  boxShadow: '0 4px 8px rgba(0, 0, 0, 0.15)',
-                  transform: 'translateY(-2px)',
-                },
-                '&:active': {
-                  transform: 'translateY(1px) scale(0.98)',
-                  boxShadow: '0 1px 2px rgba(0, 0, 0, 0.1)',
-                }
-              }}
-            >
-              Google
-            </Button>
-          </Grid>
-          <Grid item xs={6}>
-            <Button 
-              variant="outlined" 
-              startIcon={<GitHubIcon />}
-              fullWidth
-              onClick={handleGithubSignIn}
-              disabled={loading}
-              sx={{
-                borderColor: '#FFB84D',
-                color: '#FFB84D',
-                textTransform: 'none',
-                fontSize: '16px',
-                px: 2,
-                py: 1.5,
-                borderRadius: '12px',
-                '&:hover': {
-                  borderColor: '#FFA833',
-                  backgroundColor: 'rgba(255, 184, 77, 0.04)',
-                  boxShadow: '0 4px 8px rgba(0, 0, 0, 0.15)',
-                  transform: 'translateY(-2px)',
-                },
-                '&:active': {
-                  transform: 'translateY(1px) scale(0.98)',
-                  boxShadow: '0 1px 2px rgba(0, 0, 0, 0.1)',
-                }
-              }}
-            >
-              GitHub
-            </Button>
-          </Grid>
-        </Grid>
-        
-        <Typography align="center" sx={{ mt: 3 }}>
-          Don't have an account? <Link to="/register" style={{ color: '#FFB84D', textDecoration: 'none', '&:hover': { color: '#FFA833' } }}>Register</Link>
-        </Typography>
+
+        <Button
+          variant="outlined"
+          startIcon={<GoogleIcon />}
+          fullWidth
+          onClick={handleGoogleSignIn}
+          disabled={loading}
+          sx={{
+            borderColor: '#FFB84D',
+            color: '#FFB84D',
+            textTransform: 'none',
+            fontSize: '16px',
+            px: 2,
+            py: 1.5,
+            borderRadius: '12px',
+            '&:hover': {
+              borderColor: '#FFA833',
+              backgroundColor: 'rgba(255, 184, 77, 0.04)',
+              boxShadow: '0 4px 8px rgba(0, 0, 0, 0.15)',
+              transform: 'translateY(-2px)',
+            },
+            '&:active': {
+              transform: 'translateY(1px) scale(0.98)',
+              boxShadow: '0 1px 2px rgba(0, 0, 0, 0.1)',
+            }
+          }}
+        >
+          Sign in with Google
+        </Button>
+
+        <Box sx={{ mt: 3, mb: 1 }}>
+          <Divider sx={{ '&::before, &::after': { borderColor: '#e0e0e0' } }}>
+            <Typography sx={{ color: '#999', fontSize: '0.85rem' }}>Don't have an account? 没有账号？</Typography>
+          </Divider>
+        </Box>
+
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5, mt: 2 }}>
+          <Button
+            component={Link}
+            to="/register"
+            variant="outlined"
+            fullWidth
+            startIcon={<PersonAddIcon />}
+            sx={{
+              textTransform: 'none',
+              fontSize: '14px',
+              py: 1.2,
+              borderRadius: '12px',
+              borderColor: '#FFB84D',
+              color: '#FFB84D',
+              '&:hover': {
+                borderColor: '#FFA833',
+                backgroundColor: 'rgba(255, 184, 77, 0.04)',
+                boxShadow: '0 4px 8px rgba(0, 0, 0, 0.15)',
+                transform: 'translateY(-2px)',
+              },
+            }}
+          >
+            Already a member? Create account directly
+            <Typography component="span" sx={{ display: 'block', fontSize: '12px', color: '#999', ml: 0.5 }}>
+              已是成员？直接创建账号
+            </Typography>
+          </Button>
+
+          <Button
+            component={Link}
+            to="/join"
+            variant="outlined"
+            fullWidth
+            startIcon={<GroupAddIcon />}
+            sx={{
+              textTransform: 'none',
+              fontSize: '14px',
+              py: 1.2,
+              borderRadius: '12px',
+              borderColor: '#4CAF50',
+              color: '#4CAF50',
+              '&:hover': {
+                borderColor: '#388E3C',
+                backgroundColor: 'rgba(76, 175, 80, 0.04)',
+                boxShadow: '0 4px 8px rgba(0, 0, 0, 0.15)',
+                transform: 'translateY(-2px)',
+              },
+            }}
+          >
+            New to the club? Apply to join
+            <Typography component="span" sx={{ display: 'block', fontSize: '12px', color: '#999', ml: 0.5 }}>
+              新成员？申请加入
+            </Typography>
+          </Button>
+        </Box>
       </Paper>
     </Container>
   );
 };
 
-export default LoginPage; 
+export default LoginPage;

--- a/ProjectCode/client/src/pages/RegisterPage.js
+++ b/ProjectCode/client/src/pages/RegisterPage.js
@@ -1,12 +1,11 @@
-import GitHubIcon from '@mui/icons-material/GitHub';
 import GoogleIcon from '@mui/icons-material/Google';
+import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 import {
   Alert,
   Box,
   Button,
   Container,
   Divider,
-  Grid,
   Paper,
   TextField,
   Typography
@@ -15,9 +14,9 @@ import { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import {
   registerWithEmailAndPassword,
-  signInWithGithub,
   signInWithGoogle
 } from '../firebase/auth';
+import { submitExistingMemberAccountRequest } from '../api/members';
 
 const RegisterPage = () => {
   const [name, setName] = useState('');
@@ -26,80 +25,142 @@ const RegisterPage = () => {
   const [confirmPassword, setConfirmPassword] = useState('');
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
   const navigate = useNavigate();
 
   const handleRegister = async (e) => {
     e.preventDefault();
-    
+
     if (password !== confirmPassword) {
-      return setError('Passwords do not match');
+      return setError('Passwords do not match / 密码不匹配');
     }
-    
+
     setError('');
     setLoading(true);
-    
+
     try {
       const { user, error } = await registerWithEmailAndPassword(email, password, name);
       if (error) {
-        setError(error);
+        // If pending approval, send committee notification and show success
+        if (error.includes('pending')) {
+          try {
+            await submitExistingMemberAccountRequest({ name, email });
+          } catch (notifyErr) {
+            // Don't fail if notification fails - account is still created
+            console.error('Failed to send committee notification:', notifyErr);
+          }
+          setSubmitted(true);
+        } else {
+          setError(error);
+        }
       } else {
         navigate('/');
       }
     } catch (err) {
-      setError('Failed to create an account');
+      setError('Failed to create an account / 创建账号失败');
     }
-    
+
     setLoading(false);
   };
 
   const handleGoogleSignIn = async () => {
     setError('');
     setLoading(true);
-    
+
     try {
       const { user, error } = await signInWithGoogle();
       if (error) {
-        setError(error);
+        if (error.includes('pending')) {
+          try {
+            const googleName = user?.displayName || name || 'Google User';
+            const googleEmail = user?.email || email;
+            await submitExistingMemberAccountRequest({ name: googleName, email: googleEmail });
+          } catch (notifyErr) {
+            console.error('Failed to send committee notification:', notifyErr);
+          }
+          setSubmitted(true);
+        } else {
+          setError(error);
+        }
       } else {
         navigate('/');
       }
     } catch (err) {
-      setError('Failed to sign up with Google');
+      setError('Failed to sign up with Google / Google 注册失败');
     }
-    
+
     setLoading(false);
   };
 
-  const handleGithubSignIn = async () => {
-    setError('');
-    setLoading(true);
-    
-    try {
-      const { user, error } = await signInWithGithub();
-      if (error) {
-        setError(error);
-      } else {
-        navigate('/');
-      }
-    } catch (err) {
-      setError('Failed to sign up with GitHub');
-    }
-    
-    setLoading(false);
-  };
+  // Success state after registration
+  if (submitted) {
+    return (
+      <Container maxWidth="sm" sx={{ mt: 8 }}>
+        <Paper elevation={3} sx={{ p: 4, textAlign: 'center' }}>
+          <CheckCircleOutlineIcon sx={{ fontSize: 64, color: '#4CAF50', mb: 2 }} />
+          <Typography variant="h5" gutterBottom sx={{ color: 'black' }}>
+            Account Created! 账号已创建！
+          </Typography>
+          <Typography sx={{ color: '#666', mb: 2 }}>
+            Your account request has been sent to the NewBee Running Club committee for approval.
+          </Typography>
+          <Typography sx={{ color: '#666', mb: 3 }}>
+            您的账号申请已发送给新蜂跑团委员会审核。
+          </Typography>
+          <Typography sx={{ color: '#999', fontSize: '0.9rem', mb: 3 }}>
+            You will be able to log in once your account has been approved. This typically takes 1-3 business days.
+            <br />
+            账号审核通过后即可登录，通常需要1-3个工作日。
+          </Typography>
+          <Button
+            component={Link}
+            to="/login"
+            variant="contained"
+            sx={{
+              backgroundColor: '#FFB84D',
+              color: 'white',
+              textTransform: 'none',
+              fontSize: '16px',
+              px: 3,
+              py: 1.2,
+              borderRadius: '12px',
+              '&:hover': {
+                backgroundColor: '#FFA833',
+              }
+            }}
+          >
+            Back to Login 返回登录
+          </Button>
+        </Paper>
+      </Container>
+    );
+  }
 
   return (
     <Container maxWidth="sm" sx={{ mt: 8 }}>
       <Paper elevation={3} sx={{ p: 4 }}>
         <Typography variant="h4" component="h1" align="center" gutterBottom sx={{ color: 'black' }}>
-          Create Account
+          Create Account 创建账号
         </Typography>
-        
+
+        <Alert severity="info" sx={{ mb: 2, backgroundColor: 'rgba(255, 184, 77, 0.1)', border: '1px solid #FFB84D', '& .MuiAlert-icon': { color: '#FFB84D' } }}>
+          <Typography variant="body2" sx={{ fontWeight: 500 }}>
+            For existing NewBee Running Club members only.
+          </Typography>
+          <Typography variant="body2" sx={{ color: '#666' }}>
+            仅限新蜂跑团现有成员使用。
+          </Typography>
+          <Typography variant="body2" sx={{ mt: 0.5, fontSize: '0.8rem', color: '#999' }}>
+            Your request will be sent to the committee for verification. /
+            您的请求将发送给委员会验证。
+          </Typography>
+        </Alert>
+
         {error && <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>}
-        
+
         <form onSubmit={handleRegister}>
           <TextField
-            label="Name"
+            label="Name 姓名"
             type="text"
             variant="outlined"
             fullWidth
@@ -109,7 +170,7 @@ const RegisterPage = () => {
             required
           />
           <TextField
-            label="Email"
+            label="Email 邮箱"
             type="email"
             variant="outlined"
             fullWidth
@@ -119,7 +180,7 @@ const RegisterPage = () => {
             required
           />
           <TextField
-            label="Password"
+            label="Password 密码"
             type="password"
             variant="outlined"
             fullWidth
@@ -129,7 +190,7 @@ const RegisterPage = () => {
             required
           />
           <TextField
-            label="Confirm Password"
+            label="Confirm Password 确认密码"
             type="password"
             variant="outlined"
             fullWidth
@@ -138,14 +199,14 @@ const RegisterPage = () => {
             onChange={(e) => setConfirmPassword(e.target.value)}
             required
           />
-          
-          <Button 
-            type="submit" 
-            variant="contained" 
-            fullWidth 
+
+          <Button
+            type="submit"
+            variant="contained"
+            fullWidth
             size="large"
             disabled={loading}
-            sx={{ 
+            sx={{
               mt: 2,
               backgroundColor: '#FFB84D',
               color: 'white',
@@ -166,85 +227,56 @@ const RegisterPage = () => {
               }
             }}
           >
-            Register 注册
+            Create Account 创建账号
           </Button>
         </form>
-        
+
         <Box sx={{ mt: 2, mb: 2 }}>
           <Divider sx={{ '&::before, &::after': { borderColor: '#FFB84D' } }}>
             <Typography sx={{ color: '#FFB84D' }}>OR</Typography>
           </Divider>
         </Box>
-        
-        <Grid container spacing={2}>
-          <Grid item xs={6}>
-            <Button 
-              variant="outlined" 
-              startIcon={<GoogleIcon />}
-              fullWidth
-              onClick={handleGoogleSignIn}
-              disabled={loading}
-              sx={{
-                borderColor: '#FFB84D',
-                color: '#FFB84D',
-                textTransform: 'none',
-                fontSize: '17.5px',
-                px: 2.75,
-                py: 1.85,
-                borderRadius: '12px',
-                '&:hover': {
-                  borderColor: '#FFA833',
-                  backgroundColor: 'rgba(255, 184, 77, 0.04)',
-                  boxShadow: '0 4px 8px rgba(0, 0, 0, 0.15)',
-                  transform: 'translateY(-2px)',
-                },
-                '&:active': {
-                  transform: 'translateY(1px) scale(0.98)',
-                  boxShadow: '0 1px 2px rgba(0, 0, 0, 0.1)',
-                }
-              }}
-            >
-              Google
-            </Button>
-          </Grid>
-          <Grid item xs={6}>
-            <Button 
-              variant="outlined" 
-              startIcon={<GitHubIcon />}
-              fullWidth
-              onClick={handleGithubSignIn}
-              disabled={loading}
-              sx={{
-                borderColor: '#FFB84D',
-                color: '#FFB84D',
-                textTransform: 'none',
-                fontSize: '17.5px',
-                px: 2.75,
-                py: 1.85,
-                borderRadius: '12px',
-                '&:hover': {
-                  borderColor: '#FFA833',
-                  backgroundColor: 'rgba(255, 184, 77, 0.04)',
-                  boxShadow: '0 4px 8px rgba(0, 0, 0, 0.15)',
-                  transform: 'translateY(-2px)',
-                },
-                '&:active': {
-                  transform: 'translateY(1px) scale(0.98)',
-                  boxShadow: '0 1px 2px rgba(0, 0, 0, 0.1)',
-                }
-              }}
-            >
-              GitHub
-            </Button>
-          </Grid>
-        </Grid>
-        
-        <Typography align="center" sx={{ mt: 3 }}>
-          Already have an account? <Link to="/login" style={{ color: '#FFB84D', textDecoration: 'none', '&:hover': { color: '#FFA833' } }}>Sign In</Link>
-        </Typography>
+
+        <Button
+          variant="outlined"
+          startIcon={<GoogleIcon />}
+          fullWidth
+          onClick={handleGoogleSignIn}
+          disabled={loading}
+          sx={{
+            borderColor: '#FFB84D',
+            color: '#FFB84D',
+            textTransform: 'none',
+            fontSize: '17.5px',
+            px: 2.75,
+            py: 1.85,
+            borderRadius: '12px',
+            '&:hover': {
+              borderColor: '#FFA833',
+              backgroundColor: 'rgba(255, 184, 77, 0.04)',
+              boxShadow: '0 4px 8px rgba(0, 0, 0, 0.15)',
+              transform: 'translateY(-2px)',
+            },
+            '&:active': {
+              transform: 'translateY(1px) scale(0.98)',
+              boxShadow: '0 1px 2px rgba(0, 0, 0, 0.1)',
+            }
+          }}
+        >
+          Google
+        </Button>
+
+        <Box sx={{ mt: 3, display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 1 }}>
+          <Typography sx={{ fontSize: '0.9rem' }}>
+            Already have an account? <Link to="/login" style={{ color: '#FFB84D', textDecoration: 'none' }}>Sign In 登录</Link>
+          </Typography>
+          <Typography sx={{ fontSize: '0.9rem' }}>
+            New to the club? <Link to="/join" style={{ color: '#4CAF50', textDecoration: 'none' }}>Apply to join 申请加入</Link>
+          </Typography>
+        </Box>
       </Paper>
     </Container>
   );
 };
 
-export default RegisterPage; 
+export default RegisterPage;

--- a/ProjectCode/server/email_service.py
+++ b/ProjectCode/server/email_service.py
@@ -399,3 +399,69 @@ class EmailService:
 
         logger.info(f"[EMAIL] Sending rejection notification to {member_email} ({member_name})")
         return EmailService.send_email(member_email, subject, body_html, body_text)
+
+    @staticmethod
+    def send_existing_member_account_notification(member_name: str, member_email: str) -> bool:
+        """
+        Send notification to committee that an existing club member has created a website account
+        and is requesting approval.
+
+        Args:
+            member_name: Member's name
+            member_email: Member's email
+
+        Returns:
+            True if email sent successfully
+        """
+        subject = f"Existing Member Account Request: {member_name}"
+
+        body_html = f"""
+        <html>
+            <body style="font-family: Arial, sans-serif; line-height: 1.6; color: #333;">
+                <div style="max-width: 600px; margin: 0 auto; padding: 20px;">
+                    <h2 style="color: #FFA500;">Existing Member Account Request</h2>
+                    <h3 style="color: #666;">现有成员账号申请</h3>
+
+                    <p>An existing club member has created a website account and is requesting approval:</p>
+                    <p style="color: #666;">一位现有俱乐部成员已创建网站账号并请求审批：</p>
+
+                    <table style="width: 100%; border-collapse: collapse; margin: 20px 0;">
+                        <tr>
+                            <td style="padding: 8px; border: 1px solid #ddd; font-weight: bold;">Name 姓名</td>
+                            <td style="padding: 8px; border: 1px solid #ddd;">{member_name}</td>
+                        </tr>
+                        <tr>
+                            <td style="padding: 8px; border: 1px solid #ddd; font-weight: bold;">Email 邮箱</td>
+                            <td style="padding: 8px; border: 1px solid #ddd;"><a href="mailto:{member_email}">{member_email}</a></td>
+                        </tr>
+                    </table>
+
+                    <div style="background-color: #fff3e0; border-left: 4px solid #FFA500; padding: 15px; margin: 20px 0;">
+                        <p style="margin: 0; font-weight: bold;">Action Required 需要操作:</p>
+                        <p style="margin: 10px 0 0 0;">Please verify this person is an existing member and approve or reject their account in the admin panel.</p>
+                        <p style="margin: 5px 0 0 0; color: #666;">请确认此人是否为现有成员，并在管理面板中批准或拒绝其账号。</p>
+                    </div>
+
+                    <p style="margin-top: 30px;">
+                        <a href="{WEBSITE_URL}/admin" style="color: white; text-decoration: none; background-color: #FFA500; padding: 10px 20px; display: inline-block; margin-top: 10px; border-radius: 5px;">Go to Admin Panel 前往管理面板</a>
+                    </p>
+                </div>
+            </body>
+        </html>
+        """
+
+        body_text = f"""
+        Existing Member Account Request
+        现有成员账号申请
+
+        An existing club member has created a website account and is requesting approval:
+        一位现有俱乐部成员已创建网站账号并请求审批：
+
+        Name: {member_name}
+        Email: {member_email}
+
+        Please verify this person is an existing member and approve or reject their account in the admin panel at {WEBSITE_URL}/admin
+        """
+
+        logger.info(f"[EMAIL] Sending existing member account notification for: {member_name} ({member_email})")
+        return EmailService.send_email(GMAIL_USER, subject, body_html, body_text)

--- a/ProjectCode/server/main.py
+++ b/ProjectCode/server/main.py
@@ -105,7 +105,7 @@ from models import (
     DonorCreate, DonorUpdate, DonorResponse, DonorsListResponse, DonationSummary,
     DonorPublicResponse, DonorLinkMemberRequest,
     MemberCreate, MemberUpdate, MemberResponse, MemberPublicResponse, MemberStatus,
-    FirebaseUserSync, JoinApplicationRequest, JoinApplicationWithActivities,
+    FirebaseUserSync, JoinApplicationRequest, JoinApplicationWithActivities, ExistingMemberAccountRequest,
     MemberActivityCreate, MemberActivityUpdate, MemberActivityResponse, ActivityVerifyRequest, ActivityStatus,
     EventCreate, EventUpdate, EventResponse, EventStatus, EventType,
     MeetingMinutesCreate, MeetingMinutesUpdate, MeetingMinutesResponse,
@@ -1097,6 +1097,27 @@ def submit_join_application(application: JoinApplicationRequest, db: Session = D
     return {
         "message": "Application submitted successfully! You will receive a confirmation email shortly.",
         "member_id": new_member.id,
+        "status": "pending"
+    }
+
+
+@app.post("/api/members/existing-member-account-request")
+def existing_member_account_request(request: ExistingMemberAccountRequest):
+    """
+    Notify committee that an existing club member has created a website account
+    and is requesting approval. Sends an email to the club email for committee review.
+    """
+    try:
+        EmailService.send_existing_member_account_notification(
+            request.name,
+            request.email
+        )
+    except Exception as e:
+        print(f"Error sending existing member account notification email: {str(e)}")
+        # Don't fail the request if email fails
+
+    return {
+        "message": "Account request notification sent to committee.",
         "status": "pending"
     }
 

--- a/ProjectCode/server/models.py
+++ b/ProjectCode/server/models.py
@@ -228,6 +228,12 @@ class JoinApplicationRequest(BaseModel):
     introduction: str
 
 
+class ExistingMemberAccountRequest(BaseModel):
+    """Request from an existing club member to create a website account"""
+    name: str = Field(..., max_length=100)
+    email: str = Field(..., max_length=255)
+
+
 # Activity Status Enum for join workflow
 class ActivityStatus(str, Enum):
     pending = "pending"


### PR DESCRIPTION
- Remove GitHub OAuth from login page, register page, and firebase auth
- LoginPage now shows two paths: "Already a member? Create account directly"
  (routes to /register) and "New to the club? Apply to join" (routes to /join)
- RegisterPage redesigned for existing members: shows info banner, sends
  committee notification email on registration for approval
- Add backend POST /api/members/existing-member-account-request endpoint
- Add email template for existing member account request notifications
- Add ExistingMemberAccountRequest Pydantic model
- Add submitExistingMemberAccountRequest client API function

https://claude.ai/code/session_012WeAwVVaB3bjYx1wpJbJ6F