### PR TITLE
Ledger: un-approve and delete actions for reviewed donations

### DIFF
--- a/ProjectCode/client/src/api/donors.js
+++ b/ProjectCode/client/src/api/donors.js
@@ -52,10 +52,14 @@ export async function updateDonor(donorId, donorData) {
 /**
  * Delete a donor
  * @param {string} donorId - Donor ID
+ * @param {string} [firebaseUid] - Committee/admin Firebase UID
  * @returns {Promise<Object>} Deletion result
  */
-export async function deleteDonor(donorId) {
-  return api.delete(`/api/donors/${donorId}`);
+export async function deleteDonor(donorId, firebaseUid) {
+  return api.delete(
+    `/api/donors/${donorId}`,
+    firebaseUid ? { 'X-Firebase-UID': firebaseUid } : {}
+  );
 }
 
 /**
@@ -123,6 +127,18 @@ export async function getDonationLedger(firebaseUid) {
  */
 export async function approveDonation(donationId, corrections = {}, firebaseUid) {
   return api.post(`/api/donors/donations/${donationId}/approve`, corrections, {
+    'X-Firebase-UID': firebaseUid,
+  });
+}
+
+/**
+ * Send a donation back to pending review (undo an accidental approve/dismiss)
+ * @param {number} donationId - Donation ID
+ * @param {string} firebaseUid - Committee/admin Firebase UID
+ * @returns {Promise<Object>} Updated ledger entry
+ */
+export async function revertDonation(donationId, firebaseUid) {
+  return api.post(`/api/donors/donations/${donationId}/revert`, {}, {
     'X-Firebase-UID': firebaseUid,
   });
 }

--- a/ProjectCode/client/src/api/donors.test.js
+++ b/ProjectCode/client/src/api/donors.test.js
@@ -14,6 +14,7 @@ import {
   getDonationLedger,
   approveDonation,
   dismissDonation,
+  revertDonation,
   runGmailSync,
   downloadTaxReport,
 } from './donors';
@@ -59,7 +60,12 @@ test('updateDonor PUTs donor data', async () => {
 
 test('deleteDonor DELETEs the donor', async () => {
   await expect(deleteDonor('D-1')).resolves.toBe('DELETE');
-  expect(api.delete).toHaveBeenCalledWith('/api/donors/D-1');
+  expect(api.delete).toHaveBeenCalledWith('/api/donors/D-1', {});
+});
+
+test('deleteDonor passes the auth header when a uid is given', async () => {
+  await deleteDonor('D-1', 'uid-1');
+  expect(api.delete).toHaveBeenCalledWith('/api/donors/D-1', { 'X-Firebase-UID': 'uid-1' });
 });
 
 test('getDonationSummary GETs the stats summary', async () => {
@@ -107,6 +113,13 @@ test('approveDonation defaults to empty corrections', async () => {
   await approveDonation(7, undefined, 'uid-1');
   expect(api.post).toHaveBeenCalledWith(
     '/api/donors/donations/7/approve', {}, { 'X-Firebase-UID': 'uid-1' }
+  );
+});
+
+test('revertDonation POSTs with auth header', async () => {
+  await expect(revertDonation(7, 'uid-1')).resolves.toBe('POST');
+  expect(api.post).toHaveBeenCalledWith(
+    '/api/donors/donations/7/revert', {}, { 'X-Firebase-UID': 'uid-1' }
   );
 });
 

--- a/ProjectCode/client/src/components/DonationLedger.js
+++ b/ProjectCode/client/src/components/DonationLedger.js
@@ -10,10 +10,12 @@ import SyncIcon from '@mui/icons-material/Sync';
 import ReceiptLongIcon from '@mui/icons-material/ReceiptLong';
 import CheckIcon from '@mui/icons-material/Check';
 import CloseIcon from '@mui/icons-material/Close';
+import ReplayIcon from '@mui/icons-material/Replay';
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 import { useAuth } from '../context';
 import {
-  getDonationLedger, approveDonation, dismissDonation, runGmailSync,
-  downloadTaxReport
+  getDonationLedger, approveDonation, dismissDonation, revertDonation,
+  deleteDonor, runGmailSync, downloadTaxReport
 } from '../api/donors';
 
 // Design tokens (match HomePage / NavBar design language)
@@ -127,6 +129,7 @@ export default function DonationLedger({ onLedgerChange }) {
   const [syncing, setSyncing] = useState(false);
   const [actingId, setActingId] = useState(null);
   const [pendingTypes, setPendingTypes] = useState({});
+  const [deleteTarget, setDeleteTarget] = useState(null);
 
   // Tax report dialog
   const [taxDialogOpen, setTaxDialogOpen] = useState(false);
@@ -185,6 +188,38 @@ export default function DonationLedger({ onLedgerChange }) {
     } catch (err) {
       console.error('Error dismissing donation:', err);
       setError('Failed to dismiss donation. / 忽略捐款失败。');
+    } finally {
+      setActingId(null);
+    }
+  };
+
+  const handleRevert = async (donation) => {
+    setActingId(donation.donation_id);
+    setError('');
+    try {
+      await revertDonation(donation.donation_id, firebaseUid);
+      await fetchLedger();
+      if (onLedgerChange) onLedgerChange();
+    } catch (err) {
+      console.error('Error reverting donation:', err);
+      setError('Failed to un-approve donation. / 撤回捐款失败。');
+    } finally {
+      setActingId(null);
+    }
+  };
+
+  const handleConfirmDelete = async () => {
+    if (!deleteTarget) return;
+    setActingId(deleteTarget.donation_id);
+    setError('');
+    try {
+      await deleteDonor(deleteTarget.donor_id, firebaseUid);
+      setDeleteTarget(null);
+      await fetchLedger();
+      if (onLedgerChange) onLedgerChange();
+    } catch (err) {
+      console.error('Error deleting donation:', err);
+      setError('Failed to delete donation. / 删除捐款失败。');
     } finally {
       setActingId(null);
     }
@@ -460,13 +495,33 @@ export default function DonationLedger({ onLedgerChange }) {
                         </Tooltip>
                       )}
                     </TableCell>
-                    <TableCell sx={{ width: 34 }}>
-                      <KeyboardArrowDownIcon sx={{
-                        fontSize: 18,
-                        color: ORANGE,
-                        transition: 'transform 0.25s',
-                        transform: expanded ? 'rotate(180deg)' : 'none'
-                      }} />
+                    <TableCell sx={{ whiteSpace: 'nowrap', width: 110 }}>
+                      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'flex-end', gap: 0.25 }}>
+                        {!pending && (
+                          <Box onClick={(e) => e.stopPropagation()} sx={{ display: 'flex', gap: 0.25 }}>
+                            <Tooltip title="Un-approve · back to pending / 撤回待审核">
+                              <span>
+                                <IconButton size="small" onClick={() => handleRevert(donation)} disabled={acting} aria-label="Un-approve 撤回">
+                                  <ReplayIcon sx={{ fontSize: 16, color: MUTED }} />
+                                </IconButton>
+                              </span>
+                            </Tooltip>
+                            <Tooltip title="Delete permanently / 永久删除">
+                              <span>
+                                <IconButton size="small" onClick={() => setDeleteTarget(donation)} disabled={acting} aria-label="Delete 删除">
+                                  <DeleteOutlineIcon sx={{ fontSize: 16, color: '#c62828' }} />
+                                </IconButton>
+                              </span>
+                            </Tooltip>
+                          </Box>
+                        )}
+                        <KeyboardArrowDownIcon sx={{
+                          fontSize: 18,
+                          color: ORANGE,
+                          transition: 'transform 0.25s',
+                          transform: expanded ? 'rotate(180deg)' : 'none'
+                        }} />
+                      </Box>
                     </TableCell>
                   </TableRow>
                   <TableRow>
@@ -517,6 +572,31 @@ export default function DonationLedger({ onLedgerChange }) {
           </TableBody>
         </Table>
       </TableContainer>
+
+      {/* Delete confirmation dialog */}
+      <Dialog open={Boolean(deleteTarget)} onClose={() => setDeleteTarget(null)} maxWidth="xs" fullWidth>
+        <DialogTitle>Delete donation? / 删除捐款？</DialogTitle>
+        <DialogContent>
+          <Typography sx={{ fontSize: '0.875rem' }}>
+            {deleteTarget?.name} · {formatAmount(deleteTarget?.amount)} · {formatDate(deleteTarget?.donation_date)}
+          </Typography>
+          <Typography sx={{ fontSize: '0.78125rem', color: MUTED, mt: 1 }}>
+            This permanently removes the record from the ledger. To just take it off the public page, use Un-approve instead. / 此操作将从账本中永久删除该记录；若只想从公开页面移除，请使用「撤回」。
+          </Typography>
+        </DialogContent>
+        <DialogActions sx={{ px: 3, py: 2 }}>
+          <Button onClick={() => setDeleteTarget(null)}>Cancel 取消</Button>
+          <Button
+            variant="contained"
+            color="error"
+            onClick={handleConfirmDelete}
+            disabled={actingId === deleteTarget?.donation_id}
+            sx={{ textTransform: 'none', fontWeight: 700, borderRadius: '99px', boxShadow: 'none' }}
+          >
+            {actingId === deleteTarget?.donation_id ? <CircularProgress size={18} sx={{ color: 'white' }} /> : 'Delete 删除'}
+          </Button>
+        </DialogActions>
+      </Dialog>
 
       {/* Tax file dialog */}
       <Dialog open={taxDialogOpen} onClose={() => setTaxDialogOpen(false)} maxWidth="sm" fullWidth>

--- a/ProjectCode/client/src/components/DonationLedger.test.js
+++ b/ProjectCode/client/src/components/DonationLedger.test.js
@@ -5,6 +5,8 @@ import {
   getDonationLedger,
   approveDonation,
   dismissDonation,
+  revertDonation,
+  deleteDonor,
   runGmailSync,
   downloadTaxReport,
 } from '../api/donors';
@@ -16,6 +18,8 @@ jest.mock('../api/donors', () => ({
   getDonationLedger: jest.fn(),
   approveDonation: jest.fn(),
   dismissDonation: jest.fn(),
+  revertDonation: jest.fn(),
+  deleteDonor: jest.fn(),
   runGmailSync: jest.fn(),
   downloadTaxReport: jest.fn(),
 }));
@@ -99,6 +103,8 @@ beforeEach(() => {
   getDonationLedger.mockResolvedValue(ledgerData);
   approveDonation.mockResolvedValue({});
   dismissDonation.mockResolvedValue({});
+  revertDonation.mockResolvedValue({});
+  deleteDonor.mockResolvedValue({});
   runGmailSync.mockResolvedValue({ emails_found: 1, inserted: 1 });
   downloadTaxReport.mockResolvedValue({
     blob: new Blob(['pdf']),
@@ -239,6 +245,68 @@ test('dismiss calls the API and refreshes', async () => {
   fireEvent.click(screen.getByLabelText('Dismiss 忽略'));
   await waitFor(() => expect(dismissDonation).toHaveBeenCalledWith(10, 'admin-uid'));
   await waitFor(() => expect(getDonationLedger).toHaveBeenCalledTimes(2));
+});
+
+test('confirmed rows show un-approve and delete actions; pending rows do not', async () => {
+  render(<DonationLedger />);
+  await screen.findByText('Li Chen');
+  // 3 non-pending rows (Li Chen, Golden Wheat, dismissed Spam Sender)
+  expect(screen.getAllByLabelText('Un-approve 撤回')).toHaveLength(3);
+  expect(screen.getAllByLabelText('Delete 删除')).toHaveLength(3);
+});
+
+test('un-approve sends the donation back to pending', async () => {
+  const onLedgerChange = jest.fn();
+  render(<DonationLedger onLedgerChange={onLedgerChange} />);
+  await screen.findByText('Li Chen');
+  fireEvent.click(screen.getAllByLabelText('Un-approve 撤回')[0]);
+  await waitFor(() => expect(revertDonation).toHaveBeenCalledWith(11, 'admin-uid'));
+  await waitFor(() => expect(onLedgerChange).toHaveBeenCalled());
+  expect(getDonationLedger).toHaveBeenCalledTimes(2);
+});
+
+test('delete asks for confirmation then deletes by donor_id', async () => {
+  const onLedgerChange = jest.fn();
+  render(<DonationLedger onLedgerChange={onLedgerChange} />);
+  await screen.findByText('Li Chen');
+
+  fireEvent.click(screen.getAllByLabelText('Delete 删除')[0]);
+  expect(await screen.findByText('Delete donation? / 删除捐款？')).toBeInTheDocument();
+  expect(deleteDonor).not.toHaveBeenCalled();
+
+  fireEvent.click(screen.getByText('Delete 删除'));
+  await waitFor(() => expect(deleteDonor).toHaveBeenCalledWith('IND_11', 'admin-uid'));
+  await waitFor(() => expect(onLedgerChange).toHaveBeenCalled());
+});
+
+test('delete confirmation can be cancelled', async () => {
+  render(<DonationLedger />);
+  await screen.findByText('Li Chen');
+  fireEvent.click(screen.getAllByLabelText('Delete 删除')[0]);
+  await screen.findByText('Delete donation? / 删除捐款？');
+  fireEvent.click(screen.getByText('Cancel 取消'));
+  await waitFor(() =>
+    expect(screen.queryByText('Delete donation? / 删除捐款？')).not.toBeInTheDocument()
+  );
+  expect(deleteDonor).not.toHaveBeenCalled();
+});
+
+test('shows an error when un-approve fails', async () => {
+  revertDonation.mockRejectedValue(new Error('nope'));
+  render(<DonationLedger />);
+  await screen.findByText('Li Chen');
+  fireEvent.click(screen.getAllByLabelText('Un-approve 撤回')[0]);
+  expect(await screen.findByText(/Failed to un-approve donation/)).toBeInTheDocument();
+});
+
+test('shows an error when delete fails', async () => {
+  deleteDonor.mockRejectedValue(new Error('nope'));
+  render(<DonationLedger />);
+  await screen.findByText('Li Chen');
+  fireEvent.click(screen.getAllByLabelText('Delete 删除')[0]);
+  await screen.findByText('Delete donation? / 删除捐款？');
+  fireEvent.click(screen.getByText('Delete 删除'));
+  expect(await screen.findByText(/Failed to delete donation/)).toBeInTheDocument();
 });
 
 test('sync status line and Sync now button', async () => {

--- a/ProjectCode/server/routes/donors.py
+++ b/ProjectCode/server/routes/donors.py
@@ -237,6 +237,27 @@ def approve_donation(
     return donor
 
 
+@router.post("/donations/{donation_id}/revert", response_model=DonorLedgerEntry)
+def revert_donation(
+    donation_id: int,
+    db: Session = Depends(get_db),
+    current_admin: Member = Depends(get_current_committee_or_admin)
+):
+    """Send a donation back to pending review (undo an accidental approve
+    or dismiss). It disappears from the public page until re-approved."""
+    donor = db.query(Donor).filter(Donor.donation_id == donation_id).first()
+    if not donor:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Donation {donation_id} not found"
+        )
+
+    donor.status = "pending"
+    db.commit()
+    db.refresh(donor)
+    return donor
+
+
 @router.post("/donations/{donation_id}/dismiss", response_model=DonorLedgerEntry)
 def dismiss_donation(
     donation_id: int,

--- a/ProjectCode/server/tests/test_donation_ledger.py
+++ b/ProjectCode/server/tests/test_donation_ledger.py
@@ -240,6 +240,28 @@ def test_approve_applies_corrections(client, db_session, committee_member):
     assert body['hide_name'] is True
 
 
+def test_revert_confirmed_donation_back_to_pending(client, db_session, committee_member):
+    donor = seed_donation(db_session, 'C1', status='confirmed')
+    resp = client.post(f'/api/donors/donations/{donor.donation_id}/revert',
+                       headers=auth(committee_member))
+    assert resp.status_code == 200
+    assert resp.json()['status'] == 'pending'
+    # No longer public until re-approved
+    assert client.get('/api/donors/public').json() == []
+
+
+def test_revert_requires_auth(client, db_session):
+    donor = seed_donation(db_session, 'C1')
+    resp = client.post(f'/api/donors/donations/{donor.donation_id}/revert')
+    assert resp.status_code == 401
+
+
+def test_revert_unknown_donation_404(client, committee_member):
+    resp = client.post('/api/donors/donations/99999/revert',
+                       headers=auth(committee_member))
+    assert resp.status_code == 404
+
+
 def test_dismiss_donation(client, db_session, committee_member):
     donor = seed_donation(db_session, 'P1', status='pending')
     resp = client.post(f'/api/donors/donations/{donor.donation_id}/dismiss',


### PR DESCRIPTION
Committee members can now fix review mistakes in the donation ledger:

- **↩ Un-approve**: new `POST /api/donors/donations/{id}/revert` sends an accidentally approved (or dismissed) donation back to pending — it immediately disappears from the public sponsors page for re-review
- **🗑 Delete**: permanently removes the record, behind a confirmation dialog that suggests Un-approve when you only want it off the public page
- `deleteDonor` now sends the `X-Firebase-UID` auth header the endpoint has always required

## Test plan
Backend 824 tests pass; frontend 1075 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)