### PR TITLE
Fix Venmo memo parsing (inline note)

### DIFF
--- a/ProjectCode/server/sync_zelle_donations.py
+++ b/ProjectCode/server/sync_zelle_donations.py
@@ -267,16 +267,23 @@ def _extract_venmo_memo(text):
     """
     lines = [line.strip() for line in text.split('\n')]
     start = None
+    memo_lines = []
     for i, line in enumerate(lines):
-        if 'paid you' in line.lower():
+        idx = line.lower().find('paid you')
+        if idx != -1:
             start = i + 1
+            # In real Venmo HTML the note often sits on the same line as
+            # "{NAME} paid you" (inline spans) — keep what follows, minus
+            # any leading amount fragment like "$15.00" / "$15 00"
+            remainder = re.sub(r'^[\$\d.,\s]+', '', line[idx + len('paid you'):].strip())
+            if remainder:
+                memo_lines.append(remainder.strip())
             break
     if start is None:
         return None
 
     stop_markers = ('see transaction', 'money credited', 'payment id',
                     'transfer', 'for any issues')
-    memo_lines = []
     for line in lines[start:]:
         lowered = line.lower()
         if any(lowered.startswith(marker) for marker in stop_markers):

--- a/ProjectCode/server/tests/test_zelle_sync.py
+++ b/ProjectCode/server/tests/test_zelle_sync.py
@@ -152,6 +152,24 @@ def test_parse_venmo_email_rejects_outgoing_payment():
     assert zelle.parse_venmo_email(msg.as_bytes()) is None
 
 
+def test_parse_venmo_email_inline_memo_same_line_as_paid_you():
+    # Real Venmo HTML renders "{NAME} paid you {note}" inline in one block
+    html = """
+    <html><body>
+      <div>Hamilton Chen paid you ⛽ 加油</div>
+      <div>$15.00</div>
+      <a href="https://venmo.com/story/4611697894995121599">See transaction</a>
+      <div>Money credited to your Venmo account.</div>
+    </body></html>
+    """
+    msg = MIMEText(html, 'html', 'utf-8')
+    msg['Subject'] = 'Hamilton Chen paid you $15.00'
+    msg['Date'] = 'Wed, 03 Jun 2026 10:00:00 -0400'
+    parsed = zelle.parse_venmo_email(msg.as_bytes())
+    assert parsed['memo'] == '⛽ 加油'
+    assert parsed['transaction_number'] == '4611697894995121599'
+
+
 def test_parse_venmo_email_without_memo():
     parsed = zelle.parse_venmo_email(make_venmo_email(memo=''))
     assert parsed['memo'] is None


### PR DESCRIPTION
Follow-up to #71, found by dry-running against the live mailbox: real Venmo HTML puts the payment note on the same line as "{NAME} paid you", so memos were imported with that prefix (e.g. "Hamilton Chen paid you ⛽" instead of "⛽"). Now only the note is kept. 819 backend tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)