### PR TITLE
Add Venmo donation email sync to the weekly Gmail worker

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,6 +104,16 @@ python main.py                                    # Run on localhost:8000
 - `GET /api/results/women-records` - Top 10 women's times
 - `GET /api/results/all-races` - All race names
 
+### Race Record Submissions (X-Firebase-UID header)
+- `POST /api/race-submissions` - Member submits a PR from a non-NYRR race (creates the race: name/date/distance + time + proof URL + photo)
+- `GET /api/race-submissions/mine` - Member's own submissions (any status)
+- `PUT /api/race-submissions/{id}` - Edit own submission (record fields while pending/rejected; photo anytime; editing a rejected one resubmits)
+- `DELETE /api/race-submissions/{id}` - Withdraw own pending/rejected submission
+- `GET /api/race-submissions/pending` - Pending list w/ member info (committee/admin)
+- `PUT /api/race-submissions/{id}/review` - Approve/reject (committee/admin). Approval inserts a `results` row (name + gender_age from member) so the record appears on the member profile and the Records leaderboard
+- `PUT /api/race-photos` - Attach/replace member's photo on own synced race result
+- `GET /api/race-photos/mine` - Member's race photos keyed by result_id
+
 ### Donation Ledger (committee/admin, X-Firebase-UID header)
 - `GET /api/donors/ledger` - All donations (any status) + stats + Gmail sync health
 - `POST /api/donors/donations/{id}/approve` - Publish a pending Gmail-imported donation
@@ -112,9 +122,11 @@ python main.py                                    # Run on localhost:8000
 - `GET /api/donors/tax-report?start_date&end_date&format=csv|pdf` - Tax file export
 
 Weekly Gmail sync: APScheduler job `sync_zelle_donations` (Mon 4:30 AM UTC) reads
-Chase Zelle emails via IMAP (`sync_zelle_donations.py`, Gmail label
-"NewBee Finance/Chase") and inserts donations as `status='pending'` for review
-in the Sponsors page admin ledger tab. Public donor endpoints only return
+Chase Zelle emails (Gmail label "NewBee Finance/Chase") and Venmo payment
+emails (label "NewBee Finance/Venmo") via IMAP (`sync_zelle_donations.py`) and
+inserts donations as `status='pending'` for review in the Sponsors page admin
+ledger tab. Venmo dedup uses the transaction id from the "See transaction"
+link (falls back to the email Message-ID). Public donor endpoints only return
 `status='confirmed'` rows.
 
 ## Coding Conventions

--- a/ProjectCode/client/src/components/DonationLedger.js
+++ b/ProjectCode/client/src/components/DonationLedger.js
@@ -63,7 +63,16 @@ const formatDate = (dateStr) => {
   }
 };
 
-const isGmailSourced = (donation) => (donation.source || '').toLowerCase().includes('zelle');
+// Auto-imported donations carry the source email excerpt; manual ones don't
+const isGmailSourced = (donation) => Boolean(donation.email_excerpt);
+
+// Provider label for Gmail-imported donations ('Zelle', 'Venmo', ...)
+const gmailProvider = (donation) => {
+  const src = (donation.source || '').toLowerCase();
+  if (src.includes('venmo')) return 'Venmo';
+  if (src.includes('zelle')) return 'Zelle';
+  return null;
+};
 
 function StatTile({ label, value, sub, highlight, alert }) {
   return (
@@ -90,10 +99,11 @@ function StatTile({ label, value, sub, highlight, alert }) {
 
 function SourceChip({ donation }) {
   const gmail = isGmailSourced(donation);
+  const provider = gmailProvider(donation);
   return (
     <Chip
       size="small"
-      label={gmail ? '✉ Gmail · Zelle' : 'Manual 手动'}
+      label={gmail ? `✉ Gmail${provider ? ` · ${provider}` : ''}` : 'Manual 手动'}
       sx={{
         fontSize: '0.6875rem',
         fontWeight: 700,

--- a/ProjectCode/client/src/components/DonationLedger.test.js
+++ b/ProjectCode/client/src/components/DonationLedger.test.js
@@ -74,6 +74,7 @@ const ledgerData = {
       source: 'Zelle (Spam Sender)',
       receipt_confirmed: false,
       status: 'dismissed',
+      email_excerpt: 'Zelle payment received — Spam Sender sent you $5.00',
     },
   ],
   stats: {
@@ -136,6 +137,49 @@ test('pending donations sort to the top and show source chips', async () => {
   expect(screen.getAllByText('✉ Gmail · Zelle').length).toBe(3);
   // Filter chip + one manual source chip
   expect(screen.getAllByText('Manual 手动').length).toBe(2);
+});
+
+test('Venmo-imported donations show a Venmo source chip', async () => {
+  getDonationLedger.mockResolvedValue({
+    ...ledgerData,
+    donations: [{
+      donation_id: 20,
+      donor_id: 'IND_20',
+      name: 'Xiao Yang',
+      donor_type: 'individual',
+      amount: '15.00',
+      donation_date: `${currentYear}-07-05`,
+      source: 'Venmo (Xiao Yang)',
+      receipt_confirmed: true,
+      status: 'pending',
+      email_excerpt: 'Venmo payment received — Xiao Yang sent you $15.00 · Memo: 加油',
+    }],
+  });
+  render(<DonationLedger />);
+  expect(await screen.findByText('Xiao Yang')).toBeInTheDocument();
+  expect(screen.getByText('✉ Gmail · Venmo')).toBeInTheDocument();
+});
+
+test('manual entries with a payment-app source name still show as Manual', async () => {
+  getDonationLedger.mockResolvedValue({
+    ...ledgerData,
+    donations: [{
+      donation_id: 21,
+      donor_id: 'IND_21',
+      name: 'Wei Zhang',
+      donor_type: 'individual',
+      amount: '120.00',
+      donation_date: `${currentYear}-05-10`,
+      source: 'Venmo',           // manually entered, no email excerpt
+      receipt_confirmed: true,
+      status: 'confirmed',
+    }],
+  });
+  render(<DonationLedger />);
+  await screen.findByText('Wei Zhang');
+  // Filter chip + the row's source chip
+  expect(screen.getAllByText('Manual 手动').length).toBe(2);
+  expect(screen.queryByText(/✉ Gmail/)).not.toBeInTheDocument();
 });
 
 test('thank-you column shows sent state and disabled placeholder', async () => {

--- a/ProjectCode/server/sync_zelle_donations.py
+++ b/ProjectCode/server/sync_zelle_donations.py
@@ -42,6 +42,7 @@ GMAIL_APP_PASSWORD = os.getenv("GMAIL_APP_PASSWORD")
 IMAP_SERVER = "imap.gmail.com"
 IMAP_PORT = 993
 IMAP_FOLDER = '"NewBee Finance/Chase"'
+VENMO_FOLDER = '"NewBee Finance/Venmo"'
 
 
 def connect_to_gmail():
@@ -91,6 +92,33 @@ def search_zelle_emails(mail, since_date=None):
     return email_ids
 
 
+def search_venmo_emails(mail, since_date=None):
+    """
+    Search for incoming Venmo payment notification emails.
+
+    Args:
+        mail: IMAP connection (with the Venmo folder selected)
+        since_date: Optional date string (DD-Mon-YYYY) to filter emails
+
+    Returns:
+        List of email IDs
+    """
+    criteria = '(FROM "venmo@venmo.com" SUBJECT "paid you")'
+    if since_date:
+        criteria = f'(FROM "venmo@venmo.com" SUBJECT "paid you" SINCE {since_date})'
+
+    print(f"Searching emails with criteria: {criteria}")
+    status, data = mail.search(None, criteria)
+
+    if status != "OK":
+        print(f"Search failed with status: {status}")
+        return []
+
+    email_ids = data[0].split()
+    print(f"Found {len(email_ids)} Venmo email(s).")
+    return email_ids
+
+
 def strip_html(html_text):
     """Remove HTML tags and decode entities from text."""
     # Remove style/script blocks
@@ -110,19 +138,8 @@ def strip_html(html_text):
     return text.strip()
 
 
-def parse_zelle_email(raw_email):
-    """
-    Parse a raw Chase Zelle notification email into structured data.
-
-    Args:
-        raw_email: Raw email bytes
-
-    Returns:
-        Dictionary with parsed fields, or None if parsing fails
-    """
-    msg = email.message_from_bytes(raw_email)
-
-    # Get email body
+def _get_email_body(msg):
+    """Extract the decoded body from an email message, preferring HTML."""
     body = ""
     if msg.is_multipart():
         for part in msg.walk():
@@ -136,8 +153,44 @@ def parse_zelle_email(raw_email):
                 body = part.get_payload(decode=True).decode(charset, errors="replace")
     else:
         charset = msg.get_content_charset() or "utf-8"
-        body = msg.get_payload(decode=True).decode(charset, errors="replace")
+        payload = msg.get_payload(decode=True)
+        if payload is not None:
+            body = payload.decode(charset, errors="replace")
+    return body
 
+
+def _decode_subject(msg):
+    """Decode a possibly RFC 2047-encoded Subject header to a string."""
+    decoded = ""
+    for value, charset in decode_header(msg.get("Subject", "")):
+        if isinstance(value, bytes):
+            decoded += value.decode(charset or "utf-8", errors="replace")
+        else:
+            decoded += value
+    return decoded
+
+
+def _date_from_header(msg):
+    """Donation date from the email Date header, today as a last resort."""
+    try:
+        return email.utils.parsedate_to_datetime(msg.get("Date", "")).date()
+    except Exception:
+        return datetime.now().date()
+
+
+def parse_zelle_email(raw_email):
+    """
+    Parse a raw Chase Zelle notification email into structured data.
+
+    Args:
+        raw_email: Raw email bytes
+
+    Returns:
+        Dictionary with parsed fields, or None if parsing fails
+    """
+    msg = email.message_from_bytes(raw_email)
+
+    body = _get_email_body(msg)
     if not body:
         return None
 
@@ -207,6 +260,80 @@ def parse_zelle_email(raw_email):
     }
 
 
+def _extract_venmo_memo(text):
+    """
+    Pull the payment note from a stripped Venmo email body: the lines between
+    "{NAME} paid you" / the amount and the "See transaction" button.
+    """
+    lines = [line.strip() for line in text.split('\n')]
+    start = None
+    for i, line in enumerate(lines):
+        if 'paid you' in line.lower():
+            start = i + 1
+            break
+    if start is None:
+        return None
+
+    stop_markers = ('see transaction', 'money credited', 'payment id',
+                    'transfer', 'for any issues')
+    memo_lines = []
+    for line in lines[start:]:
+        lowered = line.lower()
+        if any(lowered.startswith(marker) for marker in stop_markers):
+            break
+        # Skip blanks and standalone amount fragments like "$15.00" / "$15 00"
+        if not line or re.fullmatch(r'[\$\d.,\s]+', line):
+            continue
+        memo_lines.append(line)
+
+    memo = ' '.join(memo_lines).strip()
+    return memo or None
+
+
+def parse_venmo_email(raw_email):
+    """
+    Parse a raw Venmo payment notification email into structured data.
+
+    Venmo puts the payer and amount in the subject ("Xiao Yang paid you
+    $15.00") and the payment note in the body. Dedup uses the transaction id
+    from the "See transaction" link, falling back to the email Message-ID.
+
+    Args:
+        raw_email: Raw email bytes
+
+    Returns:
+        Dictionary with parsed fields, or None if parsing fails
+    """
+    msg = email.message_from_bytes(raw_email)
+
+    subject = _decode_subject(msg)
+    subject_match = re.search(r'(.+?)\s+paid\s+you\s+\$([\d,]+\.?\d*)', subject)
+    if not subject_match:
+        return None
+    sender_name = subject_match.group(1).strip()
+    amount = Decimal(subject_match.group(2).replace(",", ""))
+
+    body = _get_email_body(msg)
+    memo = _extract_venmo_memo(strip_html(body)) if body else None
+
+    # Transaction id from the "See transaction" link, else the Message-ID
+    txn_match = re.search(
+        r'venmo\.com/(?:story|payment)s?/([A-Za-z0-9_\-]+)', body or ''
+    )
+    if txn_match:
+        transaction_number = txn_match.group(1)
+    else:
+        transaction_number = (msg.get("Message-ID") or "").strip().strip("<>") or None
+
+    return {
+        "sender_name": sender_name,
+        "amount": amount,
+        "donation_date": _date_from_header(msg),
+        "transaction_number": transaction_number,
+        "memo": memo,
+    }
+
+
 def is_duplicate(session, transaction_number):
     """
     Check if a donation with this transaction number already exists.
@@ -228,10 +355,10 @@ def is_duplicate(session, transaction_number):
     return existing is not None
 
 
-def build_email_excerpt(parsed_data):
-    """Build a human-readable summary of the source Zelle email."""
+def build_email_excerpt(parsed_data, provider="Zelle"):
+    """Build a human-readable summary of the source payment email."""
     parts = [
-        f"Zelle payment received — {parsed_data['sender_name']} sent you "
+        f"{provider} payment received — {parsed_data['sender_name']} sent you "
         f"${parsed_data['amount']}"
     ]
     if parsed_data["donation_date"]:
@@ -243,15 +370,17 @@ def build_email_excerpt(parsed_data):
     return " · ".join(parts)
 
 
-def build_donor_record(parsed_data, status="pending"):
+def build_donor_record(parsed_data, status="pending", provider="Zelle"):
     """
     Build a Donor table row dict from parsed email data.
 
     Args:
-        parsed_data: Dict from parse_zelle_email()
+        parsed_data: Dict from parse_zelle_email() / parse_venmo_email()
         status: Ledger status for the new record — 'pending' for the weekly
             sync (committee reviews in the ledger before it goes public),
             'confirmed' for trusted backfills.
+        provider: Payment provider name ('Zelle' or 'Venmo'), used in the
+            source/notes/excerpt strings.
 
     Returns:
         Dict ready for Donor(**record) insertion
@@ -265,18 +394,18 @@ def build_donor_record(parsed_data, status="pending"):
         "donor_type": "individual",
         "amount": parsed_data["amount"],
         "donation_date": parsed_data["donation_date"],
-        "source": f"Zelle ({name})",
+        "source": f"{provider} ({name})",
         "notes": (
-            f"Zelle Transaction #{parsed_data['transaction_number']}"
+            f"{provider} Transaction #{parsed_data['transaction_number']}"
             if parsed_data["transaction_number"]
-            else "Zelle (no transaction #)"
+            else f"{provider} (no transaction #)"
         ),
         "message": parsed_data["memo"],
         "donation_event": "General Support",
         "receipt_confirmed": True,
         "quantity": 1,
         "status": status,
-        "email_excerpt": build_email_excerpt(parsed_data),
+        "email_excerpt": build_email_excerpt(parsed_data, provider=provider),
     }
     return record
 
@@ -311,9 +440,82 @@ def record_sync_status(stats):
         session.close()
 
 
+def _process_provider_emails(mail, email_ids, parser, provider, session, stats,
+                             dry_run, status):
+    """
+    Fetch, parse, dedup and insert one provider's emails, updating stats.
+
+    Args:
+        mail: IMAP connection with the provider's folder selected
+        email_ids: IMAP message ids to process
+        parser: parse_zelle_email or parse_venmo_email
+        provider: 'Zelle' or 'Venmo' (used in source/notes/excerpt strings)
+        session: SQLAlchemy session
+        stats: Mutable stats dict shared across providers
+        dry_run: If True, print results without inserting
+        status: Ledger status for inserted rows
+    """
+    for i, eid in enumerate(email_ids, 1):
+        try:
+            status_code, msg_data = mail.fetch(eid, "(RFC822)")
+            if status_code != "OK":
+                print(f"  [{provider} {i}] Failed to fetch email ID {eid}")
+                stats["errors"] += 1
+                continue
+
+            raw_email = msg_data[0][1]
+            parsed = parser(raw_email)
+
+            if not parsed:
+                print(f"  [{provider} {i}] Could not parse (not an incoming payment)")
+                continue
+
+            stats["parsed"] += 1
+
+            # Check for duplicates
+            if is_duplicate(session, parsed["transaction_number"]):
+                print(
+                    f"  [{provider} {i}] Duplicate: {parsed['sender_name']} "
+                    f"${parsed['amount']} on {parsed['donation_date']} "
+                    f"(txn #{parsed['transaction_number']})"
+                )
+                stats["duplicates"] += 1
+                continue
+
+            record = build_donor_record(parsed, status=status, provider=provider)
+
+            if dry_run:
+                print(
+                    f"  [{provider} {i}] Would insert: {record['name']} - "
+                    f"${record['amount']} on {record['donation_date']} "
+                    f"| source: {record['source']} "
+                    f"| notes: {record['notes']}"
+                    f"{' | memo: ' + record['message'] if record['message'] else ''}"
+                )
+            else:
+                donor = Donor(**record)
+                session.add(donor)
+                session.commit()
+                print(
+                    f"  [{provider} {i}] Inserted: {record['name']} - "
+                    f"${record['amount']} on {record['donation_date']}"
+                )
+
+            stats["inserted"] += 1
+
+            # Small delay between inserts to ensure unique timestamps
+            time.sleep(0.01)
+
+        except Exception as e:
+            print(f"  [{provider} {i}] Error processing email: {e}")
+            session.rollback()
+            stats["errors"] += 1
+
+
 def sync_zelle_donations(since_date=None, fetch_all=False, dry_run=False, status="pending"):
     """
-    Main sync function: connect to Gmail, fetch Zelle emails, parse and insert.
+    Main sync function: connect to Gmail, fetch Zelle and Venmo payment
+    emails, parse and insert.
 
     Args:
         since_date: Optional YYYY-MM-DD string
@@ -347,65 +549,25 @@ def sync_zelle_donations(since_date=None, fetch_all=False, dry_run=False, status
     session = Session()
 
     try:
-        mail = connect_to_gmail()
-        email_ids = search_zelle_emails(mail, imap_since)
-        stats["emails_found"] = len(email_ids)
+        mail = connect_to_gmail()  # logs in and selects the Zelle folder
+        zelle_ids = search_zelle_emails(mail, imap_since)
+        stats["emails_found"] += len(zelle_ids)
+        _process_provider_emails(mail, zelle_ids, parse_zelle_email, "Zelle",
+                                 session, stats, dry_run, status)
 
-        for i, eid in enumerate(email_ids, 1):
-            try:
-                status_code, msg_data = mail.fetch(eid, "(RFC822)")
-                if status_code != "OK":
-                    print(f"  [{i}] Failed to fetch email ID {eid}")
-                    stats["errors"] += 1
-                    continue
-
-                raw_email = msg_data[0][1]
-                parsed = parse_zelle_email(raw_email)
-
-                if not parsed:
-                    print(f"  [{i}] Could not parse (not a Zelle incoming payment)")
-                    continue
-
-                stats["parsed"] += 1
-
-                # Check for duplicates
-                if is_duplicate(session, parsed["transaction_number"]):
-                    print(
-                        f"  [{i}] Duplicate: {parsed['sender_name']} "
-                        f"${parsed['amount']} on {parsed['donation_date']} "
-                        f"(txn #{parsed['transaction_number']})"
-                    )
-                    stats["duplicates"] += 1
-                    continue
-
-                record = build_donor_record(parsed, status=status)
-
-                if dry_run:
-                    print(
-                        f"  [{i}] Would insert: {record['name']} - "
-                        f"${record['amount']} on {record['donation_date']} "
-                        f"| source: {record['source']} "
-                        f"| notes: {record['notes']}"
-                        f"{' | memo: ' + record['message'] if record['message'] else ''}"
-                    )
-                else:
-                    donor = Donor(**record)
-                    session.add(donor)
-                    session.commit()
-                    print(
-                        f"  [{i}] Inserted: {record['name']} - "
-                        f"${record['amount']} on {record['donation_date']}"
-                    )
-
-                stats["inserted"] += 1
-
-                # Small delay between inserts to ensure unique timestamps
-                time.sleep(0.01)
-
-            except Exception as e:
-                print(f"  [{i}] Error processing email: {e}")
-                session.rollback()
-                stats["errors"] += 1
+        # Venmo notifications live in a separate Gmail label
+        try:
+            select_status, _ = mail.select(VENMO_FOLDER, readonly=True)
+        except Exception as e:
+            select_status = "NO"
+            print(f"Venmo folder unavailable, skipping: {e}")
+        if select_status == "OK":
+            venmo_ids = search_venmo_emails(mail, imap_since)
+            stats["emails_found"] += len(venmo_ids)
+            _process_provider_emails(mail, venmo_ids, parse_venmo_email, "Venmo",
+                                     session, stats, dry_run, status)
+        else:
+            print(f"Could not select {VENMO_FOLDER}, skipping Venmo sync.")
 
     except Exception as e:
         print(f"\nSync error: {e}")

--- a/ProjectCode/server/tests/test_zelle_sync.py
+++ b/ProjectCode/server/tests/test_zelle_sync.py
@@ -101,6 +101,153 @@ def test_build_email_excerpt_without_optional_fields():
     assert excerpt == 'Zelle payment received — Li Chen sent you $88'
 
 
+# ---------------------------------------------------------------- venmo
+
+def make_venmo_email(sender='Xiao Yang', amount='$15.00',
+                     memo='拉什福德贝林莱斯加油 凯恩进球 英格兰过关西瓜',
+                     txn_link='https://venmo.com/story/4236712345',
+                     message_id='<venmo-abc-123@venmo.com>'):
+    link_html = f'<a href="{txn_link}">See transaction</a>' if txn_link else ''
+    html = f"""
+    <html><body>
+      <p>venmo</p>
+      <p>{sender} paid you</p>
+      <p>$15 00</p>
+      <p>{memo}</p>
+      {link_html}
+      <p>Money credited to your Venmo account.</p>
+    </body></html>
+    """
+    msg = MIMEText(html, 'html', 'utf-8')
+    msg['From'] = 'Venmo <venmo@venmo.com>'
+    msg['Subject'] = f'{sender} paid you {amount}'
+    msg['Date'] = 'Sun, 05 Jul 2026 19:49:00 -0400'
+    if message_id:
+        msg['Message-ID'] = message_id
+    return msg.as_bytes()
+
+
+def test_parse_venmo_email_extracts_all_fields():
+    parsed = zelle.parse_venmo_email(make_venmo_email())
+    assert parsed['sender_name'] == 'Xiao Yang'
+    assert parsed['amount'] == Decimal('15.00')
+    assert parsed['donation_date'] == date(2026, 7, 5)
+    assert parsed['transaction_number'] == '4236712345'
+    assert '拉什福德' in parsed['memo']
+
+
+def test_parse_venmo_email_falls_back_to_message_id_for_dedup():
+    parsed = zelle.parse_venmo_email(make_venmo_email(txn_link=None))
+    assert parsed['transaction_number'] == 'venmo-abc-123@venmo.com'
+
+
+def test_parse_venmo_email_no_dedup_key_at_all():
+    parsed = zelle.parse_venmo_email(make_venmo_email(txn_link=None, message_id=None))
+    assert parsed['transaction_number'] is None
+
+
+def test_parse_venmo_email_rejects_outgoing_payment():
+    msg = MIMEText('<p>details</p>', 'html', 'utf-8')
+    msg['Subject'] = 'You paid Xiao Yang $15.00'
+    assert zelle.parse_venmo_email(msg.as_bytes()) is None
+
+
+def test_parse_venmo_email_without_memo():
+    parsed = zelle.parse_venmo_email(make_venmo_email(memo=''))
+    assert parsed['memo'] is None
+    assert parsed['amount'] == Decimal('15.00')
+
+
+def test_parse_venmo_email_encoded_subject():
+    raw = make_venmo_email()
+    # Re-encode the subject as RFC 2047 UTF-8 (how Gmail delivers CJK names)
+    import email as email_mod
+    from email.header import Header
+    msg = email_mod.message_from_bytes(raw)
+    del msg['Subject']
+    msg['Subject'] = Header('王小 paid you $88.00', 'utf-8')
+    parsed = zelle.parse_venmo_email(msg.as_bytes())
+    assert parsed['sender_name'] == '王小'
+    assert parsed['amount'] == Decimal('88.00')
+
+
+def test_build_donor_record_venmo_provider_strings():
+    parsed = zelle.parse_venmo_email(make_venmo_email())
+    record = zelle.build_donor_record(parsed, provider='Venmo')
+    assert record['status'] == 'pending'
+    assert record['source'] == 'Venmo (Xiao Yang)'
+    assert record['notes'] == 'Venmo Transaction #4236712345'
+    assert record['email_excerpt'].startswith(
+        'Venmo payment received — Xiao Yang sent you $15.00')
+
+
+def test_sync_processes_both_zelle_and_venmo(db_session, monkeypatch):
+    from sqlalchemy.orm import sessionmaker as _sessionmaker
+
+    class FakeMail:
+        def __init__(self, zelle_emails, venmo_emails):
+            self.emails = {**zelle_emails, **venmo_emails}
+            self.selected = []
+
+        def select(self, folder, readonly=False):
+            self.selected.append(folder)
+            return ('OK', [b''])
+
+        def fetch(self, eid, spec):
+            return ('OK', [(b'1 (RFC822)', self.emails[eid])])
+
+        def close(self):
+            pass
+
+        def logout(self):
+            pass
+
+    zelle_emails = {b'z1': make_zelle_email()}
+    venmo_emails = {b'v1': make_venmo_email()}
+    mail = FakeMail(zelle_emails, venmo_emails)
+
+    monkeypatch.setattr(zelle, 'Session', _sessionmaker(bind=db_session.get_bind()))
+    monkeypatch.setattr(zelle.time, 'sleep', lambda seconds: None)
+    monkeypatch.setattr(zelle, 'connect_to_gmail', lambda: mail)
+    monkeypatch.setattr(zelle, 'search_zelle_emails',
+                        lambda m, since=None: list(zelle_emails.keys()))
+    monkeypatch.setattr(zelle, 'search_venmo_emails',
+                        lambda m, since=None: list(venmo_emails.keys()))
+
+    stats = zelle.sync_zelle_donations()
+
+    assert stats == {'emails_found': 2, 'parsed': 2, 'duplicates': 0,
+                     'inserted': 2, 'errors': 0}
+    assert zelle.VENMO_FOLDER in mail.selected
+    donors = {d.name: d for d in db_session.query(Donor).all()}
+    assert set(donors) == {'Ming Zhao', 'Xiao Yang'}
+    assert donors['Xiao Yang'].source == 'Venmo (Xiao Yang)'
+    assert donors['Xiao Yang'].status == 'pending'
+    assert donors['Ming Zhao'].source == 'Zelle (Ming Zhao)'
+
+
+def test_sync_skips_venmo_when_folder_missing(db_session, monkeypatch):
+    from sqlalchemy.orm import sessionmaker as _sessionmaker
+
+    class NoVenmoMail:
+        def select(self, folder, readonly=False):
+            return ('NO', [b''])
+
+        def close(self):
+            pass
+
+        def logout(self):
+            pass
+
+    monkeypatch.setattr(zelle, 'Session', _sessionmaker(bind=db_session.get_bind()))
+    monkeypatch.setattr(zelle, 'connect_to_gmail', lambda: NoVenmoMail())
+    monkeypatch.setattr(zelle, 'search_zelle_emails', lambda m, since=None: [])
+
+    stats = zelle.sync_zelle_donations()
+    assert stats['emails_found'] == 0
+    assert stats['errors'] == 0
+
+
 # ---------------------------------------------------------------- dedup + sync status
 
 def test_is_duplicate_matches_transaction_number(db_session):


### PR DESCRIPTION
## Summary

Extends the weekly donation Gmail sync (deployed in #70) to also import **Venmo** payments:

- Reads the **"NewBee Finance/Venmo"** Gmail label (alongside the existing Zelle "NewBee Finance/Chase" label) in the same weekly job, manual "Sync now" button, and CLI backfill
- Parses payer + amount from the subject ("Xiao Yang paid you $15.00"), the payment note (memo) from the body — CJK names and notes handled, RFC 2047-encoded subjects decoded
- Dedup via the transaction id in the "See transaction" link, falling back to the email Message-ID; only "X paid you" (incoming) emails are imported
- Both providers share one fetch/parse/dedup/insert pipeline; Venmo donations land as **pending** in the admin ledger like Zelle ones
- If the Venmo label doesn't exist, the sync logs and skips it without failing the Zelle pass

Ledger UI: a donation now counts as Gmail-imported when it has an email excerpt (not by sniffing the source string), so old manually-entered rows with source "Venmo"/"WeChat" correctly display as Manual; the source chip names the provider (✉ Gmail · Zelle / ✉ Gmail · Venmo).

## Deployment
No migration and no new dependencies — just sync the backend code, restart `newbeerunning-api`, and rebuild the frontend.

## Test plan
- Backend: 818 pytest tests pass, 99.4% coverage (new: Venmo parser incl. CJK memo/encoded subject, Message-ID dedup fallback, two-provider flow, missing-label skip)
- Frontend: 1066 jest tests pass, 98.8% lines / 90.6% branches (new: Venmo source chip, manual-Venmo stays Manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)