### PR TITLE
Nav: inline Chinese labels + hide Training; weekly NYRR sync worker

### DIFF
--- a/ProjectCode/client/src/components/NavBar.js
+++ b/ProjectCode/client/src/components/NavBar.js
@@ -26,14 +26,15 @@ const HeyloIcon = (props) => (
   </SvgIcon>
 );
 
-// Primary navigation links shown as pills in the top bar (and in the mobile drawer)
+// Primary navigation links shown as pills in the top bar (and in the mobile drawer).
+// Training ('/training', 与我们训练) is intentionally hidden for now — the page
+// still exists at its URL; re-add an entry here to bring it back.
 export const navLinks = [
   { en: 'Home', cn: '主页', path: '/' },
   { en: 'About Us', cn: '关于我们', path: '/about' },
   { en: 'Upcoming', cn: '即将到来', path: '/calendar' },
   { en: 'Memories', cn: '活动回忆', path: '/highlights' },
   { en: 'Credits/Records', cn: '俱乐部积分', path: '/records' },
-  { en: 'Training', cn: '与我们训练', path: '/training' },
   { en: 'Sponsors', cn: '赞助者', path: '/sponsors' },
 ];
 
@@ -202,9 +203,6 @@ export default function NavBar() {
                           fontSize: '0.6875rem',
                           fontWeight: 400,
                           color: isActive ? 'rgba(255,255,255,0.85)' : MUTED,
-                          // Inline Chinese labels need ~1800px of bar width — only show on very wide screens
-                          display: 'none',
-                          '@media (min-width:1800px)': { display: 'inline' },
                         }}
                       >
                         {link.cn}

--- a/ProjectCode/client/src/components/NavBar.test.js
+++ b/ProjectCode/client/src/components/NavBar.test.js
@@ -77,7 +77,7 @@ describe('desktop nav pills', () => {
   test('marks the pill matching the current route as active', () => {
     renderNavBar('/about');
     expect(screen.getByRole('link', { name: /^About Us/ })).toHaveAttribute('aria-current', 'page');
-    expect(screen.getByRole('link', { name: /^Training/ })).not.toHaveAttribute('aria-current');
+    expect(screen.getByRole('link', { name: /^Sponsors/ })).not.toHaveAttribute('aria-current');
   });
 
   test('shows the short Join label below the xl breakpoint', () => {

--- a/ProjectCode/client/src/pages/HomePage.js
+++ b/ProjectCode/client/src/pages/HomePage.js
@@ -81,8 +81,9 @@ const fallbackSections = [
   { id: 2, title_en: 'Memories', title_cn: '回忆', link_path: '/highlights', image_url: '/Highlights.png' },
   { id: 3, title_en: 'Upcoming', title_cn: '即将到来', link_path: '/calendar', image_url: null },
   { id: 4, title_en: 'Club Credits/Records', title_cn: '俱乐部积分/记录', link_path: '/records', image_url: null },
-  { id: 5, title_en: 'Join NewBee', title_cn: '加入新蜂', link_path: '/join', image_url: null },
-  { id: 6, title_en: 'Training With Us', title_cn: '与我们训练', link_path: '/training', image_url: null }
+  { id: 5, title_en: 'Join NewBee', title_cn: '加入新蜂', link_path: '/join', image_url: null }
+  // Training With Us ('/training') hidden for now — restore an entry here (and
+  // reactivate the DB section in admin mode) to bring it back
 ];
 
 const MONTHS = ['JAN', 'FEB', 'MAR', 'APR', 'MAY', 'JUN', 'JUL', 'AUG', 'SEP', 'OCT', 'NOV', 'DEC'];

--- a/ProjectCode/client/src/pages/HomePage.test.js
+++ b/ProjectCode/client/src/pages/HomePage.test.js
@@ -287,7 +287,7 @@ describe('fallbacks', () => {
 
     expect(screen.getByRole('heading', { name: 'About Us' })).toBeInTheDocument();
     // Some titles also appear as fallback banner labels, so use getAllByText
-    ['Event Registration', 'Memories', 'Upcoming', 'Club Credits/Records', 'Join NewBee', 'Training With Us'].forEach(
+    ['Event Registration', 'Memories', 'Upcoming', 'Club Credits/Records', 'Join NewBee'].forEach(
       (title) => expect(screen.getAllByText(title).length).toBeGreaterThan(0)
     );
     // Fallback sections without an image show the placeholder

--- a/ProjectCode/server/scheduler.py
+++ b/ProjectCode/server/scheduler.py
@@ -353,6 +353,56 @@ def transition_past_events():
         logger.info(f"Past events transition complete. Transitioned {count} event(s).")
 
 
+def sync_nyrr_results():
+    """
+    Weekly job to sync NYRR race results for the current year.
+
+    Runs the same fetch/import pipeline as the admin "Sync NYRR Data"
+    button (routes/results.py /sync) across all known race patterns.
+    Scheduled after each weekend so Saturday/Sunday race results land
+    automatically. Unknown/renamed event codes yield no data and are
+    logged rather than raising.
+    """
+    import time as _time
+
+    logger.info("Starting weekly NYRR results sync job...")
+    try:
+        from fetch_historical_data import (
+            RACE_PATTERNS, generate_event_code, generate_race_config,
+            fetch_race_data, import_race_data,
+        )
+    except Exception as e:
+        logger.error(f"NYRR sync: failed to import fetch_historical_data: {e}")
+        return
+
+    year = date.today().year
+    total_imported = 0
+    total_errors = 0
+
+    for code, info in RACE_PATTERNS.items():
+        event_code = generate_event_code(code, year)
+        config = generate_race_config(code, info, year)
+        race_name = config["name"]
+        try:
+            df = fetch_race_data(event_code)
+            if df is not None and len(df) > 0:
+                count = import_race_data(event_code, config, df)
+                total_imported += count
+                logger.info(f"NYRR sync: {race_name} ({event_code}): imported {count} results")
+            else:
+                logger.info(f"NYRR sync: {race_name} ({event_code}): no data")
+        except Exception as e:
+            total_errors += 1
+            logger.error(f"NYRR sync: {race_name} ({event_code}): {e}")
+        # Be polite to the NYRR API between races
+        _time.sleep(0.5)
+
+    logger.info(
+        f"NYRR results sync complete: {total_imported} results imported, "
+        f"{total_errors} error(s)."
+    )
+
+
 def start_scheduler():
     """
     Start the APScheduler with configured jobs.
@@ -381,9 +431,22 @@ def start_scheduler():
         max_instances=1
     )
 
+    # Weekly NYRR results sync — Monday 4 AM UTC (Sunday night in New York),
+    # right after each race weekend. Replaces the old weekly_sync.sh crontab.
+    scheduler.add_job(
+        sync_nyrr_results,
+        CronTrigger(day_of_week='mon', hour=4, minute=0),
+        id='sync_nyrr_results',
+        replace_existing=True,
+        max_instances=1
+    )
+
     # Start the scheduler
     scheduler.start()
-    logger.info("Scheduler started - recurring events job (daily 2 AM), past events transition (weekly Mon 3 AM)")
+    logger.info(
+        "Scheduler started - recurring events job (daily 2 AM), past events "
+        "transition (weekly Mon 3 AM), NYRR results sync (weekly Mon 4 AM UTC)"
+    )
 
     # Run transition immediately on startup to catch any stale events
     transition_past_events()
@@ -414,6 +477,15 @@ def run_transition_job_now():
     """
     logger.info("Manually triggering past events transition...")
     transition_past_events()
+
+
+def run_nyrr_sync_now():
+    """
+    Manually trigger the weekly NYRR results sync job.
+    Useful for testing or administrative purposes.
+    """
+    logger.info("Manually triggering NYRR results sync...")
+    sync_nyrr_results()
 
 
 if __name__ == "__main__":

--- a/ProjectCode/server/tests/test_scheduler.py
+++ b/ProjectCode/server/tests/test_scheduler.py
@@ -8,6 +8,10 @@ from datetime import date, timedelta
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+import sys
+import time as time_mod
+import types
+
 import pytest
 from apscheduler.triggers.cron import CronTrigger
 from sqlalchemy.orm import sessionmaker
@@ -412,8 +416,8 @@ def test_start_scheduler_registers_jobs_and_runs_transition(monkeypatch):
 
     start_scheduler()
 
-    assert fake.add_job.call_count == 2
-    (recurring_call, transition_call) = fake.add_job.call_args_list
+    assert fake.add_job.call_count == 3
+    (recurring_call, transition_call, nyrr_call) = fake.add_job.call_args_list
 
     assert recurring_call.args[0] is scheduler_mod.generate_recurring_events
     assert recurring_call.kwargs['id'] == 'generate_recurring_events'
@@ -425,6 +429,13 @@ def test_start_scheduler_registers_jobs_and_runs_transition(monkeypatch):
     assert isinstance(transition_call.args[1], CronTrigger)
     assert "day_of_week='mon'" in str(transition_call.args[1])
     assert "hour='3'" in str(transition_call.args[1])
+
+    assert nyrr_call.args[0] is scheduler_mod.sync_nyrr_results
+    assert nyrr_call.kwargs['id'] == 'sync_nyrr_results'
+    assert nyrr_call.kwargs['max_instances'] == 1
+    assert isinstance(nyrr_call.args[1], CronTrigger)
+    assert "day_of_week='mon'" in str(nyrr_call.args[1])
+    assert "hour='4'" in str(nyrr_call.args[1])
 
     fake.start.assert_called_once()
     # Transition also runs once immediately on startup
@@ -473,4 +484,95 @@ def test_run_transition_job_now(monkeypatch):
     calls = []
     monkeypatch.setattr(scheduler_mod, 'transition_past_events', lambda: calls.append(True))
     run_transition_job_now()
+    assert calls == [True]
+
+
+# ---------------------------------------------------------------------------
+# weekly NYRR results sync job
+# ---------------------------------------------------------------------------
+
+def _fake_nyrr_module(fetch_impl, import_impl):
+    mod = types.ModuleType('fetch_historical_data')
+    mod.RACE_PATTERNS = {
+        'BKH': {'name_template': 'Brooklyn Half {year}', 'distance': 'Half Marathon', 'typical_month': 5},
+        'Q10K': {'name_template': 'Queens 10K {year}', 'distance': '10K', 'typical_month': 6},
+    }
+    mod.generate_event_code = lambda code, year: f'{code}-{year}'
+    mod.generate_race_config = lambda code, info, year: {
+        'name': info['name_template'].format(year=year), 'distance': info['distance'],
+    }
+    mod.fetch_race_data = fetch_impl
+    mod.import_race_data = import_impl
+    return mod
+
+
+def test_sync_nyrr_results_imports_all_races(monkeypatch):
+    imported = []
+    mod = _fake_nyrr_module(
+        fetch_impl=lambda ec: ['row1', 'row2'],
+        import_impl=lambda ec, cfg, df: imported.append((ec, cfg['name'])) or len(df),
+    )
+    monkeypatch.setitem(sys.modules, 'fetch_historical_data', mod)
+    monkeypatch.setattr(time_mod, 'sleep', lambda s: None)
+
+    scheduler_mod.sync_nyrr_results()
+
+    year = date.today().year
+    assert imported == [(f'BKH-{year}', f'Brooklyn Half {year}'), (f'Q10K-{year}', f'Queens 10K {year}')]
+
+
+def test_sync_nyrr_results_skips_races_without_data(monkeypatch):
+    imported = []
+    mod = _fake_nyrr_module(
+        fetch_impl=lambda ec: [] if ec.startswith('BKH') else None,
+        import_impl=lambda ec, cfg, df: imported.append(ec) or 0,
+    )
+    monkeypatch.setitem(sys.modules, 'fetch_historical_data', mod)
+    monkeypatch.setattr(time_mod, 'sleep', lambda s: None)
+
+    scheduler_mod.sync_nyrr_results()
+
+    assert imported == []  # empty df and None both skip import
+
+
+def test_sync_nyrr_results_continues_after_race_error(monkeypatch):
+    imported = []
+
+    def fetch(ec):
+        if ec.startswith('BKH'):
+            raise RuntimeError('nyrr down')
+        return ['row']
+
+    mod = _fake_nyrr_module(fetch, lambda ec, cfg, df: imported.append(ec) or 1)
+    monkeypatch.setitem(sys.modules, 'fetch_historical_data', mod)
+    monkeypatch.setattr(time_mod, 'sleep', lambda s: None)
+
+    scheduler_mod.sync_nyrr_results()
+
+    year = date.today().year
+    assert imported == [f'Q10K-{year}']  # BKH errored, Q10K still imported
+
+
+def test_sync_nyrr_results_counts_import_errors(monkeypatch):
+    def bad_import(ec, cfg, df):
+        raise RuntimeError('db write failed')
+
+    mod = _fake_nyrr_module(lambda ec: ['row'], bad_import)
+    monkeypatch.setitem(sys.modules, 'fetch_historical_data', mod)
+    monkeypatch.setattr(time_mod, 'sleep', lambda s: None)
+
+    # Should not raise despite every import failing
+    scheduler_mod.sync_nyrr_results()
+
+
+def test_sync_nyrr_results_handles_missing_module(monkeypatch):
+    monkeypatch.setitem(sys.modules, 'fetch_historical_data', None)
+    # Import failure logs and returns without raising
+    scheduler_mod.sync_nyrr_results()
+
+
+def test_run_nyrr_sync_now(monkeypatch):
+    calls = []
+    monkeypatch.setattr(scheduler_mod, 'sync_nyrr_results', lambda: calls.append(True))
+    scheduler_mod.run_nyrr_sync_now()
     assert calls == [True]


### PR DESCRIPTION
## Summary

- **Nav pills now show Chinese inline after English at all widths** (e.g. "About Us 关于我们"). Removing the Training pill frees the width that previously forced the labels to ≥1800px screens.
- **Training hidden from navigation** — the `/training` page still exists at its URL; restoring the `navLinks` entry brings it back. (The DB-driven "Training With Us" homepage section will be deactivated separately via its `is_active` flag.)
- **Weekly NYRR results sync moved into the app scheduler**: new APScheduler job runs Mon 04:00 UTC (≈ Sunday night NY, after each race weekend), executing the same fetch/import pipeline as the admin "Sync NYRR Data" button for all race patterns in the current year. Per-race failures log and continue. This replaces the standalone `weekly_sync.sh` crontab on the EC2 box, which should be disabled after deploy to avoid double-syncing.

## Tests
- Backend: 672 passed (6 new for the sync job; scheduler.py stays at 100%)
- Frontend: 975 passed (NavBar/HomePage assertions updated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)