### PR TITLE
NYRR sync worker: cover previous + current year

### DIFF
--- a/ProjectCode/server/scheduler.py
+++ b/ProjectCode/server/scheduler.py
@@ -375,27 +375,31 @@ def sync_nyrr_results():
         logger.error(f"NYRR sync: failed to import fetch_historical_data: {e}")
         return
 
-    year = date.today().year
+    # Current + previous year, matching the retired weekly_sync.sh: prior-year
+    # results get late corrections, and in January the current year is empty.
+    current_year = date.today().year
+    years = [current_year - 1, current_year]
     total_imported = 0
     total_errors = 0
 
-    for code, info in RACE_PATTERNS.items():
-        event_code = generate_event_code(code, year)
-        config = generate_race_config(code, info, year)
-        race_name = config["name"]
-        try:
-            df = fetch_race_data(event_code)
-            if df is not None and len(df) > 0:
-                count = import_race_data(event_code, config, df)
-                total_imported += count
-                logger.info(f"NYRR sync: {race_name} ({event_code}): imported {count} results")
-            else:
-                logger.info(f"NYRR sync: {race_name} ({event_code}): no data")
-        except Exception as e:
-            total_errors += 1
-            logger.error(f"NYRR sync: {race_name} ({event_code}): {e}")
-        # Be polite to the NYRR API between races
-        _time.sleep(0.5)
+    for year in years:
+        for code, info in RACE_PATTERNS.items():
+            event_code = generate_event_code(code, year)
+            config = generate_race_config(code, info, year)
+            race_name = config["name"]
+            try:
+                df = fetch_race_data(event_code)
+                if df is not None and len(df) > 0:
+                    count = import_race_data(event_code, config, df)
+                    total_imported += count
+                    logger.info(f"NYRR sync: {race_name} ({event_code}): imported {count} results")
+                else:
+                    logger.info(f"NYRR sync: {race_name} ({event_code}): no data")
+            except Exception as e:
+                total_errors += 1
+                logger.error(f"NYRR sync: {race_name} ({event_code}): {e}")
+            # Be polite to the NYRR API between races
+            _time.sleep(0.5)
 
     logger.info(
         f"NYRR results sync complete: {total_imported} results imported, "

--- a/ProjectCode/server/tests/test_scheduler.py
+++ b/ProjectCode/server/tests/test_scheduler.py
@@ -517,8 +517,14 @@ def test_sync_nyrr_results_imports_all_races(monkeypatch):
 
     scheduler_mod.sync_nyrr_results()
 
+    # Both previous and current year, all races (matches retired weekly_sync.sh)
     year = date.today().year
-    assert imported == [(f'BKH-{year}', f'Brooklyn Half {year}'), (f'Q10K-{year}', f'Queens 10K {year}')]
+    assert imported == [
+        (f'BKH-{year - 1}', f'Brooklyn Half {year - 1}'),
+        (f'Q10K-{year - 1}', f'Queens 10K {year - 1}'),
+        (f'BKH-{year}', f'Brooklyn Half {year}'),
+        (f'Q10K-{year}', f'Queens 10K {year}'),
+    ]
 
 
 def test_sync_nyrr_results_skips_races_without_data(monkeypatch):
@@ -550,7 +556,8 @@ def test_sync_nyrr_results_continues_after_race_error(monkeypatch):
     scheduler_mod.sync_nyrr_results()
 
     year = date.today().year
-    assert imported == [f'Q10K-{year}']  # BKH errored, Q10K still imported
+    # BKH errored both years, Q10K still imported for both
+    assert imported == [f'Q10K-{year - 1}', f'Q10K-{year}']
 
 
 def test_sync_nyrr_results_counts_import_errors(monkeypatch):


### PR DESCRIPTION
Follow-up to #68: the weekly sync job now covers the previous AND current year, matching the retired weekly_sync.sh (late prior-year corrections; January boundary when the current year is empty). Tests updated — 672 backend tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)