### PR TITLE
Admin tools: image position, delete fix, editable uploader name

### DIFF
--- a/ProjectCode/client/src/api/gallery.js
+++ b/ProjectCode/client/src/api/gallery.js
@@ -58,13 +58,14 @@ export const getBatchGalleryPreview = async (eventIds, firebaseUid = null) => {
  * @param {string|null} firebaseUid - User's Firebase UID (optional but recommended)
  * @returns {Promise<Object>} - Created gallery image
  */
-export const uploadGalleryImage = async (eventId, file, caption = null, captionCn = null, firebaseUid = null) => {
+export const uploadGalleryImage = async (eventId, file, caption = null, captionCn = null, firebaseUid = null, uploaderName = null) => {
   const API_BASE_URL = process.env.REACT_APP_API_BASE_URL || 'http://localhost:8000';
 
   const formData = new FormData();
   formData.append('file', file);
   if (caption) formData.append('caption', caption);
   if (captionCn) formData.append('caption_cn', captionCn);
+  if (uploaderName) formData.append('uploaded_by_name', uploaderName);
 
   const headers = {};
   if (firebaseUid) {

--- a/ProjectCode/client/src/components/EventCardImage.js
+++ b/ProjectCode/client/src/components/EventCardImage.js
@@ -1,0 +1,20 @@
+import { CardMedia } from '@mui/material';
+
+export default function EventCardImage({ event, height, alt, loading = 'lazy', onError, sx = {} }) {
+  return (
+    <CardMedia
+      component="img"
+      height={height}
+      image={event.image}
+      alt={alt || event.name || event.title}
+      loading={loading}
+      onError={onError}
+      sx={{
+        objectFit: 'cover',
+        objectPosition: event.image_position || 'center center',
+        backgroundColor: '#f5f5f5',
+        ...sx,
+      }}
+    />
+  );
+}

--- a/ProjectCode/client/src/components/EventDetailModal.js
+++ b/ProjectCode/client/src/components/EventDetailModal.js
@@ -18,6 +18,7 @@ import SaveIcon from '@mui/icons-material/Save';
 import CloseIcon from '@mui/icons-material/Close';
 import { useAuth } from '../context/AuthContext';
 import { useAdmin } from '../context/AdminContext';
+import ImagePositionEditor from './ImagePositionEditor';
 import { getEventEngagement, updateEvent } from '../api';
 import LikeButton from './LikeButton';
 import ReactionPicker from './ReactionPicker';
@@ -101,10 +102,17 @@ export default function EventDetailModal({ event, onClose, onEventUpdate }) {
     }
   };
 
-  if (!event) return null;
+  const [imagePosition, setImagePosition] = useState('center center');
+  const eventTitle = event?.name || event?.title;
+  const eventChineseTitle = event?.chineseName || event?.chineseTitle;
 
-  const eventTitle = event.name || event.title;
-  const eventChineseTitle = event.chineseName || event.chineseTitle;
+  useEffect(() => {
+    if (event) {
+      setImagePosition(event.image_position || event.imagePosition || 'center center');
+    }
+  }, [event]);
+
+  if (!event) return null;
 
   return (
     <Box
@@ -131,17 +139,31 @@ export default function EventDetailModal({ event, onClose, onEventUpdate }) {
         }}
         onClick={(e) => e.stopPropagation()}
       >
-        <CardMedia
-          component="img"
-          height="300"
-          image={event.image}
-          alt={eventTitle}
-          onError={handleImageError}
-          sx={{
-            objectFit: 'cover',
-            backgroundColor: '#f5f5f5'
-          }}
-        />
+        {adminModeEnabled && event.id ? (
+          <ImagePositionEditor
+            eventId={event.id}
+            imageUrl={event.image}
+            currentPosition={imagePosition}
+            onPositionSaved={(pos) => {
+              setImagePosition(pos);
+              if (onEventUpdate) onEventUpdate({ ...event, image_position: pos });
+            }}
+            sx={{ height: 300, backgroundColor: '#f5f5f5' }}
+          />
+        ) : (
+          <CardMedia
+            component="img"
+            height="300"
+            image={event.image}
+            alt={eventTitle}
+            onError={handleImageError}
+            sx={{
+              objectFit: 'cover',
+              objectPosition: imagePosition,
+              backgroundColor: '#f5f5f5'
+            }}
+          />
+        )}
         <CardContent>
           <Typography variant="h5" gutterBottom>
             {eventTitle}

--- a/ProjectCode/client/src/components/GalleryLightbox.js
+++ b/ProjectCode/client/src/components/GalleryLightbox.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
 import {
   Dialog,
   DialogContent,
@@ -48,6 +49,7 @@ const GalleryLightbox = ({
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
   const { currentUser } = useAuth();
+  const navigate = useNavigate();
   const { adminModeEnabled } = useAdmin();
 
   // Reset index when opening with new initialIndex
@@ -320,17 +322,31 @@ const GalleryLightbox = ({
                 </Typography>
               </Box>
 
-              {/* Download button - only for logged-in members */}
-              {currentUser && (
-                <Box sx={{ textAlign: 'center' }}>
-                  <IconButton onClick={handleDownload} sx={{ color: 'white' }}>
-                    <DownloadIcon />
-                  </IconButton>
-                  <Typography variant="caption" sx={{ color: 'white', display: 'block' }}>
-                    Download
-                  </Typography>
-                </Box>
-              )}
+              {/* Download button - greyed out with sign-up prompt for anonymous users */}
+              <Box sx={{ textAlign: 'center' }}>
+                {currentUser ? (
+                  <>
+                    <IconButton onClick={handleDownload} sx={{ color: 'white' }}>
+                      <DownloadIcon />
+                    </IconButton>
+                    <Typography variant="caption" sx={{ color: 'white', display: 'block' }}>
+                      Download
+                    </Typography>
+                  </>
+                ) : (
+                  <>
+                    <IconButton
+                      onClick={() => { onClose(); navigate('/register'); }}
+                      sx={{ color: 'grey.600' }}
+                    >
+                      <DownloadIcon />
+                    </IconButton>
+                    <Typography variant="caption" sx={{ color: 'grey.600', display: 'block' }}>
+                      Sign in to download
+                    </Typography>
+                  </>
+                )}
+              </Box>
 
               {/* Share button */}
               <Box sx={{ textAlign: 'center' }}>
@@ -358,8 +374,8 @@ const GalleryLightbox = ({
                 </Box>
               )}
 
-              {/* Request Delete button - logged-in non-admin users */}
-              {currentUser && !adminModeEnabled && onRequestDelete && (
+              {/* Report button - available to all users */}
+              {!adminModeEnabled && onRequestDelete && (
                 <Box sx={{ textAlign: 'center' }}>
                   <IconButton
                     onClick={() => {

--- a/ProjectCode/client/src/components/GalleryLightbox.js
+++ b/ProjectCode/client/src/components/GalleryLightbox.js
@@ -11,6 +11,7 @@ import {
   useMediaQuery,
   Snackbar,
   Alert,
+  TextField,
 } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
 import NavigateBeforeIcon from '@mui/icons-material/NavigateBefore';
@@ -21,7 +22,7 @@ import DownloadIcon from '@mui/icons-material/Download';
 import ShareIcon from '@mui/icons-material/Share';
 import WallpaperIcon from '@mui/icons-material/Wallpaper';
 import FlagIcon from '@mui/icons-material/Flag';
-import { toggleGalleryImageLike, downloadImage, shareImage } from '../api/gallery';
+import { toggleGalleryImageLike, downloadImage, shareImage, updateGalleryImage } from '../api/gallery';
 import { updateEvent } from '../api/events';
 import { useAuth } from '../context/AuthContext';
 import { useAdmin } from '../context/AdminContext';
@@ -46,6 +47,8 @@ const GalleryLightbox = ({
   const [liking, setLiking] = useState(false);
   const [settingCover, setSettingCover] = useState(false);
   const [snackbar, setSnackbar] = useState({ open: false, message: '', severity: 'success' });
+  const [editingUploaderName, setEditingUploaderName] = useState(false);
+  const [uploaderNameValue, setUploaderNameValue] = useState('');
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
   const { currentUser } = useAuth();
@@ -396,17 +399,68 @@ const GalleryLightbox = ({
 
             {/* Uploader info */}
             {currentImage.uploaded_by_name && (
-              <Typography
-                variant="caption"
-                sx={{
-                  color: 'rgba(255,255,255,0.5)',
-                  display: 'block',
-                  textAlign: 'center',
-                  mt: 1,
-                }}
-              >
-                Uploaded by {currentImage.uploaded_by_name}
-              </Typography>
+              editingUploaderName ? (
+                <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 1, mt: 1 }}>
+                  <Typography variant="caption" sx={{ color: 'rgba(255,255,255,0.5)' }}>
+                    Uploaded by
+                  </Typography>
+                  <TextField
+                    size="small"
+                    variant="standard"
+                    value={uploaderNameValue}
+                    onChange={(e) => setUploaderNameValue(e.target.value)}
+                    autoFocus
+                    onKeyDown={async (e) => {
+                      if (e.key === 'Enter') {
+                        try {
+                          await updateGalleryImage(currentImage.id, { uploaded_by_name: uploaderNameValue }, currentUser.uid);
+                          currentImage.uploaded_by_name = uploaderNameValue;
+                          if (onImageUpdate) onImageUpdate({ ...currentImage, uploaded_by_name: uploaderNameValue });
+                        } catch (err) {
+                          console.error('Failed to update uploader name:', err);
+                        }
+                        setEditingUploaderName(false);
+                      } else if (e.key === 'Escape') {
+                        setEditingUploaderName(false);
+                      }
+                    }}
+                    onBlur={async () => {
+                      try {
+                        await updateGalleryImage(currentImage.id, { uploaded_by_name: uploaderNameValue }, currentUser.uid);
+                        currentImage.uploaded_by_name = uploaderNameValue;
+                        if (onImageUpdate) onImageUpdate({ ...currentImage, uploaded_by_name: uploaderNameValue });
+                      } catch (err) {
+                        console.error('Failed to update uploader name:', err);
+                      }
+                      setEditingUploaderName(false);
+                    }}
+                    sx={{
+                      '& .MuiInput-input': { color: 'rgba(255,255,255,0.7)', fontSize: '0.75rem', py: 0 },
+                      '& .MuiInput-underline:before': { borderBottomColor: 'rgba(255,255,255,0.3)' },
+                      '& .MuiInput-underline:after': { borderBottomColor: '#FFB84D' },
+                      maxWidth: 150,
+                    }}
+                  />
+                </Box>
+              ) : (
+                <Typography
+                  variant="caption"
+                  onClick={adminModeEnabled ? () => {
+                    setUploaderNameValue(currentImage.uploaded_by_name);
+                    setEditingUploaderName(true);
+                  } : undefined}
+                  sx={{
+                    color: 'rgba(255,255,255,0.5)',
+                    display: 'block',
+                    textAlign: 'center',
+                    mt: 1,
+                    cursor: adminModeEnabled ? 'pointer' : 'default',
+                    '&:hover': adminModeEnabled ? { color: 'rgba(255,255,255,0.8)', textDecoration: 'underline' } : {},
+                  }}
+                >
+                  Uploaded by {currentImage.uploaded_by_name}
+                </Typography>
+              )
             )}
           </Box>
         </DialogContent>

--- a/ProjectCode/client/src/components/ImagePositionEditor.js
+++ b/ProjectCode/client/src/components/ImagePositionEditor.js
@@ -1,0 +1,182 @@
+import { useState, useRef, useCallback } from 'react';
+import { Box, IconButton, Tooltip, CircularProgress } from '@mui/material';
+import CropIcon from '@mui/icons-material/Crop';
+import CheckIcon from '@mui/icons-material/Check';
+import CloseIcon from '@mui/icons-material/Close';
+import { updateEvent } from '../api';
+import { useAuth } from '../context/AuthContext';
+
+export default function ImagePositionEditor({ eventId, imageUrl, currentPosition, onPositionSaved, sx }) {
+  const { currentUser } = useAuth();
+  const [editing, setEditing] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [position, setPosition] = useState(currentPosition || 'center center');
+  const [dragStart, setDragStart] = useState(null);
+  const [positionAtDragStart, setPositionAtDragStart] = useState(null);
+  const dragRef = useRef(null);
+
+  const parsePosition = (pos) => {
+    const parts = (pos || 'center center').split(' ');
+    const x = parseFloat(parts[0]) || 50;
+    const y = parseFloat(parts[1]) || 50;
+    return { x, y };
+  };
+
+  const handlePointerDown = useCallback((e) => {
+    if (!editing) return;
+    e.preventDefault();
+    e.stopPropagation();
+    const rect = dragRef.current.getBoundingClientRect();
+    setDragStart({ x: e.clientX, y: e.clientY, rect });
+    setPositionAtDragStart(parsePosition(position));
+    dragRef.current.setPointerCapture(e.pointerId);
+  }, [editing, position]);
+
+  const handlePointerMove = useCallback((e) => {
+    if (!dragStart || !editing) return;
+    e.preventDefault();
+    e.stopPropagation();
+    const dx = e.clientX - dragStart.x;
+    const dy = e.clientY - dragStart.y;
+    const pctX = Math.max(0, Math.min(100, positionAtDragStart.x - (dx / dragStart.rect.width) * 100));
+    const pctY = Math.max(0, Math.min(100, positionAtDragStart.y - (dy / dragStart.rect.height) * 100));
+    setPosition(`${pctX.toFixed(1)}% ${pctY.toFixed(1)}%`);
+  }, [dragStart, editing, positionAtDragStart]);
+
+  const handlePointerUp = useCallback((e) => {
+    if (!dragStart) return;
+    e.preventDefault();
+    e.stopPropagation();
+    setDragStart(null);
+    setPositionAtDragStart(null);
+  }, [dragStart]);
+
+  const handleSave = async (e) => {
+    e.stopPropagation();
+    if (!currentUser?.uid) return;
+    setSaving(true);
+    try {
+      await updateEvent(eventId, { image_position: position }, currentUser.uid);
+      setEditing(false);
+      if (onPositionSaved) onPositionSaved(position);
+    } catch (error) {
+      console.error('Error saving image position:', error);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleCancel = (e) => {
+    e.stopPropagation();
+    setPosition(currentPosition || 'center center');
+    setEditing(false);
+  };
+
+  const handleStartEdit = (e) => {
+    e.stopPropagation();
+    setEditing(true);
+  };
+
+  return (
+    <Box
+      sx={{
+        position: 'relative',
+        overflow: 'hidden',
+        userSelect: 'none',
+        ...sx,
+      }}
+      onClick={editing ? (e) => e.stopPropagation() : undefined}
+    >
+      <Box
+        component="img"
+        src={imageUrl}
+        sx={{
+          width: '100%',
+          height: '100%',
+          objectFit: 'cover',
+          objectPosition: position,
+          display: 'block',
+          pointerEvents: 'none',
+        }}
+      />
+      {/* Drag overlay - only this area captures pointer for dragging */}
+      {editing && (
+        <Box
+          ref={dragRef}
+          onPointerDown={handlePointerDown}
+          onPointerMove={handlePointerMove}
+          onPointerUp={handlePointerUp}
+          sx={{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            right: 0,
+            bottom: 40,
+            cursor: 'grab',
+            border: '3px dashed #FFB84D',
+            borderBottom: 'none',
+          }}
+        />
+      )}
+      {/* Edit button */}
+      {!editing && (
+        <Tooltip title="Adjust image position / 调整图片位置">
+          <IconButton
+            size="small"
+            onClick={handleStartEdit}
+            sx={{
+              position: 'absolute',
+              bottom: 8,
+              right: 8,
+              backgroundColor: 'rgba(255, 255, 255, 0.9)',
+              '&:hover': { backgroundColor: 'white' },
+              zIndex: 10,
+            }}
+          >
+            <CropIcon fontSize="small" sx={{ color: '#FFB84D' }} />
+          </IconButton>
+        </Tooltip>
+      )}
+      {/* Save/Cancel buttons */}
+      {editing && (
+        <Box
+          sx={{
+            position: 'absolute',
+            bottom: 8,
+            right: 8,
+            display: 'flex',
+            gap: 0.5,
+            zIndex: 20,
+          }}
+        >
+          <Tooltip title="Save / 保存">
+            <IconButton
+              size="small"
+              onClick={handleSave}
+              disabled={saving}
+              sx={{
+                backgroundColor: 'rgba(255, 255, 255, 0.9)',
+                '&:hover': { backgroundColor: 'white' },
+              }}
+            >
+              {saving ? <CircularProgress size={18} /> : <CheckIcon fontSize="small" sx={{ color: '#4caf50' }} />}
+            </IconButton>
+          </Tooltip>
+          <Tooltip title="Cancel / 取消">
+            <IconButton
+              size="small"
+              onClick={handleCancel}
+              disabled={saving}
+              sx={{
+                backgroundColor: 'rgba(255, 255, 255, 0.9)',
+                '&:hover': { backgroundColor: 'white' },
+              }}
+            >
+              <CloseIcon fontSize="small" sx={{ color: '#f44336' }} />
+            </IconButton>
+          </Tooltip>
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/ProjectCode/client/src/pages/CalendarPage.js
+++ b/ProjectCode/client/src/pages/CalendarPage.js
@@ -11,6 +11,7 @@ import { useEffect, useState, useRef } from 'react';
 import { ref, uploadBytes, getDownloadURL } from 'firebase/storage';
 import NavigationButtons from '../components/NavigationButtons';
 import EventDetailModal from '../components/EventDetailModal';
+import EventCardImage from '../components/EventCardImage';
 import { useAdmin, useAuth } from '../context';
 import { useAutoFillOnTab, useTranslationAutoFill } from '../hooks';
 import { storage } from '../firebase/config';
@@ -240,7 +241,7 @@ export default function CalendarPage() {
     }
     try {
       await updateEvent(event.id, { status: 'Highlight' }, currentUser.uid);
-      setEvents(prev => prev.filter(ev => ev.id !== event.id));
+      setUpcomingEvents(prev => prev.filter(ev => ev.id !== event.id));
       setSnackbar({ open: true, message: 'Event moved to Highlights / 活动已移至精彩回顾', severity: 'success' });
     } catch (error) {
       console.error('Error moving event to highlights:', error);
@@ -613,18 +614,7 @@ export default function CalendarPage() {
                     </Tooltip>
                   </Box>
                 )}
-                <CardMedia
-                  component="img"
-                  height="200"
-                  image={event.image}
-                  alt={event.title}
-                  loading="lazy"
-                  onError={handleImageError}
-                  sx={{
-                    objectFit: 'cover',
-                    backgroundColor: '#f5f5f5'
-                  }}
-                />
+                <EventCardImage event={event} height="200" onError={handleImageError} />
                 <CardContent sx={{ flexGrow: 1, display: 'flex', flexDirection: 'column' }}>
                   <Typography gutterBottom variant="h6" component="div" sx={{
                     overflow: 'hidden',
@@ -844,19 +834,7 @@ export default function CalendarPage() {
                   height: '150px'
                 }}
               >
-                <CardMedia
-                  component="img"
-                  loading="lazy"
-                  sx={{
-                    height: '100%',
-                    width: '100%',
-                    objectFit: 'cover',
-                    backgroundColor: '#f5f5f5'
-                  }}
-                  image={event.image}
-                  alt={event.name}
-                  onError={handleImageError}
-                />
+                <EventCardImage event={event} onError={handleImageError} sx={{ height: '100%', width: '100%' }} />
               </Box>
 
               {/* Time Column - hidden on mobile, shown on sm+ */}
@@ -890,19 +868,7 @@ export default function CalendarPage() {
                   flexShrink: 0
                 }}
               >
-                <CardMedia
-                  component="img"
-                  loading="lazy"
-                  sx={{
-                    height: '100%',
-                    width: '100%',
-                    objectFit: 'cover',
-                    backgroundColor: '#f5f5f5'
-                  }}
-                  image={event.image}
-                  alt={event.name}
-                  onError={handleImageError}
-                />
+                <EventCardImage event={event} onError={handleImageError} sx={{ height: '100%', width: '100%' }} />
               </Box>
 
               {/* Content Column */}

--- a/ProjectCode/client/src/pages/CalendarPage.js
+++ b/ProjectCode/client/src/pages/CalendarPage.js
@@ -4,13 +4,13 @@ import DeleteIcon from '@mui/icons-material/Delete';
 import AddIcon from '@mui/icons-material/Add';
 import InfoIcon from '@mui/icons-material/Info';
 import CloudUploadIcon from '@mui/icons-material/CloudUpload';
-import EventIcon from '@mui/icons-material/Event';
+import StarIcon from '@mui/icons-material/Star';
 import { Alert, Box, Button, Card, CardContent, CardMedia, Chip, CircularProgress, Container, Dialog, DialogActions, DialogContent, DialogTitle, FormControlLabel, Grid, IconButton, MenuItem, Snackbar, Switch, TextField, Tooltip, Typography } from '@mui/material';
 import RepeatIcon from '@mui/icons-material/Repeat';
 import { useEffect, useState, useRef } from 'react';
 import { ref, uploadBytes, getDownloadURL } from 'firebase/storage';
-import DOMPurify from 'dompurify';
 import NavigationButtons from '../components/NavigationButtons';
+import EventDetailModal from '../components/EventDetailModal';
 import { useAdmin, useAuth } from '../context';
 import { useAutoFillOnTab, useTranslationAutoFill } from '../hooks';
 import { storage } from '../firebase/config';
@@ -230,6 +230,22 @@ export default function CalendarPage() {
     e.stopPropagation();
     setEventToDelete(event);
     setDeleteDialogOpen(true);
+  };
+
+  const handleMoveToHighlights = async (e, event) => {
+    e.stopPropagation();
+    if (!currentUser?.uid) {
+      setSnackbar({ open: true, message: 'You must be logged in / 您必须登录', severity: 'error' });
+      return;
+    }
+    try {
+      await updateEvent(event.id, { status: 'Highlight' }, currentUser.uid);
+      setEvents(prev => prev.filter(ev => ev.id !== event.id));
+      setSnackbar({ open: true, message: 'Event moved to Highlights / 活动已移至精彩回顾', severity: 'success' });
+    } catch (error) {
+      console.error('Error moving event to highlights:', error);
+      setSnackbar({ open: true, message: 'Failed to move event / 移动活动失败', severity: 'error' });
+    }
   };
 
   const handleAddEvent = () => {
@@ -583,6 +599,18 @@ export default function CalendarPage() {
                         <DeleteIcon fontSize="small" color="error" />
                       </IconButton>
                     </Tooltip>
+                    <Tooltip title="Move to Highlights / 移至精彩回顾">
+                      <IconButton
+                        size="small"
+                        onClick={(e) => handleMoveToHighlights(e, event)}
+                        sx={{
+                          backgroundColor: 'rgba(255, 255, 255, 0.9)',
+                          '&:hover': { backgroundColor: 'white' }
+                        }}
+                      >
+                        <StarIcon fontSize="small" sx={{ color: '#FFB84D' }} />
+                      </IconButton>
+                    </Tooltip>
                   </Box>
                 )}
                 <CardMedia
@@ -793,6 +821,18 @@ export default function CalendarPage() {
                       <DeleteIcon fontSize="small" color="error" />
                     </IconButton>
                   </Tooltip>
+                  <Tooltip title="Move to Highlights / 移至精彩回顾">
+                    <IconButton
+                      size="small"
+                      onClick={(e) => handleMoveToHighlights(e, event)}
+                      sx={{
+                        backgroundColor: 'rgba(255, 255, 255, 0.9)',
+                        '&:hover': { backgroundColor: 'white' }
+                      }}
+                    >
+                      <StarIcon fontSize="small" sx={{ color: '#FFB84D' }} />
+                    </IconButton>
+                  </Tooltip>
                 </Box>
               )}
 
@@ -937,169 +977,10 @@ export default function CalendarPage() {
 
       {/* Event Detail Modal */}
       {selectedEvent && (
-        <Box
-          sx={{
-            position: 'fixed',
-            top: 0,
-            left: 0,
-            right: 0,
-            bottom: 0,
-            backgroundColor: 'rgba(0, 0, 0, 0.7)',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            zIndex: 1000
-          }}
-          onClick={() => setSelectedEvent(null)}
-        >
-          <Card
-            sx={{
-              maxWidth: 600,
-              width: '90%',
-              maxHeight: '90vh',
-              overflow: 'auto'
-            }}
-            onClick={(e) => e.stopPropagation()}
-          >
-            <CardMedia
-              component="img"
-              height="300"
-              image={selectedEvent.image}
-              alt={selectedEvent.name || selectedEvent.title}
-              onError={handleImageError}
-              sx={{
-                objectFit: 'cover',
-                backgroundColor: '#f5f5f5'
-              }}
-            />
-            <CardContent>
-              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
-                <Typography variant="h5" sx={{ flexGrow: 1 }}>
-                  {selectedEvent.name || selectedEvent.title}
-                </Typography>
-                {(selectedEvent.eventType || selectedEvent.event_type) === 'heylo' && (
-                  <Chip
-                    icon={<EventIcon />}
-                    label="Heylo Event"
-                    size="small"
-                    color="primary"
-                    variant="outlined"
-                  />
-                )}
-                {(selectedEvent.eventType || selectedEvent.event_type) === 'race' && (
-                  <Chip
-                    label="Race"
-                    size="small"
-                    color="secondary"
-                    variant="outlined"
-                  />
-                )}
-              </Box>
-              <Typography variant="h6" color="text.secondary" gutterBottom>
-                {selectedEvent.chineseName || selectedEvent.chineseTitle}
-              </Typography>
-
-              {/* Heylo Embed Display */}
-              {(selectedEvent.eventType || selectedEvent.event_type) === 'heylo' && (selectedEvent.heyloEmbed || selectedEvent.heylo_embed) && (
-                <Box
-                  sx={{
-                    my: 2,
-                    p: 2,
-                    backgroundColor: '#f5f5f5',
-                    borderRadius: 2,
-                    border: '1px solid #e0e0e0'
-                  }}
-                >
-                  <Typography variant="subtitle2" color="text.secondary" gutterBottom>
-                    Heylo Event Details / Heylo活动详情
-                  </Typography>
-                  <Box
-                    dangerouslySetInnerHTML={{
-                      __html: DOMPurify.sanitize(selectedEvent.heyloEmbed || selectedEvent.heylo_embed, {
-                        ADD_TAGS: ['iframe'],
-                        ADD_ATTR: ['allow', 'allowfullscreen', 'frameborder', 'scrolling']
-                      })
-                    }}
-                    sx={{
-                      '& iframe': {
-                        maxWidth: '100%',
-                        borderRadius: 1
-                      }
-                    }}
-                  />
-                </Box>
-              )}
-
-              <Typography variant="body1" paragraph>
-                {selectedEvent.description}
-              </Typography>
-              <Typography variant="body2" color="text.secondary" paragraph>
-                Date: {selectedEvent.date}
-              </Typography>
-              <Typography variant="body2" color="text.secondary" paragraph>
-                Time: {selectedEvent.time}
-              </Typography>
-              <Typography variant="body2" color="text.secondary" paragraph>
-                Location: {selectedEvent.location}
-              </Typography>
-              <Typography variant="body2" color="text.secondary" paragraph>
-                {selectedEvent.chineseLocation}
-              </Typography>
-              <Box sx={{ mt: 2 }}>
-                <Button
-                  variant="contained"
-                  sx={{
-                    backgroundColor: '#FFB84D',
-                    color: 'white',
-                    textTransform: 'none',
-                    fontSize: '16px',
-                    px: 2,
-                    py: 1.5,
-                    borderRadius: '12px',
-                    border: '2px solid #FFB84D',
-                    mr: 2,
-                    '&:hover': {
-                      backgroundColor: '#FFA833',
-                      boxShadow: '0 4px 8px rgba(0, 0, 0, 0.15)',
-                      transform: 'translateY(-2px)',
-                    },
-                    '&:active': {
-                      transform: 'translateY(1px) scale(0.98)',
-                      boxShadow: '0 1px 2px rgba(0, 0, 0, 0.1)',
-                    }
-                  }}
-                >
-                  Sign Up 报名
-                </Button>
-                <Button
-                  variant="outlined"
-                  onClick={() => setSelectedEvent(null)}
-                  sx={{
-                    color: '#FFB84D',
-                    borderColor: '#FFB84D',
-                    textTransform: 'none',
-                    fontSize: '16px',
-                    px: 2,
-                    py: 1.5,
-                    borderRadius: '12px',
-                    '&:hover': {
-                      borderColor: '#FFA833',
-                      backgroundColor: 'rgba(255, 184, 77, 0.04)',
-                      boxShadow: '0 4px 8px rgba(0, 0, 0, 0.15)',
-                      transform: 'translateY(-2px)',
-                    },
-                    '&:active': {
-                      transform: 'translateY(1px) scale(0.98)',
-                      boxShadow: '0 1px 2px rgba(0, 0, 0, 0.1)',
-                    }
-                  }}
-                >
-                  Close 关闭
-                </Button>
-              </Box>
-            </CardContent>
-          </Card>
-        </Box>
+        <EventDetailModal
+          event={selectedEvent}
+          onClose={() => setSelectedEvent(null)}
+        />
       )}
 
       {/* Event Form Dialog */}

--- a/ProjectCode/client/src/pages/HighlightsPage.js
+++ b/ProjectCode/client/src/pages/HighlightsPage.js
@@ -2,7 +2,8 @@ import MoreVertIcon from '@mui/icons-material/MoreVert';
 import PlaylistAddIcon from '@mui/icons-material/PlaylistAdd';
 import DragIndicatorIcon from '@mui/icons-material/DragIndicator';
 import ShareIcon from '@mui/icons-material/Share';
-import { Alert, Box, Button, Card, CardContent, CardMedia, Chip, Container, Grid, IconButton, Menu, MenuItem, Snackbar, TextField, Typography } from '@mui/material';
+import DeleteIcon from '@mui/icons-material/Delete';
+import { Alert, Box, Button, Card, CardContent, CardMedia, Chip, CircularProgress, Container, Dialog, DialogActions, DialogContent, DialogTitle, Grid, IconButton, Menu, MenuItem, Snackbar, TextField, Typography } from '@mui/material';
 import { useEffect, useState, useCallback } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { DndContext, DragOverlay, useSensor, useSensors, TouchSensor, MouseSensor, closestCenter } from '@dnd-kit/core';
@@ -14,7 +15,7 @@ import EventDetailModal from '../components/EventDetailModal';
 import EventGroupCard from '../components/EventGroupCard';
 import EventGroupGalleryModal from '../components/EventGroupGalleryModal';
 import UndoSnackbar from '../components/UndoSnackbar';
-import { getEventsByStatus, getBatchEngagement, toggleSeriesParent, getHighlightsGrouped, mergeEventsToGroup, removeEventFromGroup, undoGroupMerge } from '../api';
+import { getEventsByStatus, getBatchEngagement, toggleSeriesParent, getHighlightsGrouped, mergeEventsToGroup, removeEventFromGroup, undoGroupMerge, deleteEvent } from '../api';
 import { useAuth } from '../context/AuthContext';
 import { useAdmin } from '../context/AdminContext';
 
@@ -87,6 +88,9 @@ export default function HighlightsPage() {
   const [undoData, setUndoData] = useState(null); // { parentId, eventId, message }
   const [draggedEventId, setDraggedEventId] = useState(null);
   const [activeId, setActiveId] = useState(null);
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [eventToDelete, setEventToDelete] = useState(null);
+  const [deleteLoading, setDeleteLoading] = useState(false);
 
   // Sensors: TouchSensor with 250ms delay (long press like iOS), MouseSensor with distance
   const sensors = useSensors(
@@ -132,6 +136,32 @@ export default function HighlightsPage() {
   const handleMenuClose = () => {
     setMenuAnchorEl(null);
     setMenuEventId(null);
+  };
+
+  const handleDeleteEvent = () => {
+    const event = [...standaloneEvents, ...pastEvents].find(e => e.id === menuEventId);
+    if (event) {
+      setEventToDelete(event);
+      setDeleteDialogOpen(true);
+    }
+    handleMenuClose();
+  };
+
+  const handleDeleteConfirm = async () => {
+    if (!eventToDelete || !currentUser?.uid) return;
+    setDeleteLoading(true);
+    try {
+      await deleteEvent(eventToDelete.id, currentUser.uid);
+      setDeleteDialogOpen(false);
+      setEventToDelete(null);
+      setSnackbar({ open: true, message: 'Event deleted / 活动已删除', severity: 'success' });
+      refreshEvents();
+    } catch (error) {
+      console.error('Error deleting event:', error);
+      setSnackbar({ open: true, message: 'Failed to delete event / 删除活动失败', severity: 'error' });
+    } finally {
+      setDeleteLoading(false);
+    }
   };
 
   const refreshEvents = useCallback(async () => {
@@ -1071,6 +1101,10 @@ export default function HighlightsPage() {
           <PlaylistAddIcon sx={{ mr: 1, color: '#FFA500' }} />
           Mark as Series Parent 设为系列主活动
         </MenuItem>
+        <MenuItem onClick={handleDeleteEvent}>
+          <DeleteIcon sx={{ mr: 1, color: 'error.main' }} />
+          Delete Event 删除活动
+        </MenuItem>
       </Menu>
 
       {/* Event Detail Modal */}
@@ -1093,6 +1127,31 @@ export default function HighlightsPage() {
         onRemoveFromGroup={handleRemoveFromGroup}
         adminModeEnabled={adminModeEnabled}
       />
+
+      {/* Delete Confirmation Dialog */}
+      <Dialog open={deleteDialogOpen} onClose={() => setDeleteDialogOpen(false)}>
+        <DialogTitle>Delete Event / 删除活动</DialogTitle>
+        <DialogContent>
+          <Typography>
+            Are you sure you want to delete "{eventToDelete?.name || eventToDelete?.title}"?
+          </Typography>
+          <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+            您确定要删除 "{eventToDelete?.chineseName || eventToDelete?.chineseTitle || eventToDelete?.name || eventToDelete?.title}" 吗？
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setDeleteDialogOpen(false)} disabled={deleteLoading}>
+            Cancel 取消
+          </Button>
+          <Button
+            onClick={handleDeleteConfirm}
+            color="error"
+            disabled={deleteLoading}
+          >
+            {deleteLoading ? <CircularProgress size={24} /> : 'Delete / 删除'}
+          </Button>
+        </DialogActions>
+      </Dialog>
 
       {/* Share Snackbar */}
       <Snackbar

--- a/ProjectCode/client/src/pages/HighlightsPage.js
+++ b/ProjectCode/client/src/pages/HighlightsPage.js
@@ -9,6 +9,7 @@ import { useSearchParams } from 'react-router-dom';
 import { DndContext, DragOverlay, useSensor, useSensors, TouchSensor, MouseSensor, closestCenter } from '@dnd-kit/core';
 import { useDraggable, useDroppable } from '@dnd-kit/core';
 import NavigationButtons from '../components/NavigationButtons';
+import EventCardImage from '../components/EventCardImage';
 import EventEngagementBar from '../components/EventEngagementBar';
 import EventGalleryPreview from '../components/EventGalleryPreview';
 import EventDetailModal from '../components/EventDetailModal';
@@ -604,18 +605,7 @@ export default function HighlightsPage() {
                 onClick={() => handleEventClick(event)}
               >
                 <Box sx={{ position: 'relative' }}>
-                  <CardMedia
-                    component="img"
-                    height="200"
-                    image={event.image}
-                    alt={event.title}
-                    loading="lazy"
-                    onError={handleImageError}
-                    sx={{
-                      objectFit: 'cover',
-                      backgroundColor: '#f5f5f5'
-                    }}
-                  />
+                  <EventCardImage event={event} height="200" onError={handleImageError} />
                   <IconButton
                     size="small"
                     onClick={(e) => handleShare(e, event.id, event.title)}
@@ -828,18 +818,10 @@ export default function HighlightsPage() {
                           position: 'relative'
                         }}
                       >
-                        <CardMedia
-                          component="img"
-                          loading="lazy"
-                          sx={{
-                            height: '100%',
-                            width: '100%',
-                            objectFit: 'cover',
-                            backgroundColor: '#f5f5f5'
-                          }}
-                          image={event.image}
-                          alt={event.name}
+                        <EventCardImage
+                          event={event}
                           onError={handleImageError}
+                          sx={{ height: '100%', width: '100%' }}
                         />
                         {/* Mobile drag handle - long press to drag */}
                         {adminModeEnabled && (
@@ -927,19 +909,7 @@ export default function HighlightsPage() {
                   flexShrink: 0
                 }}
               >
-                <CardMedia
-                  component="img"
-                  loading="lazy"
-                  sx={{
-                    height: '100%',
-                    width: '100%',
-                    objectFit: 'cover',
-                    backgroundColor: '#f5f5f5'
-                  }}
-                  image={event.image}
-                  alt={event.name}
-                  onError={handleImageError}
-                />
+                <EventCardImage event={event} onError={handleImageError} sx={{ height: '100%', width: '100%' }} />
               </Box>
 
               {/* Content Column */}

--- a/ProjectCode/server/database.py
+++ b/ProjectCode/server/database.py
@@ -268,6 +268,7 @@ class Event(Base):
     description = Column(Text)
     chinese_description = Column(Text)
     image = Column(String(500))
+    image_position = Column(String(50), default='center center')  # CSS object-position value
     signup_link = Column(String(500))
     status = Column(String(50), default='Upcoming')  # 'Upcoming', 'Highlight', 'Cancelled'
 

--- a/ProjectCode/server/main.py
+++ b/ProjectCode/server/main.py
@@ -1437,6 +1437,16 @@ def delete_event(
             detail=f"Event with ID {event_id} not found"
         )
 
+    # Manually delete related records (MySQL FK cascades may not be set up correctly)
+    db.query(EventCommentSettings).filter(EventCommentSettings.event_id == event_id).delete()
+    db.query(Comment).filter(Comment.event_id == event_id).delete()
+    db.query(Like).filter(Like.event_id == event_id).delete()
+    db.query(Reaction).filter(Reaction.event_id == event_id).delete()
+    db.query(EventGalleryImage).filter(EventGalleryImage.event_id == event_id).delete()
+    db.query(EventRecurrenceRule).filter(EventRecurrenceRule.event_id == event_id).delete()
+    # Unlink child events from this parent
+    db.query(Event).filter(Event.parent_event_id == event_id).update({Event.parent_event_id: None})
+
     db.delete(event)
     db.commit()
     return {"message": f"Event {event_id} deleted successfully"}
@@ -3272,6 +3282,7 @@ async def upload_gallery_image(
     file: UploadFile = File(...),
     caption: Optional[str] = Form(None),
     caption_cn: Optional[str] = Form(None),
+    uploaded_by_name: Optional[str] = Form(None),
     db: Session = Depends(get_db),
     x_firebase_uid: Optional[str] = Header(None, alias="X-Firebase-UID")
 ):
@@ -3318,7 +3329,7 @@ async def upload_gallery_image(
         caption_cn=caption_cn,
         display_order=max_order + 1,
         uploaded_by_id=current_member.id if current_member else None,
-        uploaded_by_name=current_member.display_name or current_member.username if current_member else "Anonymous"
+        uploaded_by_name=uploaded_by_name or (current_member.display_name or current_member.username if current_member else "Anonymous")
     )
 
     db.add(new_image)

--- a/ProjectCode/server/models.py
+++ b/ProjectCode/server/models.py
@@ -312,6 +312,7 @@ class EventBase(BaseModel):
     description: Optional[str] = None
     chinese_description: Optional[str] = None
     image: Optional[str] = None
+    image_position: Optional[str] = Field(None, max_length=50)
     signup_link: Optional[str] = Field(None, max_length=500)
     status: EventStatus = Field(default=EventStatus.upcoming)
     event_type: EventType = Field(default=EventType.standard)
@@ -332,6 +333,7 @@ class EventUpdate(BaseModel):
     description: Optional[str] = None
     chinese_description: Optional[str] = None
     image: Optional[str] = None
+    image_position: Optional[str] = Field(None, max_length=50)
     signup_link: Optional[str] = Field(None, max_length=500)
     status: Optional[EventStatus] = None
     event_type: Optional[EventType] = None
@@ -344,6 +346,7 @@ class EventResponse(EventBase):
     id: int
     event_type: str = "standard"
     heylo_embed: Optional[str] = None
+    image_position: Optional[str] = None
     # Event group fields
     group_name: Optional[str] = None
     group_name_cn: Optional[str] = None
@@ -728,6 +731,7 @@ class EventGalleryImageUpdate(BaseModel):
     caption_cn: Optional[str] = Field(None, max_length=500)
     display_order: Optional[int] = None
     is_active: Optional[bool] = None
+    uploaded_by_name: Optional[str] = Field(None, max_length=100)
 
 
 class GalleryDeletionRequestResponse(BaseModel):


### PR DESCRIPTION
## Summary
- **Calendar modal fix:** Replaced inline modal (z-index 1000) with shared EventDetailModal (z-index 9999) so navbar no longer covers it.
- **Move to Highlights:** Admin star button on calendar cards to manually move events to highlights.
- **Highlights delete:** Added delete option to the admin menu on highlight event cards.
- **Image position editor:** Admin can drag to adjust event card image focal point in the detail modal (crop icon). Position saved to DB and applied across all card views.
- **Event delete fix:** Fixed 500 error when deleting events by manually cleaning up related records before deletion.
- **Editable uploader name:** Admin can click "Uploaded by X" in the gallery lightbox to edit the name inline.
- **Code cleanup:** Created shared `EventCardImage` component to eliminate repeated CardMedia patterns.

## Test plan
- [ ] Click event card on /calendar — modal appears on top of navbar
- [ ] Admin mode: star button moves event from calendar to highlights
- [ ] Admin mode: delete event from /highlights via menu
- [ ] Admin mode: crop icon on event detail modal image, drag to adjust, save
- [ ] Image position persists on all card views after save
- [ ] Delete an event — should succeed without 500 error
- [ ] Admin mode: click uploader name in gallery lightbox, edit inline

🤖 Generated with [Claude Code](https://claude.com/claude-code)