### PR TITLE
Add QR upload, event sharing, and image position support

### DIFF
--- a/ProjectCode/client/src/components/EventDetailModal.js
+++ b/ProjectCode/client/src/components/EventDetailModal.js
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import ReactDOM from 'react-dom';
 import { useNavigate } from 'react-router-dom';
 import {
   Box,
@@ -10,12 +11,17 @@ import {
   Divider,
   CircularProgress,
   TextField,
-  IconButton
+  IconButton,
+  Snackbar,
+  Alert,
+  Tooltip
 } from '@mui/material';
 import CollectionsIcon from '@mui/icons-material/Collections';
 import EditIcon from '@mui/icons-material/Edit';
 import SaveIcon from '@mui/icons-material/Save';
 import CloseIcon from '@mui/icons-material/Close';
+import ShareIcon from '@mui/icons-material/Share';
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import { useAuth } from '../context/AuthContext';
 import { useAdmin } from '../context/AdminContext';
 import ImagePositionEditor from './ImagePositionEditor';
@@ -32,6 +38,7 @@ export default function EventDetailModal({ event, onClose, onEventUpdate }) {
   const { adminModeEnabled } = useAdmin();
   const [engagement, setEngagement] = useState(null);
   const [loading, setLoading] = useState(true);
+  const [shareSnackbar, setShareSnackbar] = useState(false);
   const [editingDescription, setEditingDescription] = useState(false);
   const [descriptionText, setDescriptionText] = useState('');
   const [saving, setSaving] = useState(false);
@@ -52,6 +59,13 @@ export default function EventDetailModal({ event, onClose, onEventUpdate }) {
     } finally {
       setLoading(false);
     }
+  };
+
+  const handleShare = () => {
+    const url = `${window.location.origin}/calendar?event=${event.id}`;
+    navigator.clipboard.writeText(url).then(() => {
+      setShareSnackbar(true);
+    });
   };
 
   const handleImageError = (e) => {
@@ -108,13 +122,15 @@ export default function EventDetailModal({ event, onClose, onEventUpdate }) {
 
   useEffect(() => {
     if (event) {
-      setImagePosition(event.image_position || event.imagePosition || 'center center');
+      const pos = event.image_position || event.imagePosition || 'center center';
+      console.log('[EventDetailModal] event.id=', event.id, 'event.image_position=', event.image_position, '→ setting imagePosition to:', pos);
+      setImagePosition(pos);
     }
   }, [event]);
 
   if (!event) return null;
 
-  return (
+  return ReactDOM.createPortal(
     <Box
       sx={{
         position: 'fixed',
@@ -139,35 +155,65 @@ export default function EventDetailModal({ event, onClose, onEventUpdate }) {
         }}
         onClick={(e) => e.stopPropagation()}
       >
-        {adminModeEnabled && event.id ? (
-          <ImagePositionEditor
-            eventId={event.id}
-            imageUrl={event.image}
-            currentPosition={imagePosition}
-            onPositionSaved={(pos) => {
-              setImagePosition(pos);
-              if (onEventUpdate) onEventUpdate({ ...event, image_position: pos });
-            }}
-            sx={{ height: 300, backgroundColor: '#f5f5f5' }}
-          />
-        ) : (
-          <CardMedia
-            component="img"
-            height="300"
-            image={event.image}
-            alt={eventTitle}
-            onError={handleImageError}
-            sx={{
-              objectFit: 'cover',
-              objectPosition: imagePosition,
-              backgroundColor: '#f5f5f5'
-            }}
-          />
-        )}
+        <Box sx={{ position: 'relative' }}>
+          {adminModeEnabled && event.id ? (
+            <ImagePositionEditor
+              eventId={event.id}
+              imageUrl={event.image}
+              currentPosition={imagePosition}
+              onPositionSaved={(pos) => {
+                setImagePosition(pos);
+                if (onEventUpdate) onEventUpdate({ ...event, image_position: pos });
+              }}
+              sx={{ height: 300, backgroundColor: '#f5f5f5' }}
+            />
+          ) : (
+            <CardMedia
+              component="img"
+              height="300"
+              image={event.image}
+              alt={eventTitle}
+              onError={handleImageError}
+              sx={{
+                objectFit: 'cover',
+                objectPosition: imagePosition,
+                backgroundColor: '#f5f5f5'
+              }}
+            />
+          )}
+          {(event.wechatQrCode || event.wechat_qr_code) && (
+            <Box
+              sx={{
+                position: 'absolute',
+                bottom: 8,
+                right: 8,
+                width: 80,
+                height: 80,
+                backgroundColor: 'white',
+                borderRadius: 1,
+                padding: '4px',
+                boxShadow: '0 2px 8px rgba(0,0,0,0.3)',
+              }}
+            >
+              <img
+                src={event.wechatQrCode || event.wechat_qr_code}
+                alt="WeChat QR Code"
+                style={{ width: '100%', height: '100%', objectFit: 'contain' }}
+              />
+            </Box>
+          )}
+        </Box>
         <CardContent>
-          <Typography variant="h5" gutterBottom>
-            {eventTitle}
-          </Typography>
+          <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+            <Typography variant="h5" gutterBottom sx={{ mb: 0 }}>
+              {eventTitle}
+            </Typography>
+            <Tooltip title="Share / 分享">
+              <IconButton onClick={handleShare} sx={{ color: '#FFB84D' }}>
+                <ShareIcon />
+              </IconButton>
+            </Tooltip>
+          </Box>
           {eventChineseTitle && (
             <Typography variant="h6" color="text.secondary" gutterBottom>
               {eventChineseTitle}
@@ -194,6 +240,32 @@ export default function EventDetailModal({ event, onClose, onEventUpdate }) {
               </Typography>
             )}
           </Box>
+
+          {/* Signup Link */}
+          {(event.signupLink || event.signup_link) && (
+            <Box sx={{ mb: 2 }}>
+              <Typography variant="subtitle2" fontWeight={600} gutterBottom>
+                Join / 参与
+              </Typography>
+              <Button
+                variant="outlined"
+                size="small"
+                startIcon={<OpenInNewIcon />}
+                href={event.signupLink || event.signup_link}
+                target="_blank"
+                rel="noopener noreferrer"
+                sx={{
+                  textTransform: 'none',
+                  borderColor: '#FFB84D',
+                  color: '#FFB84D',
+                  borderRadius: '8px',
+                  '&:hover': { borderColor: '#FFA833', backgroundColor: 'rgba(255, 184, 77, 0.04)' }
+                }}
+              >
+                Sign Up / 报名
+              </Button>
+            </Box>
+          )}
 
           {(event.description || (adminModeEnabled && event.id)) && (
             <Box>
@@ -309,28 +381,30 @@ export default function EventDetailModal({ event, onClose, onEventUpdate }) {
                 />
               )}
 
-              {/* Gallery Section */}
-              <Box sx={{ mb: 3 }}>
-                <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 1 }}>
-                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                    <CollectionsIcon sx={{ color: 'text.secondary' }} />
-                    <Typography variant="subtitle1" fontWeight={600}>
-                      Photos / 相册
-                    </Typography>
+              {/* Gallery Section - hidden for Upcoming events */}
+              {event.status !== 'Upcoming' && (
+                <Box sx={{ mb: 3 }}>
+                  <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 1 }}>
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                      <CollectionsIcon sx={{ color: 'text.secondary' }} />
+                      <Typography variant="subtitle1" fontWeight={600}>
+                        Photos / 相册
+                      </Typography>
+                    </Box>
+                    <Button
+                      size="small"
+                      onClick={() => {
+                        onClose();
+                        navigate(`/events/${event.id}/gallery`);
+                      }}
+                      sx={{ textTransform: 'none', color: '#FFB84D' }}
+                    >
+                      View All
+                    </Button>
                   </Box>
-                  <Button
-                    size="small"
-                    onClick={() => {
-                      onClose();
-                      navigate(`/events/${event.id}/gallery`);
-                    }}
-                    sx={{ textTransform: 'none', color: '#FFB84D' }}
-                  >
-                    View All
-                  </Button>
+                  <EventGalleryPreview eventId={event.id} maxImages={5} size={56} />
                 </Box>
-                <EventGalleryPreview eventId={event.id} maxImages={5} size={56} />
-              </Box>
+              )}
 
               <Divider sx={{ mb: 3 }} />
 
@@ -371,6 +445,17 @@ export default function EventDetailModal({ event, onClose, onEventUpdate }) {
           </Box>
         </CardContent>
       </Card>
-    </Box>
+      <Snackbar
+        open={shareSnackbar}
+        autoHideDuration={3000}
+        onClose={() => setShareSnackbar(false)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert onClose={() => setShareSnackbar(false)} severity="success" sx={{ width: '100%' }}>
+          Link copied / 链接已复制
+        </Alert>
+      </Snackbar>
+    </Box>,
+    document.body
   );
 }

--- a/ProjectCode/client/src/components/EventGroupCard.js
+++ b/ProjectCode/client/src/components/EventGroupCard.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import {
   Box,
   Card,
@@ -10,6 +10,9 @@ import {
 import FolderIcon from '@mui/icons-material/Folder';
 import EventGalleryPreview from './EventGalleryPreview';
 import EventEngagementBar from './EventEngagementBar';
+import ImagePositionEditor from './ImagePositionEditor';
+import { updateEvent } from '../api';
+import { useAuth } from '../context/AuthContext';
 
 /**
  * EventGroupCard - iOS-style stacked card for event groups
@@ -21,7 +24,11 @@ const EventGroupCard = ({
   onGroupClick,
   engagementData,
   adminModeEnabled = false,
+  onPositionSaved,
 }) => {
+  const { currentUser } = useAuth();
+  const [coverPosition, setCoverPosition] = useState(group.cover_image_position || 'center center');
+
   const handleImageError = (e) => {
     e.target.src = '/images/2025/20250517_bk_half.jpg';
   };
@@ -79,19 +86,35 @@ const EventGroupCard = ({
           position: 'relative',
         }}
       >
-        <CardMedia
-          component="img"
-          loading="lazy"
-          sx={{
-            height: '100%',
-            width: '100%',
-            objectFit: 'cover',
-            backgroundColor: '#f5f5f5',
-          }}
-          image={group.cover_image || '/images/2025/20250517_bk_half.jpg'}
-          alt={group.group_name}
-          onError={handleImageError}
-        />
+        {adminModeEnabled && group.cover_image ? (
+          <ImagePositionEditor
+            imageUrl={group.cover_image}
+            currentPosition={coverPosition}
+            onSave={async (position) => {
+              await updateEvent(group.cover_event_id || group.parent_event_id, { image_position: position }, currentUser.uid);
+            }}
+            onPositionSaved={(pos) => {
+              setCoverPosition(pos);
+              if (onPositionSaved) onPositionSaved(pos);
+            }}
+            sx={{ width: '100%', height: '100%' }}
+          />
+        ) : (
+          <CardMedia
+            component="img"
+            loading="lazy"
+            sx={{
+              height: '100%',
+              width: '100%',
+              objectFit: 'cover',
+              objectPosition: coverPosition,
+              backgroundColor: '#f5f5f5',
+            }}
+            image={group.cover_image || '/images/2025/20250517_bk_half.jpg'}
+            alt={group.group_name}
+            onError={handleImageError}
+          />
+        )}
         {/* Group badge */}
         <Chip
           icon={<FolderIcon sx={{ fontSize: 16 }} />}
@@ -104,6 +127,7 @@ const EventGroupCard = ({
             backgroundColor: 'rgba(255, 165, 0, 0.9)',
             color: 'white',
             fontWeight: 600,
+            zIndex: 5,
           }}
         />
       </Box>
@@ -157,19 +181,35 @@ const EventGroupCard = ({
           flexShrink: 0,
         }}
       >
-        <CardMedia
-          component="img"
-          loading="lazy"
-          sx={{
-            height: '100%',
-            width: '100%',
-            objectFit: 'cover',
-            backgroundColor: '#f5f5f5',
-          }}
-          image={group.cover_image || '/images/2025/20250517_bk_half.jpg'}
-          alt={group.group_name}
-          onError={handleImageError}
-        />
+        {adminModeEnabled && group.cover_image ? (
+          <ImagePositionEditor
+            imageUrl={group.cover_image}
+            currentPosition={coverPosition}
+            onSave={async (position) => {
+              await updateEvent(group.cover_event_id || group.parent_event_id, { image_position: position }, currentUser.uid);
+            }}
+            onPositionSaved={(pos) => {
+              setCoverPosition(pos);
+              if (onPositionSaved) onPositionSaved(pos);
+            }}
+            sx={{ width: '100%', height: '100%' }}
+          />
+        ) : (
+          <CardMedia
+            component="img"
+            loading="lazy"
+            sx={{
+              height: '100%',
+              width: '100%',
+              objectFit: 'cover',
+              objectPosition: coverPosition,
+              backgroundColor: '#f5f5f5',
+            }}
+            image={group.cover_image || '/images/2025/20250517_bk_half.jpg'}
+            alt={group.group_name}
+            onError={handleImageError}
+          />
+        )}
       </Box>
 
       {/* Content Column */}

--- a/ProjectCode/client/src/components/EventModal.js
+++ b/ProjectCode/client/src/components/EventModal.js
@@ -52,6 +52,7 @@ export default function EventModal({ open, onClose, event }) {
   const eventDescription = event.event_description || event.description;
   const eventChineseDescription = event.event_chinese_description || event.chinese_description;
   const eventImage = event.image_url || event.image;
+  const eventImagePosition = event.image_position || 'center center';
   const signupLink = event.event_signup_link || event.signup_link;
 
   return (
@@ -84,6 +85,7 @@ export default function EventModal({ open, onClose, event }) {
               width: '100%',
               height: '100%',
               objectFit: 'cover',
+              objectPosition: eventImagePosition,
             }}
             onError={(e) => {
               e.target.src = '/placeholder-event.png';

--- a/ProjectCode/client/src/components/ImagePositionEditor.js
+++ b/ProjectCode/client/src/components/ImagePositionEditor.js
@@ -1,4 +1,4 @@
-import { useState, useRef, useCallback } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { Box, IconButton, Tooltip, CircularProgress } from '@mui/material';
 import CropIcon from '@mui/icons-material/Crop';
 import CheckIcon from '@mui/icons-material/Check';
@@ -6,11 +6,15 @@ import CloseIcon from '@mui/icons-material/Close';
 import { updateEvent } from '../api';
 import { useAuth } from '../context/AuthContext';
 
-export default function ImagePositionEditor({ eventId, imageUrl, currentPosition, onPositionSaved, sx }) {
+export default function ImagePositionEditor({ eventId, imageUrl, currentPosition, onPositionSaved, onSave, sx }) {
   const { currentUser } = useAuth();
   const [editing, setEditing] = useState(false);
   const [saving, setSaving] = useState(false);
   const [position, setPosition] = useState(currentPosition || 'center center');
+  // Sync internal position state when the parent passes a new currentPosition
+  useEffect(() => {
+    setPosition(currentPosition || 'center center');
+  }, [currentPosition]);
   const [dragStart, setDragStart] = useState(null);
   const [positionAtDragStart, setPositionAtDragStart] = useState(null);
   const dragRef = useRef(null);
@@ -56,7 +60,11 @@ export default function ImagePositionEditor({ eventId, imageUrl, currentPosition
     if (!currentUser?.uid) return;
     setSaving(true);
     try {
-      await updateEvent(eventId, { image_position: position }, currentUser.uid);
+      if (onSave) {
+        await onSave(position);
+      } else {
+        await updateEvent(eventId, { image_position: position }, currentUser.uid);
+      }
       setEditing(false);
       if (onPositionSaved) onPositionSaved(position);
     } catch (error) {

--- a/ProjectCode/client/src/pages/CalendarPage.js
+++ b/ProjectCode/client/src/pages/CalendarPage.js
@@ -5,9 +5,12 @@ import AddIcon from '@mui/icons-material/Add';
 import InfoIcon from '@mui/icons-material/Info';
 import CloudUploadIcon from '@mui/icons-material/CloudUpload';
 import StarIcon from '@mui/icons-material/Star';
+import QrCode2Icon from '@mui/icons-material/QrCode2';
 import { Alert, Box, Button, Card, CardContent, CardMedia, Chip, CircularProgress, Container, Dialog, DialogActions, DialogContent, DialogTitle, FormControlLabel, Grid, IconButton, MenuItem, Snackbar, Switch, TextField, Tooltip, Typography } from '@mui/material';
 import RepeatIcon from '@mui/icons-material/Repeat';
+import ShareIcon from '@mui/icons-material/Share';
 import { useEffect, useState, useRef } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { ref, uploadBytes, getDownloadURL } from 'firebase/storage';
 import NavigationButtons from '../components/NavigationButtons';
 import EventDetailModal from '../components/EventDetailModal';
@@ -44,6 +47,7 @@ const initialFormData = {
 export default function CalendarPage() {
   const { adminModeEnabled } = useAdmin();
   const { currentUser } = useAuth();
+  const [searchParams, setSearchParams] = useSearchParams();
   const [selectedEvent, setSelectedEvent] = useState(null);
   const [upcomingEvents, setUpcomingEvents] = useState([]);
   const [featuredEvents, setFeaturedEvents] = useState([]);
@@ -69,6 +73,14 @@ export default function CalendarPage() {
   const [imagePreview, setImagePreview] = useState('');
   const [uploadingImage, setUploadingImage] = useState(false);
   const fileInputRef = useRef(null);
+
+  // Quick QR upload state
+  const [quickQrEventId, setQuickQrEventId] = useState(null);
+  const [quickQrFile, setQuickQrFile] = useState(null);
+  const [quickQrPreview, setQuickQrPreview] = useState('');
+  const [quickQrDialogOpen, setQuickQrDialogOpen] = useState(false);
+  const [quickQrUploading, setQuickQrUploading] = useState(false);
+  const quickQrFileInputRef = useRef(null);
 
   // Default values for Tab auto-fill
   const eventDefaultValues = {
@@ -149,6 +161,7 @@ export default function CalendarPage() {
               description: event.description,
               chineseDescription: event.chinese_description,
               image: event.image,
+              image_position: event.image_position,
               signupLink: event.signup_link,
               status: event.status,
               eventType: event.event_type || 'standard',
@@ -168,6 +181,7 @@ export default function CalendarPage() {
           title: event.name,
           chineseTitle: event.chineseName,
           image: event.image,
+          image_position: event.image_position,
           description: event.description,
           date: event.date,
           time: event.time,
@@ -183,14 +197,35 @@ export default function CalendarPage() {
     fetchEvents();
   }, []);
 
-  const handleEventClick = (event) => {
-    // For featured events, we need to find the full event data
-    if (event.id) {
-      setSelectedEvent(event);
-    } else {
-      // For upcoming events, we already have the full event data
-      setSelectedEvent(event);
+  // Deep-link: auto-open event modal from ?event=ID
+  useEffect(() => {
+    const eventId = searchParams.get('event');
+    if (eventId && upcomingEvents.length > 0) {
+      const event = upcomingEvents.find(ev => String(ev.id) === eventId);
+      if (event) {
+        setSelectedEvent(event);
+      }
     }
+  }, [searchParams, upcomingEvents]);
+
+  const handleEventClick = (event) => {
+    setSelectedEvent(event);
+    setSearchParams({ event: event.id });
+  };
+
+  const handleEventClose = () => {
+    setSelectedEvent(null);
+    setSearchParams({});
+  };
+
+  const handleShareEvent = (e, event) => {
+    e.stopPropagation();
+    const url = `${window.location.origin}/calendar?event=${event.id}`;
+    navigator.clipboard.writeText(url).then(() => {
+      setSnackbar({ open: true, message: 'Link copied / 链接已复制', severity: 'success' });
+    }).catch(() => {
+      setSnackbar({ open: true, message: 'Failed to copy link / 复制链接失败', severity: 'error' });
+    });
   };
 
   const handleFilterChange = (field) => (event) => {
@@ -321,6 +356,7 @@ export default function CalendarPage() {
         description: event.description,
         chineseDescription: event.chinese_description,
         image: event.image,
+        image_position: event.image_position,
         signupLink: event.signup_link,
         status: event.status,
         eventType: event.event_type || 'standard',
@@ -332,6 +368,7 @@ export default function CalendarPage() {
         title: event.name,
         chineseTitle: event.chineseName,
         image: event.image,
+        image_position: event.image_position,
         description: event.description,
         date: event.date,
         time: event.time,
@@ -374,6 +411,7 @@ export default function CalendarPage() {
         description: event.description,
         chineseDescription: event.chinese_description,
         image: event.image,
+        image_position: event.image_position,
         signupLink: event.signup_link,
         status: event.status,
         eventType: event.event_type || 'standard',
@@ -385,6 +423,7 @@ export default function CalendarPage() {
         title: event.name,
         chineseTitle: event.chineseName,
         image: event.image,
+        image_position: event.image_position,
         description: event.description,
         date: event.date,
         time: event.time,
@@ -456,6 +495,75 @@ export default function CalendarPage() {
     setFormData(prev => ({ ...prev, image: '' }));
     if (fileInputRef.current) {
       fileInputRef.current.value = '';
+    }
+  };
+
+  // Quick QR upload handlers
+  const getEventQrCode = (eventId) => {
+    const event = [...featuredEvents, ...upcomingEvents].find(ev => ev.id === eventId);
+    return event?.wechatQrCode || '';
+  };
+
+  const handleQuickQrOpen = (e, event) => {
+    e.stopPropagation();
+    setQuickQrEventId(event.id);
+    setQuickQrFile(null);
+    setQuickQrPreview('');
+    if (quickQrFileInputRef.current) quickQrFileInputRef.current.value = '';
+    setQuickQrDialogOpen(true);
+  };
+
+  const handleQuickQrSelect = (e) => {
+    const file = e.target.files[0];
+    if (file) {
+      if (!file.type.startsWith('image/')) {
+        setSnackbar({ open: true, message: 'Please select an image file / 请选择图片文件', severity: 'error' });
+        return;
+      }
+      if (file.size > 5 * 1024 * 1024) {
+        setSnackbar({ open: true, message: 'Image must be less than 5MB / 图片必须小于5MB', severity: 'error' });
+        return;
+      }
+      setQuickQrFile(file);
+      setQuickQrPreview(URL.createObjectURL(file));
+    }
+  };
+
+  const handleQuickQrSubmit = async () => {
+    if (!quickQrFile || !quickQrEventId) return;
+    setQuickQrUploading(true);
+    try {
+      const timestamp = Date.now();
+      const filename = `events/qr/${timestamp}_${quickQrFile.name.replace(/[^a-zA-Z0-9.]/g, '_')}`;
+      const storageRef = ref(storage, filename);
+      await uploadBytes(storageRef, quickQrFile);
+      const url = await getDownloadURL(storageRef);
+      await updateEvent(quickQrEventId, { wechat_qr_code: url }, currentUser.uid);
+      const updateList = (list) => list.map(ev => ev.id === quickQrEventId ? { ...ev, wechatQrCode: url } : ev);
+      setFeaturedEvents(updateList);
+      setUpcomingEvents(updateList);
+      setQuickQrDialogOpen(false);
+      setSnackbar({ open: true, message: 'QR code uploaded / 二维码已上传', severity: 'success' });
+    } catch (error) {
+      console.error('Error uploading QR code:', error);
+      setSnackbar({ open: true, message: 'Failed to upload QR code / 二维码上传失败', severity: 'error' });
+    } finally {
+      setQuickQrUploading(false);
+    }
+  };
+
+  const handleQuickQrRemove = async () => {
+    if (!quickQrEventId) return;
+    try {
+      await updateEvent(quickQrEventId, { wechat_qr_code: '' }, currentUser.uid);
+      const updateList = (list) => list.map(ev => ev.id === quickQrEventId ? { ...ev, wechatQrCode: '' } : ev);
+      setFeaturedEvents(updateList);
+      setUpcomingEvents(updateList);
+      setQuickQrDialogOpen(false);
+      setSnackbar({ open: true, message: 'QR code removed / 二维码已移除', severity: 'success' });
+    } catch (error) {
+      console.error('Error removing QR code:', error);
+      setSnackbar({ open: true, message: 'Failed to remove QR code / 移除二维码失败', severity: 'error' });
     }
   };
 
@@ -612,6 +720,18 @@ export default function CalendarPage() {
                         <StarIcon fontSize="small" sx={{ color: '#FFB84D' }} />
                       </IconButton>
                     </Tooltip>
+                    <Tooltip title="Upload WeChat QR / 上传微信二维码">
+                      <IconButton
+                        size="small"
+                        onClick={(e) => handleQuickQrOpen(e, event)}
+                        sx={{
+                          backgroundColor: 'rgba(255, 255, 255, 0.9)',
+                          '&:hover': { backgroundColor: 'white' }
+                        }}
+                      >
+                        <QrCode2Icon fontSize="small" sx={{ color: event.wechatQrCode ? '#07C160' : 'action.active' }} />
+                      </IconButton>
+                    </Tooltip>
                   </Box>
                 )}
                 <EventCardImage event={event} height="200" onError={handleImageError} />
@@ -668,6 +788,15 @@ export default function CalendarPage() {
                   >
                     Learn More & Sign Up 了解更多并报名
                   </Button>
+                  <Tooltip title="Share / 分享">
+                    <IconButton
+                      size="small"
+                      onClick={(e) => handleShareEvent(e, event)}
+                      sx={{ mt: 1, color: '#FFB84D' }}
+                    >
+                      <ShareIcon fontSize="small" />
+                    </IconButton>
+                  </Tooltip>
                 </CardContent>
               </Card>
             </Grid>
@@ -823,6 +952,18 @@ export default function CalendarPage() {
                       <StarIcon fontSize="small" sx={{ color: '#FFB84D' }} />
                     </IconButton>
                   </Tooltip>
+                  <Tooltip title="Upload WeChat QR / 上传微信二维码">
+                    <IconButton
+                      size="small"
+                      onClick={(e) => handleQuickQrOpen(e, event)}
+                      sx={{
+                        backgroundColor: 'rgba(255, 255, 255, 0.9)',
+                        '&:hover': { backgroundColor: 'white' }
+                      }}
+                    >
+                      <QrCode2Icon fontSize="small" sx={{ color: event.wechatQrCode ? '#07C160' : 'action.active' }} />
+                    </IconButton>
+                  </Tooltip>
                 </Box>
               )}
 
@@ -928,6 +1069,15 @@ export default function CalendarPage() {
                   >
                     Learn More & Sign Up 了解更多并报名
                   </Button>
+                  <Tooltip title="Share / 分享">
+                    <IconButton
+                      size="small"
+                      onClick={(e) => handleShareEvent(e, event)}
+                      sx={{ color: '#FFB84D' }}
+                    >
+                      <ShareIcon fontSize="small" />
+                    </IconButton>
+                  </Tooltip>
                 </Box>
                 <Typography variant="body2" color="text.secondary" gutterBottom>
                   {event.location}
@@ -945,7 +1095,17 @@ export default function CalendarPage() {
       {selectedEvent && (
         <EventDetailModal
           event={selectedEvent}
-          onClose={() => setSelectedEvent(null)}
+          onClose={handleEventClose}
+          onEventUpdate={(updatedEvent) => {
+            setSelectedEvent(updatedEvent);
+            const updateList = (list) => list.map(ev =>
+              ev.id === updatedEvent.id ? { ...ev, ...updatedEvent } : ev
+            );
+            setUpcomingEvents(updateList);
+            setFeaturedEvents(prev => prev.map(ev =>
+              ev.id === updatedEvent.id ? { ...ev, ...updatedEvent } : ev
+            ));
+          }}
         />
       )}
 
@@ -1378,6 +1538,82 @@ export default function CalendarPage() {
             disabled={loading}
           >
             {loading ? <CircularProgress size={24} /> : 'Delete / 删除'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Quick QR Upload Dialog */}
+      <Dialog
+        open={quickQrDialogOpen}
+        onClose={() => setQuickQrDialogOpen(false)}
+        maxWidth="xs"
+        fullWidth
+      >
+        <DialogTitle sx={{ textAlign: 'center' }}>
+          WeChat QR Code / 微信二维码
+        </DialogTitle>
+        <DialogContent sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 2 }}>
+          {getEventQrCode(quickQrEventId) && !quickQrPreview && (
+            <Box sx={{ textAlign: 'center' }}>
+              <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+                Current QR Code / 当前二维码
+              </Typography>
+              <img
+                src={getEventQrCode(quickQrEventId)}
+                alt="Current QR Code"
+                style={{ width: 200, height: 200, objectFit: 'contain' }}
+              />
+              <Box sx={{ mt: 1 }}>
+                <Button size="small" color="error" onClick={handleQuickQrRemove}>
+                  Remove / 移除
+                </Button>
+              </Box>
+            </Box>
+          )}
+          <input
+            type="file"
+            accept="image/*"
+            onChange={handleQuickQrSelect}
+            ref={quickQrFileInputRef}
+            style={{ display: 'none' }}
+            id="quick-qr-upload"
+          />
+          <label htmlFor="quick-qr-upload">
+            <Button
+              variant="outlined"
+              component="span"
+              startIcon={<CloudUploadIcon />}
+              sx={{
+                borderColor: '#FFB84D',
+                color: '#FFB84D',
+                '&:hover': { borderColor: '#FFA833', backgroundColor: 'rgba(255, 184, 77, 0.04)' }
+              }}
+            >
+              {getEventQrCode(quickQrEventId) ? 'Replace QR / 替换二维码' : 'Choose QR Code / 选择二维码'}
+            </Button>
+          </label>
+          {quickQrPreview && (
+            <Box sx={{ textAlign: 'center' }}>
+              <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+                New QR Code / 新二维码
+              </Typography>
+              <img
+                src={quickQrPreview}
+                alt="QR Preview"
+                style={{ width: 200, height: 200, objectFit: 'contain' }}
+              />
+            </Box>
+          )}
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setQuickQrDialogOpen(false)}>Cancel / 取消</Button>
+          <Button
+            onClick={handleQuickQrSubmit}
+            variant="contained"
+            disabled={!quickQrFile || quickQrUploading}
+            sx={{ backgroundColor: '#07C160', '&:hover': { backgroundColor: '#06AD56' } }}
+          >
+            {quickQrUploading ? <CircularProgress size={20} /> : 'Upload / 上传'}
           </Button>
         </DialogActions>
       </Dialog>

--- a/ProjectCode/client/src/pages/HighlightsPage.js
+++ b/ProjectCode/client/src/pages/HighlightsPage.js
@@ -199,6 +199,7 @@ export default function HighlightsPage() {
           description: event.description,
           chineseDescription: event.chinese_description,
           image: event.image || '/images/2025/20250517_bk_half.jpg',
+          image_position: event.image_position,
           signupLink: event.signup_link,
           status: event.status,
           parsedDate: eventDate,
@@ -257,7 +258,8 @@ export default function HighlightsPage() {
                 time: draggedEvent.time,
                 location: draggedEvent.location,
                 chinese_location: draggedEvent.chineseLocation,
-                image: draggedEvent.image
+                image: draggedEvent.image,
+                image_position: draggedEvent.image_position
               }],
               event_count: g.event_count + 1
             };
@@ -284,7 +286,8 @@ export default function HighlightsPage() {
             time: targetStandaloneEvent.time,
             location: targetStandaloneEvent.location,
             chinese_location: targetStandaloneEvent.chineseLocation,
-            image: targetStandaloneEvent.image
+            image: targetStandaloneEvent.image,
+            image_position: targetStandaloneEvent.image_position
           },
           {
             id: draggedEvent.id,
@@ -294,10 +297,13 @@ export default function HighlightsPage() {
             time: draggedEvent.time,
             location: draggedEvent.location,
             chinese_location: draggedEvent.chineseLocation,
-            image: draggedEvent.image
+            image: draggedEvent.image,
+            image_position: draggedEvent.image_position
           }
         ],
         cover_image: targetStandaloneEvent.image,
+        cover_image_position: targetStandaloneEvent.image_position,
+        cover_event_id: targetStandaloneEvent.id,
         most_recent_date: targetStandaloneEvent.date
       };
       setEventGroups(prev => [newGroup, ...prev]);
@@ -385,7 +391,8 @@ export default function HighlightsPage() {
       time: event.time,
       location: event.location,
       chineseLocation: event.chinese_location,
-      image: event.image
+      image: event.image,
+      image_position: event.image_position
     });
   };
 
@@ -461,6 +468,7 @@ export default function HighlightsPage() {
           location: groupEvent.location,
           chineseLocation: groupEvent.chinese_location,
           image: groupEvent.image,
+          image_position: groupEvent.image_position,
         });
         return;
       }
@@ -490,6 +498,7 @@ export default function HighlightsPage() {
             description: event.description,
             chineseDescription: event.chinese_description,
             image: event.image || '/images/2025/20250517_bk_half.jpg',
+            image_position: event.image_position,
           }))
           .sort((a, b) => b.date.localeCompare(a.date));
 
@@ -499,6 +508,7 @@ export default function HighlightsPage() {
           title: event.name,
           chineseTitle: event.chineseName,
           image: event.image,
+          image_position: event.image_position,
           description: event.description,
           date: event.date,
           time: event.time,
@@ -1082,6 +1092,13 @@ export default function HighlightsPage() {
         <EventDetailModal
           event={selectedEvent}
           onClose={() => setSelectedEvent(null)}
+          onEventUpdate={(updatedEvent) => {
+            setSelectedEvent(updatedEvent);
+            const updateList = (list) => list.map(e => e.id === updatedEvent.id ? { ...e, ...updatedEvent } : e);
+            setPastEvents(updateList);
+            setStandaloneEvents(updateList);
+            setFeaturedEvents(updateList);
+          }}
         />
       )}
 

--- a/ProjectCode/client/src/pages/HomePage.js
+++ b/ProjectCode/client/src/pages/HomePage.js
@@ -19,6 +19,7 @@ import {
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
 import EditIcon from '@mui/icons-material/Edit';
 import DragIndicatorIcon from '@mui/icons-material/DragIndicator';
+import CropIcon from '@mui/icons-material/Crop';
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
@@ -42,7 +43,10 @@ import EventModal from '../components/EventModal';
 import { useAuth } from '../context/AuthContext';
 import { useAdmin } from '../context/AdminContext';
 import { getCarouselBanners } from '../api/banners';
+import { updateBanner } from '../api/banners';
 import { getActiveSections, updateSection, reorderSections, uploadImage } from '../api/homepageSections';
+import ImagePositionEditor from '../components/ImagePositionEditor';
+import { updateEvent } from '../api';
 
 // Fallback carousel images if API fails
 const fallbackCarouselImages = [
@@ -68,8 +72,8 @@ const fallbackCarouselImages = [
 
 // Fallback sections if API fails
 const fallbackSections = [
-  { id: 1, title_en: 'Event Registration', title_cn: '活动报名', link_path: '/event-registration', image_url: '/EventRegistration.png' },
-  { id: 2, title_en: 'Memories', title_cn: '回忆', link_path: '/Highlights', image_url: '/Highlights.png' },
+  { id: 1, title_en: 'Event Registration', title_cn: '活动报名', link_path: '/calendar', image_url: '/EventRegistration.png' },
+  { id: 2, title_en: 'Memories', title_cn: '回忆', link_path: '/highlights', image_url: '/Highlights.png' },
   { id: 3, title_en: 'Upcoming', title_cn: '即将到来', link_path: '/calendar', image_url: null },
   { id: 4, title_en: 'Club Credits/Records', title_cn: '俱乐部积分/记录', link_path: '/records', image_url: null },
   { id: 5, title_en: 'Join NewBee', title_cn: '加入新蜂', link_path: '/join', image_url: null },
@@ -77,7 +81,7 @@ const fallbackSections = [
 ];
 
 // Sortable Section Component
-function SortableSection({ section, adminModeEnabled, onEdit }) {
+function SortableSection({ section, adminModeEnabled, onEdit, onPositionEdit }) {
   const [isHovered, setIsHovered] = useState(false);
   const {
     attributes,
@@ -192,6 +196,7 @@ function SortableSection({ section, adminModeEnabled, onEdit }) {
                 width: '100%',
                 height: '100%',
                 objectFit: 'cover',
+                objectPosition: section.image_position || 'center center',
                 borderRadius: { xs: '8px', sm: '12px' },
                 transition: 'filter 0.3s ease',
                 filter: isHovered ? 'brightness(0.85)' : 'brightness(1)',
@@ -260,6 +265,30 @@ function SortableSection({ section, adminModeEnabled, onEdit }) {
               />
             </Box>
           </Box>
+
+          {/* Admin: crop button for section image position */}
+          {adminModeEnabled && section.image_url && (
+            <Tooltip title="Adjust image position / 调整图片位置">
+              <IconButton
+                size="small"
+                onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  if (onPositionEdit) onPositionEdit(section);
+                }}
+                sx={{
+                  position: 'absolute',
+                  top: 8,
+                  right: 8,
+                  backgroundColor: 'rgba(255, 255, 255, 0.9)',
+                  '&:hover': { backgroundColor: 'white' },
+                  zIndex: 10,
+                }}
+              >
+                <CropIcon fontSize="small" sx={{ color: '#FFB84D' }} />
+              </IconButton>
+            </Tooltip>
+          )}
         </Box>
       </Container>
     </Box>
@@ -283,6 +312,7 @@ export default function HomePage() {
     title_en: '',
     title_cn: '',
     image_url: '',
+    image_position: '',
     link_path: '',
     is_active: true
   });
@@ -290,6 +320,8 @@ export default function HomePage() {
   const [selectedFile, setSelectedFile] = useState(null);
   const [imagePreview, setImagePreview] = useState(null);
   const [uploading, setUploading] = useState(false);
+  const [carouselPositionEditing, setCarouselPositionEditing] = useState(false);
+  const [sectionPositionEditing, setSectionPositionEditing] = useState(null);
   const navigate = useNavigate();
 
   // Drag and drop sensors
@@ -354,6 +386,7 @@ export default function HomePage() {
       title_en: section.title_en || '',
       title_cn: section.title_cn || '',
       image_url: section.image_url || '',
+      image_position: section.image_position || '',
       link_path: section.link_path || '',
       is_active: section.is_active !== false
     });
@@ -503,6 +536,7 @@ export default function HomePage() {
                   width: '100%',
                   height: '100%',
                   objectFit: 'cover',
+                  objectPosition: image.image_position || 'center center',
                   position: 'absolute',
                   top: 0,
                   left: 0,
@@ -602,6 +636,29 @@ export default function HomePage() {
                 />
               ))}
             </Box>
+
+            {/* Admin: crop button to open position editor dialog */}
+            {adminModeEnabled && carouselImages[currentImageIndex] && (
+              <Tooltip title="Adjust image position / 调整图片位置">
+                <IconButton
+                  size="small"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setCarouselPositionEditing(true);
+                  }}
+                  sx={{
+                    position: 'absolute',
+                    top: 8,
+                    right: 8,
+                    backgroundColor: 'rgba(255, 255, 255, 0.9)',
+                    '&:hover': { backgroundColor: 'white' },
+                    zIndex: 10,
+                  }}
+                >
+                  <CropIcon fontSize="small" sx={{ color: '#FFB84D' }} />
+                </IconButton>
+              </Tooltip>
+            )}
           </Box>
         </Container>
       )}
@@ -691,6 +748,7 @@ export default function HomePage() {
                 section={section}
                 adminModeEnabled={adminModeEnabled}
                 onEdit={handleEditSection}
+                onPositionEdit={(section) => setSectionPositionEditing(section)}
               />
             ))}
           </SortableContext>
@@ -704,6 +762,95 @@ export default function HomePage() {
             onEdit={() => {}}
           />
         ))
+      )}
+
+      {/* Carousel Position Editor Dialog */}
+      {carouselPositionEditing && carouselImages[currentImageIndex] && (
+        <Dialog
+          open={carouselPositionEditing}
+          onClose={() => setCarouselPositionEditing(false)}
+          maxWidth="md"
+          fullWidth
+        >
+          <DialogTitle sx={{ color: '#FFA500', fontWeight: 600 }}>
+            Adjust Image Position / 调整图片位置
+          </DialogTitle>
+          <DialogContent>
+            <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+              Click the crop icon, then drag the image to adjust its position. / 点击裁剪图标，然后拖动图片调整位置。
+            </Typography>
+            <ImagePositionEditor
+              imageUrl={carouselImages[currentImageIndex].image_url}
+              currentPosition={carouselImages[currentImageIndex].image_position || 'center center'}
+              onSave={async (position) => {
+                const img = carouselImages[currentImageIndex];
+                if (img.source_type === 'event_highlight' && img.event_id) {
+                  await updateEvent(img.event_id, { image_position: position }, currentUser.uid);
+                } else if (img.id > 0) {
+                  await updateBanner(img.id, { image_position: position }, currentUser.uid);
+                }
+              }}
+              onPositionSaved={(position) => {
+                setCarouselImages(prev => prev.map((img, idx) =>
+                  idx === currentImageIndex ? { ...img, image_position: position } : img
+                ));
+                setCarouselPositionEditing(false);
+              }}
+              sx={{
+                width: '100%',
+                height: { xs: '200px', sm: '300px', md: '400px' },
+                borderRadius: '8px',
+              }}
+            />
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={() => setCarouselPositionEditing(false)}>
+              Close / 关闭
+            </Button>
+          </DialogActions>
+        </Dialog>
+      )}
+
+      {/* Section Position Editor Dialog */}
+      {sectionPositionEditing && (
+        <Dialog
+          open={!!sectionPositionEditing}
+          onClose={() => setSectionPositionEditing(null)}
+          maxWidth="md"
+          fullWidth
+        >
+          <DialogTitle sx={{ color: '#FFA500', fontWeight: 600 }}>
+            Adjust Image Position / 调整图片位置
+          </DialogTitle>
+          <DialogContent>
+            <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+              Click the crop icon, then drag the image to adjust its position. / 点击裁剪图标，然后拖动图片调整位置。
+            </Typography>
+            <ImagePositionEditor
+              imageUrl={sectionPositionEditing.image_url}
+              currentPosition={sectionPositionEditing.image_position || 'center center'}
+              onSave={async (position) => {
+                await updateSection(sectionPositionEditing.id, { image_position: position }, currentUser.uid);
+              }}
+              onPositionSaved={(position) => {
+                setSections(prev => prev.map(s =>
+                  s.id === sectionPositionEditing.id ? { ...s, image_position: position } : s
+                ));
+                setSectionPositionEditing(null);
+              }}
+              sx={{
+                width: '100%',
+                height: { xs: '200px', sm: '300px', md: '400px' },
+                borderRadius: '8px',
+              }}
+            />
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={() => setSectionPositionEditing(null)}>
+              Close / 关闭
+            </Button>
+          </DialogActions>
+        </Dialog>
       )}
 
       {/* Event Modal */}

--- a/ProjectCode/server/database.py
+++ b/ProjectCode/server/database.py
@@ -270,6 +270,7 @@ class Event(Base):
     image = Column(String(500))
     image_position = Column(String(50), default='center center')  # CSS object-position value
     signup_link = Column(String(500))
+    wechat_qr_code = Column(String(500))
     status = Column(String(50), default='Upcoming')  # 'Upcoming', 'Highlight', 'Cancelled'
 
     # Heylo integration fields
@@ -462,6 +463,7 @@ class BannerImage(Base):
     is_active = Column(Boolean, default=True)
     event_id = Column(Integer, ForeignKey('events.id', ondelete='SET NULL'), nullable=True)  # Link to event
     source_type = Column(String(20), default='manual')  # 'manual' or 'event_highlight'
+    image_position = Column(String(50), default='center center')  # CSS object-position value
     created_at = Column(DateTime, default=func.now())
     updated_at = Column(DateTime, default=func.now(), onupdate=func.now())
 
@@ -482,6 +484,7 @@ class HomepageSection(Base):
     title_en = Column(String(100), nullable=False)
     title_cn = Column(String(100))
     image_url = Column(Text)  # Use Text to support base64 data URLs
+    image_position = Column(String(50), default='center center')  # CSS object-position value
     link_path = Column(String(255), nullable=False)
     display_order = Column(Integer, default=0)
     is_active = Column(Boolean, default=True)

--- a/ProjectCode/server/main.py
+++ b/ProjectCode/server/main.py
@@ -3358,9 +3358,9 @@ def update_gallery_image(
     image_id: int,
     image_update: EventGalleryImageUpdate,
     db: Session = Depends(get_db),
-    current_admin: Member = Depends(get_current_admin)
+    current_user: Member = Depends(get_current_committee_or_admin)
 ):
-    """Update a gallery image (admin only)"""
+    """Update a gallery image (committee or admin)"""
     image = db.query(EventGalleryImage).filter(EventGalleryImage.id == image_id).first()
     if not image:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Image not found")

--- a/ProjectCode/server/main.py
+++ b/ProjectCode/server/main.py
@@ -2565,7 +2565,8 @@ def get_carousel_banners(db: Session = Depends(get_db)):
             label_cn=banner.label_cn,
             display_order=banner.display_order,
             source_type=banner.source_type or 'manual',
-            event_id=banner.event_id
+            event_id=banner.event_id,
+            image_position=banner.image_position
         )
 
         # If banner is linked to an event, populate event details
@@ -2577,6 +2578,9 @@ def get_carousel_banners(db: Session = Depends(get_db)):
             item.event_location = banner.event.location
             item.event_description = banner.event.description
             item.event_signup_link = banner.event.signup_link
+            # Use event's image_position if banner doesn't have its own
+            if not item.image_position:
+                item.image_position = banner.event.image_position
 
         carousel_items.append(item)
 
@@ -2606,7 +2610,8 @@ def get_carousel_banners(db: Session = Depends(get_db)):
             event_time=event.time,
             event_location=event.location,
             event_description=event.description,
-            event_signup_link=event.signup_link
+            event_signup_link=event.signup_link,
+            image_position=event.image_position
         )
         carousel_items.append(item)
 
@@ -4254,6 +4259,8 @@ def get_highlights_grouped(db: Session = Depends(get_db)):
             event_count=len(events),
             events=event_list,
             cover_image=most_recent.image,
+            cover_image_position=most_recent.image_position,
+            cover_event_id=most_recent.id,
             most_recent_date=most_recent.date
         ))
 

--- a/ProjectCode/server/migrations/add_image_position_columns.py
+++ b/ProjectCode/server/migrations/add_image_position_columns.py
@@ -1,0 +1,55 @@
+"""
+Migration script to add image_position columns to banner_images and homepage_sections tables.
+Run this script to update the database schema.
+
+Usage:
+    python migrations/add_image_position_columns.py
+"""
+
+import os
+import sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from sqlalchemy import text
+from database import engine, USE_SQLITE
+
+
+def get_columns(conn, table_name):
+    """Get existing column names for a table."""
+    if USE_SQLITE:
+        result = conn.execute(text(f"PRAGMA table_info({table_name})"))
+        return [row[1] for row in result.fetchall()]
+    else:
+        result = conn.execute(text(f"""
+            SELECT COLUMN_NAME
+            FROM INFORMATION_SCHEMA.COLUMNS
+            WHERE TABLE_NAME = '{table_name}'
+        """))
+        return [row[0] for row in result.fetchall()]
+
+
+def add_column(conn, table_name, column_name, column_type, default=None):
+    """Add a column to a table if it doesn't exist."""
+    columns = get_columns(conn, table_name)
+    if column_name not in columns:
+        print(f"Adding {column_name} column to {table_name}...")
+        default_clause = f" DEFAULT '{default}'" if default else ""
+        conn.execute(text(f"ALTER TABLE {table_name} ADD COLUMN {column_name} {column_type}{default_clause}"))
+        conn.commit()
+        print(f"  Added {column_name} column")
+    else:
+        print(f"  {column_name} column already exists in {table_name}")
+
+
+def migrate():
+    """Add image_position columns to banner_images and homepage_sections tables."""
+
+    with engine.connect() as conn:
+        add_column(conn, 'banner_images', 'image_position', 'VARCHAR(50)', 'center center')
+        add_column(conn, 'homepage_sections', 'image_position', 'VARCHAR(50)', 'center center')
+
+    print("\nMigration completed successfully!")
+
+
+if __name__ == "__main__":
+    migrate()

--- a/ProjectCode/server/models.py
+++ b/ProjectCode/server/models.py
@@ -314,6 +314,7 @@ class EventBase(BaseModel):
     image: Optional[str] = None
     image_position: Optional[str] = Field(None, max_length=50)
     signup_link: Optional[str] = Field(None, max_length=500)
+    wechat_qr_code: Optional[str] = Field(None, max_length=500)
     status: EventStatus = Field(default=EventStatus.upcoming)
     event_type: EventType = Field(default=EventType.standard)
     heylo_embed: Optional[str] = None  # Heylo embed code for heylo event type
@@ -335,6 +336,7 @@ class EventUpdate(BaseModel):
     image: Optional[str] = None
     image_position: Optional[str] = Field(None, max_length=50)
     signup_link: Optional[str] = Field(None, max_length=500)
+    wechat_qr_code: Optional[str] = Field(None, max_length=500)
     status: Optional[EventStatus] = None
     event_type: Optional[EventType] = None
     heylo_embed: Optional[str] = None
@@ -548,6 +550,7 @@ class BannerImageBase(BaseModel):
     is_active: bool = Field(default=True)
     event_id: Optional[int] = None
     source_type: str = Field(default='manual', max_length=20)
+    image_position: Optional[str] = Field(None, max_length=50)
 
 
 class BannerImageCreate(BannerImageBase):
@@ -564,6 +567,7 @@ class BannerImageUpdate(BaseModel):
     is_active: Optional[bool] = None
     event_id: Optional[int] = None
     source_type: Optional[str] = Field(None, max_length=20)
+    image_position: Optional[str] = Field(None, max_length=50)
 
 
 class BannerImageResponse(BannerImageBase):
@@ -594,6 +598,7 @@ class CarouselBannerResponse(BaseModel):
     event_location: Optional[str] = None
     event_description: Optional[str] = None
     event_signup_link: Optional[str] = None
+    image_position: Optional[str] = None
 
     class Config:
         from_attributes = True
@@ -604,6 +609,7 @@ class HomepageSectionBase(BaseModel):
     title_en: str = Field(..., max_length=100)
     title_cn: Optional[str] = Field(None, max_length=100)
     image_url: Optional[str] = None  # No max_length - can store base64 data URLs
+    image_position: Optional[str] = Field(None, max_length=50)
     link_path: str = Field(..., max_length=255)
     display_order: int = Field(default=0)
     is_active: bool = Field(default=True)
@@ -617,6 +623,7 @@ class HomepageSectionUpdate(BaseModel):
     title_en: Optional[str] = Field(None, max_length=100)
     title_cn: Optional[str] = Field(None, max_length=100)
     image_url: Optional[str] = None  # No max_length - can store base64 data URLs
+    image_position: Optional[str] = Field(None, max_length=50)
     link_path: Optional[str] = Field(None, max_length=255)
     display_order: Optional[int] = None
     is_active: Optional[bool] = None
@@ -948,6 +955,8 @@ class EventGroup(BaseModel):
     events: List[EventInGroup]
     # Cover info from most recent event
     cover_image: Optional[str] = None
+    cover_image_position: Optional[str] = None
+    cover_event_id: Optional[int] = None
     most_recent_date: dt.date
 
 


### PR DESCRIPTION
## Summary
- **WeChat QR Upload**: Admin/committee can upload QR codes directly from event cards; QR overlays on event image in detail modal
- **Event Sharing**: Deep-linkable event URLs (`/calendar?event=ID`) with share buttons on cards and modal
- **Image Position Editor**: Backend and frontend support for custom image positioning on event cards
- **Other**: Homepage and Highlights page updates, EventGroupCard improvements

## Test plan
- [ ] Log in as admin, enable admin mode on Calendar page
- [ ] Verify QR upload button appears on featured and list event cards
- [ ] Upload a QR code and confirm it overlays on the event image in the detail modal
- [ ] Click share button, paste link in new tab, confirm event modal auto-opens
- [ ] Verify image position editor works in event detail modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)