### PR TITLE
Venmo memo/Transaction-ID parsing fix; dropdown z-index fix; ledger self-migration

### DIFF
--- a/ProjectCode/client/src/components/EventDetailModal.js
+++ b/ProjectCode/client/src/components/EventDetailModal.js
@@ -391,6 +391,8 @@ export default function EventDetailModal({ event, onClose, onEventUpdate }) {
                   onChange={handleEditFieldChange('status')}
                   size="small"
                   sx={{ flex: 1 }}
+                  // Menu must portal above this modal's zIndex: 9999 overlay
+                  SelectProps={{ MenuProps: { sx: { zIndex: 10000 } } }}
                 >
                   <MenuItem value="Upcoming">Upcoming / 即将举行</MenuItem>
                   <MenuItem value="Past">Past / 已结束</MenuItem>
@@ -403,6 +405,7 @@ export default function EventDetailModal({ event, onClose, onEventUpdate }) {
                   onChange={handleEditFieldChange('event_type')}
                   size="small"
                   sx={{ flex: 1 }}
+                  SelectProps={{ MenuProps: { sx: { zIndex: 10000 } } }}
                 >
                   <MenuItem value="standard">Standard</MenuItem>
                   <MenuItem value="heylo">Heylo</MenuItem>

--- a/ProjectCode/client/src/components/EventDetailModal.test.js
+++ b/ProjectCode/client/src/components/EventDetailModal.test.js
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import EventDetailModal from './EventDetailModal';
 import { getEventEngagement, updateEvent, getEventById } from '../api';
 import { useAuth } from '../context/AuthContext';
@@ -441,6 +441,36 @@ describe('EventDetailModal', () => {
       // edit mode exits
       await waitFor(() =>
         expect(screen.queryByLabelText(/Event Name/)).not.toBeInTheDocument()
+      );
+    });
+
+    test('status and type dropdowns open above the overlay and change values', async () => {
+      updateEvent.mockResolvedValue({ id: 1, name: 'Server Name', status: 'Cancelled' });
+      renderModal();
+      fireEvent.click((await screen.findByTestId('EditIcon')).closest('button'));
+      await screen.findByLabelText(/Event Name/);
+
+      // The modal overlay uses zIndex 9999 — menus must portal above it or
+      // they open invisibly behind the backdrop (regression: uneditable selects)
+      fireEvent.mouseDown(screen.getByLabelText(/Status \/ 状态/));
+      let listbox = await screen.findByRole('listbox');
+      expect(Number(getComputedStyle(listbox.closest('.MuiModal-root')).zIndex)).toBeGreaterThan(9999);
+      fireEvent.click(within(listbox).getByText('Cancelled / 已取消'));
+      await waitFor(() => expect(screen.queryByRole('listbox')).not.toBeInTheDocument());
+
+      fireEvent.mouseDown(screen.getByLabelText(/Type \/ 类型/));
+      listbox = await screen.findByRole('listbox');
+      expect(Number(getComputedStyle(listbox.closest('.MuiModal-root')).zIndex)).toBeGreaterThan(9999);
+      fireEvent.click(within(listbox).getByText('Standard'));
+      await waitFor(() => expect(screen.queryByRole('listbox')).not.toBeInTheDocument());
+
+      fireEvent.click(screen.getByRole('button', { name: /Save \/ 保存/ }));
+      await waitFor(() =>
+        expect(updateEvent).toHaveBeenCalledWith(
+          1,
+          expect.objectContaining({ status: 'Cancelled', event_type: 'standard' }),
+          'user-1'
+        )
       );
     });
 

--- a/ProjectCode/server/main.py
+++ b/ProjectCode/server/main.py
@@ -128,6 +128,25 @@ def _run_migrations():
         ))
         conn.commit()
 
+    # Donation ledger columns on donors (same DDL as migrate_donation_ledger.py,
+    # kept here so fresh environments self-migrate on startup). Guarded on table
+    # existence for schemas created outside create_tables().
+    if 'donors' in inspector.get_table_names():
+        donor_columns = [c['name'] for c in inspector.get_columns('donors')]
+        ledger_columns = [
+            ("status", "VARCHAR(20) NOT NULL DEFAULT 'confirmed'"),
+            ("thank_you_sent_at", "DATETIME NULL"),
+            ("email_excerpt", "TEXT NULL"),
+        ]
+        missing = [(name, ddl) for name, ddl in ledger_columns if name not in donor_columns]
+        if missing:
+            with engine.connect() as conn:
+                for name, ddl in missing:
+                    conn.execute(text(f"ALTER TABLE donors ADD COLUMN {name} {ddl}"))
+                # Belt and suspenders: a partial prior run could leave NULLs
+                conn.execute(text("UPDATE donors SET status = 'confirmed' WHERE status IS NULL"))
+                conn.commit()
+
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):

--- a/ProjectCode/server/sync_zelle_donations.py
+++ b/ProjectCode/server/sync_zelle_donations.py
@@ -262,33 +262,45 @@ def parse_zelle_email(raw_email):
 
 def _extract_venmo_memo(text):
     """
-    Pull the payment note from a stripped Venmo email body: the lines between
-    "{NAME} paid you" / the amount and the "See transaction" button.
+    Pull the payment note from a stripped Venmo email body.
+
+    Real Venmo emails render as: a title/preheader line ("X paid you $15.00",
+    sometimes duplicated), then the card heading "X paid you", the amount
+    split across lines ("$" / "15" / ". 00"), the note, and the
+    "See transaction" button. The note is whatever sits between the LAST
+    "paid you" heading and the first stop marker, skipping amount fragments.
     """
     lines = [line.strip() for line in text.split('\n')]
-    start = None
-    memo_lines = []
+
+    stop_markers = ('see transaction', 'money credited', 'payment id',
+                    'transfer', 'for any issues', 'transaction details')
+    stop = len(lines)
     for i, line in enumerate(lines):
-        idx = line.lower().find('paid you')
-        if idx != -1:
-            start = i + 1
-            # In real Venmo HTML the note often sits on the same line as
-            # "{NAME} paid you" (inline spans) — keep what follows, minus
-            # any leading amount fragment like "$15.00" / "$15 00"
-            remainder = re.sub(r'^[\$\d.,\s]+', '', line[idx + len('paid you'):].strip())
-            if remainder:
-                memo_lines.append(remainder.strip())
+        if any(line.lower().startswith(marker) for marker in stop_markers):
+            stop = i
+            break
+
+    start = None
+    heading_idx = -1
+    for i in range(stop - 1, -1, -1):
+        heading_idx = lines[i].lower().find('paid you')
+        if heading_idx != -1:
+            start = i
             break
     if start is None:
         return None
 
-    stop_markers = ('see transaction', 'money credited', 'payment id',
-                    'transfer', 'for any issues')
-    for line in lines[start:]:
-        lowered = line.lower()
-        if any(lowered.startswith(marker) for marker in stop_markers):
-            break
-        # Skip blanks and standalone amount fragments like "$15.00" / "$15 00"
+    memo_lines = []
+    # The note may sit inline after "paid you" on the heading line itself,
+    # minus any leading amount fragment like "$15.00" / "$15 00"
+    remainder = re.sub(
+        r'^[\$\d.,\s]+', '', lines[start][heading_idx + len('paid you'):].strip()
+    )
+    if remainder:
+        memo_lines.append(remainder.strip())
+
+    for line in lines[start + 1:stop]:
+        # Skip blanks and standalone amount fragments ("$", "15", ". 00")
         if not line or re.fullmatch(r'[\$\d.,\s]+', line):
             continue
         memo_lines.append(line)
@@ -321,12 +333,16 @@ def parse_venmo_email(raw_email):
     amount = Decimal(subject_match.group(2).replace(",", ""))
 
     body = _get_email_body(msg)
-    memo = _extract_venmo_memo(strip_html(body)) if body else None
+    text = strip_html(body) if body else ''
+    memo = _extract_venmo_memo(text) if text else None
 
-    # Transaction id from the "See transaction" link, else the Message-ID
-    txn_match = re.search(
-        r'venmo\.com/(?:story|payment)s?/([A-Za-z0-9_\-]+)', body or ''
-    )
+    # Transaction id: the "Transaction ID" field in the body, else the id in
+    # the "See transaction" link, else the email Message-ID
+    txn_match = re.search(r'Transaction\s+ID\s*\n\s*(\d+)', text, re.IGNORECASE)
+    if not txn_match:
+        txn_match = re.search(
+            r'venmo\.com/(?:story|payment)s?/([A-Za-z0-9_\-]+)', body or ''
+        )
     if txn_match:
         transaction_number = txn_match.group(1)
     else:

--- a/ProjectCode/server/tests/test_main.py
+++ b/ProjectCode/server/tests/test_main.py
@@ -163,6 +163,15 @@ def legacy_engine(monkeypatch):
             "(4, 'Normal Past',      '2020-01-01', 'Past'), "
             "(5, 'Stale Upcoming',   '2020-01-01', 'Upcoming')"
         ))
+        # Pre-ledger donors table (no status/thank_you_sent_at/email_excerpt)
+        conn.execute(text(
+            'CREATE TABLE donors (donation_id INTEGER PRIMARY KEY, '
+            'name VARCHAR(255), donor_type VARCHAR(20), amount DECIMAL(10,2))'
+        ))
+        conn.execute(text(
+            "INSERT INTO donors (donation_id, name, donor_type, amount) "
+            "VALUES (1, 'Legacy Donor', 'individual', 100)"
+        ))
         conn.commit()
     monkeypatch.setattr(main, 'engine', eng)
     return eng
@@ -192,6 +201,14 @@ def test_run_migrations_adds_columns_and_backfills(legacy_engine):
     index_names = {ix['name'] for ix in inspect(legacy_engine).get_indexes('events')}
     assert 'idx_event_is_highlight' in index_names
 
+    # Donation ledger columns added, legacy row defaulted to 'confirmed'
+    donor_cols = [c['name'] for c in inspect(legacy_engine).get_columns('donors')]
+    for col in ('status', 'thank_you_sent_at', 'email_excerpt'):
+        assert col in donor_cols
+    with legacy_engine.connect() as conn:
+        row = conn.execute(text('SELECT status FROM donors WHERE donation_id = 1')).fetchone()
+    assert row[0] == 'confirmed'
+
 
 def test_run_migrations_is_idempotent(legacy_engine):
     main._run_migrations()
@@ -202,6 +219,8 @@ def test_run_migrations_is_idempotent(legacy_engine):
     assert event_rows(legacy_engine) == first
     member_cols = [c['name'] for c in inspect(legacy_engine).get_columns('members')]
     assert member_cols.count('nickname') == 1
+    donor_cols = [c['name'] for c in inspect(legacy_engine).get_columns('donors')]
+    assert donor_cols.count('status') == 1
 
 
 # ---------------------------------------------------------------------------

--- a/ProjectCode/server/tests/test_zelle_sync.py
+++ b/ProjectCode/server/tests/test_zelle_sync.py
@@ -106,16 +106,27 @@ def test_build_email_excerpt_without_optional_fields():
 def make_venmo_email(sender='Xiao Yang', amount='$15.00',
                      memo='拉什福德贝林莱斯加油 凯恩进球 英格兰过关西瓜',
                      txn_link='https://venmo.com/story/4236712345',
+                     txn_text=None,
                      message_id='<venmo-abc-123@venmo.com>'):
+    """Mirror the real Venmo email text structure: duplicated title/preheader
+    line, card heading, amount split across lines, note, button, details."""
     link_html = f'<a href="{txn_link}">See transaction</a>' if txn_link else ''
+    txn_html = (
+        f'<p>Transaction details</p><p>Date</p><p>Jul 05, 2026</p>'
+        f'<p>Transaction ID</p><p>{txn_text}</p>'
+        if txn_text else ''
+    )
     html = f"""
     <html><body>
+      <p>{sender} paid you {amount} {sender} paid you {amount}</p>
       <p>venmo</p>
       <p>{sender} paid you</p>
-      <p>$15 00</p>
+      <p>$</p><p>15</p><p>. 00</p>
       <p>{memo}</p>
       {link_html}
       <p>Money credited to your Venmo account.</p>
+      {txn_html}
+      <p>For any issues, please contact us at Help Center.</p>
     </body></html>
     """
     msg = MIMEText(html, 'html', 'utf-8')
@@ -134,6 +145,19 @@ def test_parse_venmo_email_extracts_all_fields():
     assert parsed['donation_date'] == date(2026, 7, 5)
     assert parsed['transaction_number'] == '4236712345'
     assert '拉什福德' in parsed['memo']
+
+
+def test_parse_venmo_email_title_line_does_not_leak_into_memo():
+    parsed = zelle.parse_venmo_email(make_venmo_email(memo='red tee'))
+    # The duplicated "X paid you $15.00" preheader and the split amount
+    # fragments must not appear in the note
+    assert parsed['memo'] == 'red tee'
+
+
+def test_parse_venmo_email_prefers_transaction_id_field():
+    parsed = zelle.parse_venmo_email(make_venmo_email(
+        txn_text='4611697894323507636'))
+    assert parsed['transaction_number'] == '4611697894323507636'
 
 
 def test_parse_venmo_email_falls_back_to_message_id_for_dedup():


### PR DESCRIPTION
## Summary
- **Venmo parsing fix** (follow-up to #71, verified against the live mailbox): real Venmo emails begin with a duplicated "X paid you $15.00" preheader and split the amount across lines, so memos were imported with that prefix. The note is now taken after the last "paid you" heading before the See-transaction button, and dedup prefers the body's "Transaction ID" field (fallback: story-link id, then Message-ID). Live dry-run now yields clean memos (⛽ / 可非 / "1 red + 1 white 队服").
- Fix Status/Type dropdowns opening invisibly behind the event detail modal (z-index).
- Self-migrate donation ledger columns on startup.

## Test plan
821+ backend tests pass; live-mailbox dry-run verified before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)