### PR TITLE
Add shop demo video modal

### DIFF
--- a/ProjectCode/client/src/components/NavBar.js
+++ b/ProjectCode/client/src/components/NavBar.js
@@ -1,8 +1,11 @@
-import { AppBar, Badge, Box, Button, Container, IconButton, SvgIcon, Switch, Toolbar, Tooltip, useMediaQuery, useTheme } from '@mui/material';
+import { AppBar, Badge, Box, Button, Container, Dialog, DialogContent, DialogTitle, IconButton, Stack, SvgIcon, Switch, Toolbar, Tooltip, Typography, useMediaQuery, useTheme } from '@mui/material';
 import AdminPanelSettingsIcon from '@mui/icons-material/AdminPanelSettings';
 import PersonIcon from '@mui/icons-material/Person';
 import InstagramIcon from '@mui/icons-material/Instagram';
 import ShoppingBagIcon from '@mui/icons-material/ShoppingBag';
+import StorefrontIcon from '@mui/icons-material/Storefront';
+import PlayCircleOutlineIcon from '@mui/icons-material/PlayCircleOutline';
+import CloseIcon from '@mui/icons-material/Close';
 import { NavLink, useNavigate } from 'react-router-dom';
 import { useEffect, useState } from 'react';
 import { useAdmin, useAuth, useSocialLinks } from '../context';
@@ -32,9 +35,33 @@ export default function NavBar() {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
   const [pendingCount, setPendingCount] = useState(0);
+  const [shopDialogOpen, setShopDialogOpen] = useState(false);
+  const [demoVideoOpen, setDemoVideoOpen] = useState(false);
 
   // Helper to check if a social link is configured
   const hasLink = (link) => link && link.trim() !== '' && link !== '#';
+
+  const handleShopClick = (e) => {
+    if (!hasLink(socialLinks.shop) && !hasLink(socialLinks.shopDemoVideo)) {
+      // Empty: fall back to old behavior (admin can configure)
+      handleSocialClick(socialLinks.shop, e);
+      return;
+    }
+    e.preventDefault();
+    setShopDialogOpen(true);
+  };
+
+  const handleGoToStore = () => {
+    if (hasLink(socialLinks.shop)) {
+      window.open(socialLinks.shop, '_blank', 'noopener,noreferrer');
+    }
+    setShopDialogOpen(false);
+  };
+
+  const handleWatchDemo = () => {
+    setShopDialogOpen(false);
+    setDemoVideoOpen(true);
+  };
 
   // Handle social link click - navigate to settings if admin mode enabled and link empty
   const handleSocialClick = (link, event) => {
@@ -166,15 +193,13 @@ export default function NavBar() {
                     </IconButton>
                   </span>
                 </Tooltip>
-                <Tooltip title={hasLink(socialLinks.shop) ? "Shop" : (adminModeEnabled ? "Shop (Click to configure)" : "Shop (Not configured)")}>
+                <Tooltip title={hasLink(socialLinks.shop) || hasLink(socialLinks.shopDemoVideo) ? "Shop / 商店" : (adminModeEnabled ? "Shop (Click to configure)" : "Shop (Not configured)")}>
                   <span>
                     <IconButton
-                      href={hasLink(socialLinks.shop) ? socialLinks.shop : '#'}
-                      target={hasLink(socialLinks.shop) ? "_blank" : undefined}
-                      onClick={(e) => handleSocialClick(socialLinks.shop, e)}
-                      disabled={!hasLink(socialLinks.shop) && !adminModeEnabled}
+                      onClick={handleShopClick}
+                      disabled={!hasLink(socialLinks.shop) && !hasLink(socialLinks.shopDemoVideo) && !adminModeEnabled}
                       sx={{
-                        color: hasLink(socialLinks.shop) ? 'rgba(255, 255, 255, 0.8)' : 'rgba(255, 255, 255, 0.3)',
+                        color: (hasLink(socialLinks.shop) || hasLink(socialLinks.shopDemoVideo)) ? 'rgba(255, 255, 255, 0.8)' : 'rgba(255, 255, 255, 0.3)',
                         padding: { xs: '4px', sm: '6px' },
                         '&:hover': { color: 'white', backgroundColor: 'rgba(255, 255, 255, 0.1)' },
                         '&.Mui-disabled': { color: 'rgba(255, 255, 255, 0.3)' }
@@ -289,6 +314,108 @@ export default function NavBar() {
           </Toolbar>
         </Container>
       </AppBar>
+
+      {/* Shop options dialog: Store vs Demo Video */}
+      <Dialog
+        open={shopDialogOpen}
+        onClose={() => setShopDialogOpen(false)}
+        maxWidth="sm"
+        fullWidth
+        PaperProps={{ sx: { borderRadius: 3 } }}
+      >
+        <DialogTitle sx={{ textAlign: 'center', fontWeight: 700, pb: 1 }}>
+          Shop / 商店
+        </DialogTitle>
+        <DialogContent sx={{ pb: 4 }}>
+          <Typography variant="body2" sx={{ textAlign: 'center', color: 'text.secondary', mb: 3 }}>
+            How would you like to start? / 您想如何开始？
+          </Typography>
+          <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} justifyContent="center">
+            <Button
+              onClick={handleGoToStore}
+              disabled={!hasLink(socialLinks.shop)}
+              variant="contained"
+              startIcon={<StorefrontIcon />}
+              sx={{
+                flex: 1,
+                py: 2,
+                borderRadius: 2,
+                textTransform: 'none',
+                fontSize: '1rem',
+                backgroundColor: '#e98f4bff',
+                '&:hover': { backgroundColor: '#d97f3bff' },
+              }}
+            >
+              <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+                <span>Go to Store</span>
+                <span style={{ fontSize: '0.8rem', opacity: 0.9 }}>直接进入商店</span>
+              </Box>
+            </Button>
+            <Button
+              onClick={handleWatchDemo}
+              disabled={!hasLink(socialLinks.shopDemoVideo)}
+              variant="outlined"
+              startIcon={<PlayCircleOutlineIcon />}
+              sx={{
+                flex: 1,
+                py: 2,
+                borderRadius: 2,
+                textTransform: 'none',
+                fontSize: '1rem',
+                borderColor: '#e98f4bff',
+                color: '#e98f4bff',
+                '&:hover': { borderColor: '#d97f3bff', backgroundColor: 'rgba(233, 143, 75, 0.08)' },
+              }}
+            >
+              <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+                <span>Watch Demo</span>
+                <span style={{ fontSize: '0.8rem', opacity: 0.9 }}>个性化设计演示</span>
+              </Box>
+            </Button>
+          </Stack>
+        </DialogContent>
+      </Dialog>
+
+      {/* Demo video player dialog */}
+      <Dialog
+        open={demoVideoOpen}
+        onClose={() => setDemoVideoOpen(false)}
+        maxWidth="md"
+        fullWidth
+        PaperProps={{ sx: { borderRadius: 3, backgroundColor: '#e98f4bff', overflow: 'hidden' } }}
+      >
+        <DialogTitle sx={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          color: 'white',
+          fontWeight: 700,
+          backgroundColor: '#e98f4bff',
+          py: 1.25,
+        }}>
+          <span>Personalized Design Demo / 个性化设计演示</span>
+          <IconButton
+            onClick={() => setDemoVideoOpen(false)}
+            sx={{
+              color: 'white',
+              '&:hover': { backgroundColor: 'rgba(255, 255, 255, 0.15)' },
+            }}
+          >
+            <CloseIcon />
+          </IconButton>
+        </DialogTitle>
+        <DialogContent sx={{ p: 0, backgroundColor: '#e98f4bff' }}>
+          {hasLink(socialLinks.shopDemoVideo) && (
+            <Box
+              component="video"
+              src={socialLinks.shopDemoVideo}
+              controls
+              autoPlay
+              sx={{ width: '100%', display: 'block', maxHeight: '75vh', backgroundColor: '#e98f4bff' }}
+            />
+          )}
+        </DialogContent>
+      </Dialog>
     </Box>
   );
 }

--- a/ProjectCode/client/src/context/SocialLinksContext.js
+++ b/ProjectCode/client/src/context/SocialLinksContext.js
@@ -8,7 +8,8 @@ const DEFAULT_SOCIAL_LINKS = {
   instagram: 'https://www.instagram.com/newbeerunningclub/',
   xiaohongshu: 'https://xhslink.com/m/8znk8WTxhjd',
   heylo: 'https://www.heylo.com/g/b7bf1310-ca40-4d4d-9da5-2b7f4f3c197e',
-  shop: ''
+  shop: '',
+  shopDemoVideo: ''
 };
 
 export function useSocialLinks() {
@@ -31,7 +32,8 @@ export function SocialLinksProvider({ children }) {
         instagram: links.instagram || DEFAULT_SOCIAL_LINKS.instagram,
         xiaohongshu: links.xiaohongshu || DEFAULT_SOCIAL_LINKS.xiaohongshu,
         heylo: links.heylo || DEFAULT_SOCIAL_LINKS.heylo,
-        shop: links.shop || DEFAULT_SOCIAL_LINKS.shop
+        shop: links.shop || DEFAULT_SOCIAL_LINKS.shop,
+        shopDemoVideo: links.shop_demo_video || DEFAULT_SOCIAL_LINKS.shopDemoVideo
       });
     } catch (err) {
       console.error('Error fetching social links:', err);

--- a/ProjectCode/client/src/pages/AdminPanelPage.js
+++ b/ProjectCode/client/src/pages/AdminPanelPage.js
@@ -182,7 +182,8 @@ export default function AdminPanelPage() {
     instagram: '',
     xiaohongshu: '',
     heylo: '',
-    shop: ''
+    shop: '',
+    shopDemoVideo: ''
   });
   const [joinRequirementsForm, setJoinRequirementsForm] = useState({
     minEnglishWords: '120',
@@ -694,12 +695,13 @@ export default function AdminPanelPage() {
     if (!currentUser?.uid) return;
     try {
       const settings = await getSettingsByCategory('social', currentUser.uid);
-      const formData = { instagram: '', xiaohongshu: '', heylo: '', shop: '' };
+      const formData = { instagram: '', xiaohongshu: '', heylo: '', shop: '', shopDemoVideo: '' };
       settings.forEach(setting => {
         if (setting.key === 'social_instagram') formData.instagram = setting.value || '';
         if (setting.key === 'social_xiaohongshu') formData.xiaohongshu = setting.value || '';
         if (setting.key === 'social_heylo') formData.heylo = setting.value || '';
         if (setting.key === 'social_shop') formData.shop = setting.value || '';
+        if (setting.key === 'social_shop_demo_video') formData.shopDemoVideo = setting.value || '';
       });
       setSocialLinksForm(formData);
     } catch (err) {
@@ -732,6 +734,7 @@ export default function AdminPanelPage() {
         updateSetting('social_xiaohongshu', { value: socialLinksForm.xiaohongshu }, currentUser.uid),
         updateSetting('social_heylo', { value: socialLinksForm.heylo }, currentUser.uid),
         updateSetting('social_shop', { value: socialLinksForm.shop }, currentUser.uid),
+        updateSetting('social_shop_demo_video', { value: socialLinksForm.shopDemoVideo }, currentUser.uid),
         updateSetting('join_min_english_words', { value: joinRequirementsForm.minEnglishWords }, currentUser.uid),
         updateSetting('join_min_chinese_chars', { value: joinRequirementsForm.minChineseChars }, currentUser.uid),
       ]);
@@ -1621,6 +1624,16 @@ export default function AdminPanelPage() {
                   onChange={(e) => setSocialLinksForm(prev => ({ ...prev, shop: e.target.value }))}
                   placeholder="https://shop.newbeerunningclub.org/"
                   helperText="Leave empty to disable / 留空以禁用"
+                />
+              </Grid>
+              <Grid item xs={12} md={6}>
+                <TextField
+                  fullWidth
+                  label="Shop Demo Video URL / 商店演示视频链接"
+                  value={socialLinksForm.shopDemoVideo}
+                  onChange={(e) => setSocialLinksForm(prev => ({ ...prev, shopDemoVideo: e.target.value }))}
+                  placeholder="https://your-bucket.s3.amazonaws.com/shop-demo.mp4"
+                  helperText="Direct video URL (S3 or other host). Shown when users click the shop icon. / 视频直链，点击商店图标时显示"
                 />
               </Grid>
             </Grid>

--- a/ProjectCode/server/models.py
+++ b/ProjectCode/server/models.py
@@ -911,6 +911,7 @@ class SocialLinksResponse(BaseModel):
     xiaohongshu: Optional[str] = None
     heylo: Optional[str] = None
     shop: Optional[str] = None
+    shop_demo_video: Optional[str] = None
 
 
 # ========== Event Group Schemas (iOS-style folder grouping) ==========

--- a/ProjectCode/server/routes/settings.py
+++ b/ProjectCode/server/routes/settings.py
@@ -43,6 +43,13 @@ def seed_social_links(db: Session):
             "label_en": "Shop",
             "label_cn": "商店",
             "category": "social"
+        },
+        {
+            "key": "social_shop_demo_video",
+            "value": "",
+            "label_en": "Shop Demo Video",
+            "label_cn": "商店演示视频",
+            "category": "social"
         }
     ]
 
@@ -96,6 +103,8 @@ def get_social_links(db: Session = Depends(get_db)):
             result.heylo = setting.value
         elif setting.key == "social_shop":
             result.shop = setting.value
+        elif setting.key == "social_shop_demo_video":
+            result.shop_demo_video = setting.value
 
     return result
 


### PR DESCRIPTION
## Summary
- Clicking the shopping bag icon now opens a centered dialog offering "Go to Store" or "Watch Demo".
- "Watch Demo" plays the personalized design demo video inline; player frame uses the site's orange theme.
- Adds a `social_shop_demo_video` setting (configurable from the admin panel) for the video URL.

## Test plan
- [x] Local E2E: backend serves new `shop_demo_video` field; frontend renders both buttons; video autoplays from S3.
- [ ] In prod, admin sets the demo video URL under Admin → Settings → Social Media Links.
- [ ] Click shopping bag icon → both options appear and behave correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)