### PR TITLE
Fix gender filter bug in member race results

### DIFF
--- a/ProjectCode/server/main.py
+++ b/ProjectCode/server/main.py
@@ -486,7 +486,10 @@ def get_member_race_results(
     ).order_by(Results.race_time.desc()).all()
 
     # If gender and birth_year provided, filter by matching gender and calculated birth year
+    # Map standard gender codes to NYRR codes (NYRR uses "M"/"W" instead of "M"/"F")
+    gender_map = {"F": "W", "W": "W", "M": "M"}
     if gender and birth_year:
+        mapped_gender = gender_map.get(gender.upper(), gender.upper())
         filtered_results = []
         for result in results:
             if result.race_time and result.gender_age:
@@ -504,7 +507,7 @@ def get_member_race_results(
 
                     # Match if gender matches AND calculated birth year is exact or +1 year
                     # (+1 tolerance because if birthday hasn't passed yet, age is 1 less → calc birth year is 1 more)
-                    if result_gender == gender and calculated_birth_year in (birth_year, birth_year + 1):
+                    if result_gender == mapped_gender and calculated_birth_year in (birth_year, birth_year + 1):
                         filtered_results.append(result)
         results = filtered_results
 


### PR DESCRIPTION
## Summary
- Fix gender filter in `/api/results/member/{search_key}` endpoint to correctly map standard gender code "F" to NYRR's "W" code
- Previously, querying with `gender=F` returned empty results for female runners because NYRR data uses "W" for women

## Test plan
- [x] Verified querying `Jingxuan Zhang` with `gender=F&birth_year=1994` now returns 14 race results
- [ ] Verify male runner queries still work correctly with `gender=M`

🤖 Generated with [Claude Code](https://claude.com/claude-code)