### PR TITLE
Deploy: S3 image upload, race sync, and records UI

### DIFF
--- a/ProjectCode/client/src/api/records.js
+++ b/ProjectCode/client/src/api/records.js
@@ -39,3 +39,59 @@ export async function getWomenRecords(year = null) {
 export async function getAllRaces() {
   return api.get('/api/results/all-races');
 }
+
+/**
+ * Get available NYRR race patterns for syncing
+ * @returns {Promise<{races: Array<{code, name_template, distance, typical_month}>}>}
+ */
+export async function getSyncRacePatterns() {
+  return api.get('/api/results/sync/races');
+}
+
+/**
+ * Start NYRR data sync via SSE streaming
+ * @param {{years: number[], race_codes: string[]|null}} params
+ * @param {string} firebaseUid
+ * @param {function} onProgress - Called with each SSE event object
+ * @returns {Promise<void>}
+ */
+export async function startNyrrSync(params, firebaseUid, onProgress) {
+  const API_BASE_URL = process.env.REACT_APP_API_BASE_URL || 'http://localhost:8000';
+  const response = await fetch(`${API_BASE_URL}/api/results/sync`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Firebase-UID': firebaseUid,
+    },
+    body: JSON.stringify(params),
+  });
+
+  if (!response.ok) {
+    const err = await response.json().catch(() => ({}));
+    throw new Error(err.detail || `Sync failed with status ${response.status}`);
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+
+    buffer += decoder.decode(value, { stream: true });
+    const lines = buffer.split('\n');
+    buffer = lines.pop(); // keep incomplete line in buffer
+
+    for (const line of lines) {
+      if (line.startsWith('data: ')) {
+        try {
+          const event = JSON.parse(line.slice(6));
+          onProgress(event);
+        } catch {
+          // skip malformed events
+        }
+      }
+    }
+  }
+}

--- a/ProjectCode/client/src/pages/RecordsPage.js
+++ b/ProjectCode/client/src/pages/RecordsPage.js
@@ -4,9 +4,14 @@ import AddIcon from '@mui/icons-material/Add';
 import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
 import UploadFileIcon from '@mui/icons-material/UploadFile';
-import { Alert, Box, Button, CircularProgress, Container, Dialog, DialogActions, DialogContent, DialogTitle, FormControl, FormControlLabel, IconButton, InputAdornment, InputLabel, MenuItem, Paper, Radio, RadioGroup, Select, Tab, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Tabs, TextField, Typography, useMediaQuery, useTheme } from '@mui/material';
+import SyncIcon from '@mui/icons-material/Sync';
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import ErrorIcon from '@mui/icons-material/Error';
+import RemoveCircleOutlineIcon from '@mui/icons-material/RemoveCircleOutline';
+import { Alert, Box, Button, Checkbox, Chip, CircularProgress, Container, Dialog, DialogActions, DialogContent, DialogTitle, FormControl, FormControlLabel, FormGroup, IconButton, InputAdornment, InputLabel, LinearProgress, MenuItem, Paper, Radio, RadioGroup, Select, Tab, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Tabs, TextField, Typography, useMediaQuery, useTheme } from '@mui/material';
 import { useEffect, useState } from 'react';
-import { getAvailableYears, getMenRecords, getWomenRecords } from '../api/records';
+import { getAvailableYears, getMenRecords, getWomenRecords, getSyncRacePatterns, startNyrrSync } from '../api/records';
+import { clearApiCache } from '../api/client';
 import { getCredits, createCredit, updateCredit, deleteCredit, bulkUploadCredits } from '../api/credits';
 import ClubEntryRules from '../components/ClubEntryRules';
 import NavigationButtons from '../components/NavigationButtons';
@@ -53,6 +58,17 @@ export default function RecordsPage() {
   const [bulkUploadMode, setBulkUploadMode] = useState('merge');
   const [bulkUploadLoading, setBulkUploadLoading] = useState(false);
   const [bulkUploadResult, setBulkUploadResult] = useState(null);
+
+  // NYRR Sync state
+  const currentYear = new Date().getFullYear();
+  const [syncDialogOpen, setSyncDialogOpen] = useState(false);
+  const [syncYears, setSyncYears] = useState([currentYear]);
+  const [syncRaceCodes, setSyncRaceCodes] = useState([]);
+  const [syncAllRaces, setSyncAllRaces] = useState(true);
+  const [availableRacePatterns, setAvailableRacePatterns] = useState([]);
+  const [syncProgress, setSyncProgress] = useState([]);
+  const [syncRunning, setSyncRunning] = useState(false);
+  const [syncResult, setSyncResult] = useState(null);
 
   const distances = [
     { label: "1 Mile\n一英里", value: "1M" },
@@ -283,6 +299,77 @@ export default function RecordsPage() {
     }
   };
 
+  // NYRR Sync handlers
+  const handleOpenSyncDialog = async () => {
+    setSyncDialogOpen(true);
+    setSyncProgress([]);
+    setSyncResult(null);
+    setSyncYears([currentYear]);
+    setSyncAllRaces(true);
+    setSyncRaceCodes([]);
+    try {
+      const data = await getSyncRacePatterns();
+      setAvailableRacePatterns(data.races || []);
+    } catch (error) {
+      console.error('Error fetching race patterns:', error);
+    }
+  };
+
+  const handleCloseSyncDialog = () => {
+    if (!syncRunning) {
+      setSyncDialogOpen(false);
+    }
+  };
+
+  const toggleSyncYear = (year) => {
+    setSyncYears(prev =>
+      prev.includes(year) ? prev.filter(y => y !== year) : [...prev, year].sort()
+    );
+  };
+
+  const toggleSyncRaceCode = (code) => {
+    setSyncRaceCodes(prev =>
+      prev.includes(code) ? prev.filter(c => c !== code) : [...prev, code]
+    );
+  };
+
+  const handleStartSync = async () => {
+    if (syncYears.length === 0) return;
+    setSyncRunning(true);
+    setSyncProgress([]);
+    setSyncResult(null);
+
+    try {
+      await startNyrrSync(
+        {
+          years: syncYears,
+          race_codes: syncAllRaces ? null : syncRaceCodes,
+        },
+        currentUser?.uid,
+        (event) => {
+          if (event.type === 'progress') {
+            setSyncProgress(prev => {
+              const updated = [...prev];
+              updated[event.index] = event;
+              return updated;
+            });
+          } else if (event.type === 'complete') {
+            setSyncResult(event);
+          }
+        }
+      );
+    } catch (error) {
+      setSyncResult({ total_imported: 0, total_errors: 1, error: error.message });
+    } finally {
+      setSyncRunning(false);
+      // Refresh records data
+      clearApiCache('/api/results');
+      await fetchRecordsData(selectedYear || null);
+      const yearsJson = await getAvailableYears();
+      setAvailableYears(yearsJson.years || []);
+    }
+  };
+
   const handleTabChange = (event, newValue) => {
     setCurrentTab(newValue);
     setShowAll(false);
@@ -420,6 +507,8 @@ export default function RecordsPage() {
         <Box sx={{
           display: 'flex',
           justifyContent: 'center',
+          alignItems: 'center',
+          gap: 2,
           mb: 3
         }}>
           <FormControl sx={{ minWidth: 200 }}>
@@ -457,6 +546,19 @@ export default function RecordsPage() {
               ))}
             </Select>
           </FormControl>
+          {adminModeEnabled && (
+            <Button
+              variant="contained"
+              startIcon={<SyncIcon />}
+              onClick={handleOpenSyncDialog}
+              sx={{
+                backgroundColor: '#FFA500',
+                '&:hover': { backgroundColor: '#e69500' },
+              }}
+            >
+              Sync NYRR Data
+            </Button>
+          )}
         </Box>
 
         {/* Records Tabs */}
@@ -987,6 +1089,132 @@ export default function RecordsPage() {
             color="error"
           >
             Delete 删除
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* NYRR Sync Dialog */}
+      <Dialog open={syncDialogOpen} onClose={handleCloseSyncDialog} maxWidth="sm" fullWidth>
+        <DialogTitle>Sync NYRR Race Data 同步NYRR比赛数据</DialogTitle>
+        <DialogContent>
+          {/* Year Selection */}
+          <Typography variant="subtitle2" sx={{ mb: 1, mt: 1 }}>
+            Select Years 选择年份
+          </Typography>
+          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, mb: 2 }}>
+            {Array.from({ length: currentYear - 2014 }, (_, i) => 2015 + i).map(year => (
+              <Chip
+                key={year}
+                label={year}
+                clickable
+                color={syncYears.includes(year) ? 'primary' : 'default'}
+                variant={syncYears.includes(year) ? 'filled' : 'outlined'}
+                onClick={() => toggleSyncYear(year)}
+                disabled={syncRunning}
+                sx={syncYears.includes(year) ? {
+                  backgroundColor: '#FFA500',
+                  '&:hover': { backgroundColor: '#e69500' },
+                } : {}}
+              />
+            ))}
+          </Box>
+
+          {/* Race Selection */}
+          <Typography variant="subtitle2" sx={{ mb: 1 }}>
+            Select Races 选择比赛
+          </Typography>
+          <Box sx={{ mb: 1 }}>
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={syncAllRaces}
+                  onChange={(e) => setSyncAllRaces(e.target.checked)}
+                  disabled={syncRunning}
+                  sx={{ '&.Mui-checked': { color: '#FFA500' } }}
+                />
+              }
+              label="All Races 所有比赛"
+            />
+          </Box>
+          {!syncAllRaces && (
+            <FormGroup sx={{ maxHeight: 200, overflowY: 'auto', ml: 1, mb: 2 }}>
+              {availableRacePatterns.map(race => (
+                <FormControlLabel
+                  key={race.code}
+                  control={
+                    <Checkbox
+                      checked={syncRaceCodes.includes(race.code)}
+                      onChange={() => toggleSyncRaceCode(race.code)}
+                      disabled={syncRunning}
+                      size="small"
+                      sx={{ '&.Mui-checked': { color: '#FFA500' } }}
+                    />
+                  }
+                  label={
+                    <Typography variant="body2">
+                      {race.name_template.replace('{year}', '')} ({race.distance})
+                    </Typography>
+                  }
+                />
+              ))}
+            </FormGroup>
+          )}
+
+          {/* Progress Area */}
+          {(syncRunning || syncProgress.length > 0) && (
+            <Box sx={{ mt: 2 }}>
+              <Typography variant="subtitle2" sx={{ mb: 1 }}>
+                Progress 进度
+              </Typography>
+              {syncRunning && <LinearProgress sx={{ mb: 1, '& .MuiLinearProgress-bar': { backgroundColor: '#FFA500' } }} />}
+              <Box sx={{ maxHeight: 250, overflowY: 'auto' }}>
+                {syncProgress.map((item, idx) => item && (
+                  <Box key={idx} sx={{ display: 'flex', alignItems: 'center', gap: 1, py: 0.5 }}>
+                    {item.status === 'fetching' && <CircularProgress size={16} sx={{ color: '#FFA500' }} />}
+                    {item.status === 'imported' && <CheckCircleIcon sx={{ fontSize: 16, color: 'success.main' }} />}
+                    {item.status === 'no_data' && <RemoveCircleOutlineIcon sx={{ fontSize: 16, color: 'text.disabled' }} />}
+                    {item.status === 'error' && <ErrorIcon sx={{ fontSize: 16, color: 'error.main' }} />}
+                    <Typography variant="body2" sx={{ flex: 1 }}>
+                      {item.race}
+                    </Typography>
+                    <Typography variant="caption" color="text.secondary">
+                      {item.status === 'imported' && `${item.count} records`}
+                      {item.status === 'no_data' && 'No data'}
+                      {item.status === 'error' && 'Error'}
+                      {item.status === 'fetching' && 'Fetching...'}
+                    </Typography>
+                  </Box>
+                ))}
+              </Box>
+            </Box>
+          )}
+
+          {/* Sync Result */}
+          {syncResult && (
+            <Alert severity={syncResult.error ? 'error' : 'success'} sx={{ mt: 2 }}>
+              {syncResult.error ? (
+                <Typography variant="body2">{syncResult.error}</Typography>
+              ) : (
+                <Typography variant="body2">
+                  Sync complete! Imported {syncResult.total_imported} records.
+                  {syncResult.total_errors > 0 && ` Errors: ${syncResult.total_errors}`}
+                </Typography>
+              )}
+            </Alert>
+          )}
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleCloseSyncDialog} disabled={syncRunning}>
+            Close 关闭
+          </Button>
+          <Button
+            onClick={handleStartSync}
+            variant="contained"
+            disabled={syncRunning || syncYears.length === 0 || (!syncAllRaces && syncRaceCodes.length === 0)}
+            startIcon={syncRunning ? <CircularProgress size={20} color="inherit" /> : <SyncIcon />}
+            sx={{ backgroundColor: '#FFA500', '&:hover': { backgroundColor: '#e69500' } }}
+          >
+            {syncRunning ? 'Syncing...' : 'Start Sync 开始同步'}
           </Button>
         </DialogActions>
       </Dialog>

--- a/ProjectCode/server/main.py
+++ b/ProjectCode/server/main.py
@@ -1,12 +1,15 @@
 from contextlib import asynccontextmanager
 from datetime import datetime
-from fastapi import FastAPI, Depends, HTTPException, status, Header, File, UploadFile, Form
+from fastapi import FastAPI, Depends, HTTPException, status, Header, File, UploadFile, Form, Request
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import StreamingResponse
 from sqlalchemy.orm import Session
 from sqlalchemy import func
 from typing import List, Optional
 from pydantic import BaseModel
 import os
+import json
+import asyncio
 import uuid
 import base64
 from pathlib import Path
@@ -364,6 +367,103 @@ def get_all_races(db: Session = Depends(get_db)):
             } for race in races
         ]
     }
+
+
+@app.get("/api/results/sync/races")
+def get_sync_race_patterns():
+    """Return the list of NYRR race patterns available for syncing."""
+    from fetch_historical_data import RACE_PATTERNS
+
+    patterns = []
+    for code, info in RACE_PATTERNS.items():
+        patterns.append({
+            "code": code,
+            "name_template": info["name_template"],
+            "distance": info["distance"],
+            "typical_month": info["typical_month"],
+        })
+
+    patterns.sort(key=lambda p: p["typical_month"])
+    return {"races": patterns}
+
+
+class NyrrSyncRequest(BaseModel):
+    years: List[int]
+    race_codes: Optional[List[str]] = None
+
+
+@app.post("/api/results/sync")
+async def sync_nyrr_data(request: Request):
+    """
+    Stream NYRR race data sync progress via SSE.
+    Auth is validated manually since StreamingResponse doesn't work with Depends().
+    """
+    # Manual auth check
+    firebase_uid = request.headers.get("X-Firebase-UID")
+    if not firebase_uid:
+        raise HTTPException(status_code=401, detail="Authentication required.")
+
+    db = next(get_db())
+    try:
+        member = db.query(Member).filter(Member.firebase_uid == firebase_uid).first()
+        if not member or member.status not in ('admin', 'committee'):
+            raise HTTPException(status_code=403, detail="Committee or admin access required.")
+    finally:
+        db.close()
+
+    # Parse request body
+    body = await request.json()
+    sync_req = NyrrSyncRequest(**body)
+
+    from fetch_historical_data import (
+        RACE_PATTERNS, generate_event_code, generate_race_config,
+        fetch_race_data, import_race_data
+    )
+
+    # Determine which races to sync
+    if sync_req.race_codes:
+        race_items = [(code, RACE_PATTERNS[code]) for code in sync_req.race_codes if code in RACE_PATTERNS]
+    else:
+        race_items = list(RACE_PATTERNS.items())
+
+    # Build list of (year, code, info) combos
+    combos = []
+    for year in sync_req.years:
+        for code, info in race_items:
+            combos.append((year, code, info))
+
+    async def event_stream():
+        yield f"data: {json.dumps({'type': 'start', 'total': len(combos)})}\n\n"
+
+        total_imported = 0
+        total_errors = 0
+
+        for i, (year, code, info) in enumerate(combos):
+            event_code = generate_event_code(code, year)
+            config = generate_race_config(code, info, year)
+            race_name = config["name"]
+
+            # Send fetching status
+            yield f"data: {json.dumps({'type': 'progress', 'index': i, 'race': race_name, 'status': 'fetching', 'event_code': event_code})}\n\n"
+
+            try:
+                df = await asyncio.to_thread(fetch_race_data, event_code)
+                if df is not None and len(df) > 0:
+                    count = await asyncio.to_thread(import_race_data, event_code, config, df)
+                    total_imported += count
+                    yield f"data: {json.dumps({'type': 'progress', 'index': i, 'race': race_name, 'status': 'imported', 'count': count})}\n\n"
+                else:
+                    yield f"data: {json.dumps({'type': 'progress', 'index': i, 'race': race_name, 'status': 'no_data', 'count': 0})}\n\n"
+            except Exception as e:
+                total_errors += 1
+                yield f"data: {json.dumps({'type': 'progress', 'index': i, 'race': race_name, 'status': 'error', 'error': str(e)})}\n\n"
+
+            # Delay between API calls
+            await asyncio.sleep(0.5)
+
+        yield f"data: {json.dumps({'type': 'complete', 'total_imported': total_imported, 'total_errors': total_errors})}\n\n"
+
+    return StreamingResponse(event_stream(), media_type="text/event-stream")
 
 
 @app.get("/api/results/member/{search_key}")
@@ -2794,7 +2894,7 @@ async def upload_image(
     file: UploadFile = File(...),
     current_admin: Member = Depends(get_current_committee_or_admin)
 ):
-    """Upload an image file (admin only). Returns base64 data URL for database storage."""
+    """Upload an image file to S3 (admin only). Returns the public S3 URL."""
     # Get file extension
     file_ext = Path(file.filename).suffix.lower() if file.filename else ''
 
@@ -2811,25 +2911,58 @@ async def upload_image(
             detail=f"File type not allowed. Allowed types: JPEG, PNG, GIF, WebP"
         )
 
-    # Validate file size (max 5MB)
-    max_size = 5 * 1024 * 1024  # 5MB
+    # Validate file size (max 20MB)
+    max_size = 20 * 1024 * 1024  # 20MB
     contents = await file.read()
     if len(contents) > max_size:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="File too large. Maximum size is 5MB."
+            detail="File too large. Maximum size is 20MB."
         )
 
     try:
-        # Convert to base64 data URL
-        base64_data = base64.b64encode(contents).decode('utf-8')
-        data_url = f"data:{mime_type};base64,{base64_data}"
+        # Resize/compress image to save S3 space
+        from PIL import Image
+        import io
 
-        return {"url": data_url}
+        img = Image.open(io.BytesIO(contents))
+
+        # Convert RGBA/P to RGB for JPEG output
+        if img.mode in ('RGBA', 'P'):
+            img = img.convert('RGB')
+
+        # Resize if larger than 1920px on the longest side
+        max_dimension = 1920
+        if max(img.size) > max_dimension:
+            img.thumbnail((max_dimension, max_dimension), Image.LANCZOS)
+
+        # Save as JPEG with quality 85
+        output = io.BytesIO()
+        img.save(output, format='JPEG', quality=85, optimize=True)
+        contents = output.getvalue()
+        mime_type = 'image/jpeg'
+        safe_ext = 'jpg'
+
+        # Upload to S3
+        s3_client = get_s3_client()
+        bucket, region = get_s3_config()
+        key = f"homepage/{uuid.uuid4().hex}.{safe_ext}"
+
+        s3_client.put_object(
+            Bucket=bucket,
+            Key=key,
+            Body=contents,
+            ContentType=mime_type
+        )
+
+        url = f"https://{bucket}.s3.{region}.amazonaws.com/{key}"
+        return {"url": url}
+    except HTTPException:
+        raise
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Failed to process image: {str(e)}"
+            detail=f"Failed to upload image: {str(e)}"
         )
     finally:
         await file.close()

--- a/ProjectCode/server/requirements.txt
+++ b/ProjectCode/server/requirements.txt
@@ -16,3 +16,4 @@ python-multipart
 apscheduler
 python-dateutil
 boto3>=1.28.0
+Pillow>=10.0.0


### PR DESCRIPTION
## Summary
- Replace base64 image storage with S3 upload + Pillow server-side compression (max 1920px, JPEG quality 85) to fix upload failures on deployed server and save storage
- Increase image upload size limit from 5MB to 20MB (images compressed server-side anyway)
- Add SSE streaming endpoint for NYRR race data sync with progress reporting
- Add records sync UI and API client for admin race data management

## Test plan
- [ ] Upload a homepage section image and verify it uploads to S3 successfully
- [ ] Verify uploaded images are compressed (check S3 file sizes)
- [ ] Test NYRR race sync from the records page (admin only)
- [ ] Verify existing image position editing still works
- [ ] Confirm Pillow is installed on production (`pip install Pillow>=10.0.0`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)