### PR TITLE
Profile record wall UI: medal wall, poster mode, submissions tracker, committee review tab

### DIFF
--- a/ProjectCode/client/src/api/raceSubmissions.test.js
+++ b/ProjectCode/client/src/api/raceSubmissions.test.js
@@ -1,0 +1,91 @@
+import { api } from './client';
+import {
+  createRaceSubmission,
+  getMyRaceSubmissions,
+  updateRaceSubmission,
+  deleteRaceSubmission,
+  getPendingRaceSubmissions,
+  reviewRaceSubmission,
+  upsertRacePhoto,
+  getMyRacePhotos,
+} from './raceSubmissions';
+
+jest.mock('./client', () => ({
+  api: { get: jest.fn(), post: jest.fn(), put: jest.fn(), delete: jest.fn() },
+}));
+
+const UID = 'uid-1';
+const AUTH = { 'X-Firebase-UID': UID };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  api.get.mockResolvedValue('GET');
+  api.post.mockResolvedValue('POST');
+  api.put.mockResolvedValue('PUT');
+  api.delete.mockResolvedValue('DELETE');
+});
+
+test('createRaceSubmission POSTs the submission with auth header', async () => {
+  const data = { race_name: 'Boston Marathon', race_date: '2026-04-20', race_distance: 'Marathon', finish_time: '3:25:58' };
+  await expect(createRaceSubmission(data, UID)).resolves.toBe('POST');
+  expect(api.post).toHaveBeenCalledWith('/api/race-submissions', data, AUTH);
+});
+
+test('getMyRaceSubmissions GETs own submissions uncached', async () => {
+  await expect(getMyRaceSubmissions(UID)).resolves.toBe('GET');
+  expect(api.get).toHaveBeenCalledWith('/api/race-submissions/mine', {}, AUTH, { skipCache: true });
+});
+
+test('updateRaceSubmission PUTs changes to the submission', async () => {
+  await expect(updateRaceSubmission(5, { finish_time: '3:20:00' }, UID)).resolves.toBe('PUT');
+  expect(api.put).toHaveBeenCalledWith('/api/race-submissions/5', { finish_time: '3:20:00' }, AUTH);
+});
+
+test('deleteRaceSubmission DELETEs the submission', async () => {
+  await expect(deleteRaceSubmission(5, UID)).resolves.toBe('DELETE');
+  expect(api.delete).toHaveBeenCalledWith('/api/race-submissions/5', AUTH);
+});
+
+test('getPendingRaceSubmissions GETs the committee review list uncached', async () => {
+  await expect(getPendingRaceSubmissions(UID)).resolves.toBe('GET');
+  expect(api.get).toHaveBeenCalledWith('/api/race-submissions/pending', {}, AUTH, { skipCache: true });
+});
+
+test('reviewRaceSubmission PUTs the decision with note', async () => {
+  await expect(reviewRaceSubmission(5, false, 'link broken', UID)).resolves.toBe('PUT');
+  expect(api.put).toHaveBeenCalledWith(
+    '/api/race-submissions/5/review',
+    { approved: false, review_note: 'link broken' },
+    AUTH
+  );
+});
+
+test('reviewRaceSubmission sends null note when omitted', async () => {
+  await reviewRaceSubmission(5, true, undefined, UID);
+  expect(api.put).toHaveBeenCalledWith(
+    '/api/race-submissions/5/review',
+    { approved: true, review_note: null },
+    AUTH
+  );
+});
+
+test('upsertRacePhoto PUTs the photo for a result', async () => {
+  await expect(upsertRacePhoto(9, 'https://img/x.jpg', UID)).resolves.toBe('PUT');
+  expect(api.put).toHaveBeenCalledWith('/api/race-photos', { result_id: 9, photo_url: 'https://img/x.jpg' }, AUTH);
+});
+
+test('getMyRacePhotos GETs own race photos uncached', async () => {
+  await expect(getMyRacePhotos(UID)).resolves.toBe('GET');
+  expect(api.get).toHaveBeenCalledWith('/api/race-photos/mine', {}, AUTH, { skipCache: true });
+});
+
+test('all helpers reject without a firebase uid', async () => {
+  await expect(createRaceSubmission({}, null)).rejects.toThrow('Firebase UID is required');
+  await expect(getMyRaceSubmissions()).rejects.toThrow('Firebase UID is required');
+  await expect(updateRaceSubmission(1, {}, '')).rejects.toThrow('Firebase UID is required');
+  await expect(deleteRaceSubmission(1, undefined)).rejects.toThrow('Firebase UID is required');
+  await expect(getPendingRaceSubmissions(null)).rejects.toThrow('Firebase UID is required');
+  await expect(reviewRaceSubmission(1, true, null, null)).rejects.toThrow('Firebase UID is required');
+  await expect(upsertRacePhoto(1, 'x', null)).rejects.toThrow('Firebase UID is required');
+  await expect(getMyRacePhotos(null)).rejects.toThrow('Firebase UID is required');
+});

--- a/ProjectCode/client/src/components/AddRaceRecordDialog.js
+++ b/ProjectCode/client/src/components/AddRaceRecordDialog.js
@@ -1,0 +1,289 @@
+/**
+ * AddRaceRecordDialog — member creates a race (name / date / distance /
+ * official-results link), attaches their time + race photo, and submits the
+ * record for NewBee committee review. Also used to edit & resubmit a
+ * pending/rejected submission.
+ */
+import { useEffect, useRef, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControl,
+  Grid,
+  IconButton,
+  InputLabel,
+  MenuItem,
+  Select,
+  TextField,
+  Typography,
+} from '@mui/material';
+import { Close as CloseIcon, CameraAlt as CameraIcon } from '@mui/icons-material';
+import { storage } from '../firebase/config';
+import { ref, uploadBytes, getDownloadURL } from 'firebase/storage';
+import { createRaceSubmission, updateRaceSubmission } from '../api/raceSubmissions';
+
+const ORANGE = '#FFA500';
+const ORANGE_DARK = '#F29400';
+const MUTED = '#757575';
+
+const DISTANCES = ['Marathon', 'Half Marathon', '15K', '10K', '5K', '10M', '5M', '4M', '1M'];
+const OTHER = '__other__';
+const TIME_PATTERN = /^\d{1,2}:\d{2}(:\d{2})?$/;
+
+const emptyForm = {
+  race_name: '',
+  race_date: '',
+  race_distance: 'Marathon',
+  custom_distance: '',
+  finish_time: '',
+  proof_url: '',
+  photo_url: '',
+};
+
+const AddRaceRecordDialog = ({ open, onClose, onSubmitted, firebaseUid, editSubmission }) => {
+  const [form, setForm] = useState(emptyForm);
+  const [error, setError] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [uploadingPhoto, setUploadingPhoto] = useState(false);
+  const fileInputRef = useRef(null);
+
+  useEffect(() => {
+    if (open && editSubmission) {
+      const isKnown = DISTANCES.includes(editSubmission.race_distance);
+      setForm({
+        race_name: editSubmission.race_name || '',
+        race_date: editSubmission.race_date || '',
+        race_distance: isKnown ? editSubmission.race_distance : OTHER,
+        custom_distance: isKnown ? '' : editSubmission.race_distance || '',
+        finish_time: editSubmission.finish_time || '',
+        proof_url: editSubmission.proof_url || '',
+        photo_url: editSubmission.photo_url || '',
+      });
+    } else if (open) {
+      setForm(emptyForm);
+    }
+    setError('');
+  }, [open, editSubmission]);
+
+  const setField = (field) => (event) => {
+    setForm((prev) => ({ ...prev, [field]: event.target.value }));
+  };
+
+  const handlePhotoUpload = async (event) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+    if (!file.type.startsWith('image/')) {
+      setError('Please select an image file. / 请选择图片文件。');
+      return;
+    }
+    if (file.size > 5 * 1024 * 1024) {
+      setError('Image size must be less than 5MB. / 图片大小不能超过5MB。');
+      return;
+    }
+    setUploadingPhoto(true);
+    setError('');
+    try {
+      const storageRef = ref(storage, `race-photos/${firebaseUid}/${Date.now()}_${file.name}`);
+      await uploadBytes(storageRef, file);
+      const url = await getDownloadURL(storageRef);
+      setForm((prev) => ({ ...prev, photo_url: url }));
+    } catch (err) {
+      setError('Failed to upload photo. Please try again. / 照片上传失败，请重试。');
+    } finally {
+      setUploadingPhoto(false);
+      if (fileInputRef.current) fileInputRef.current.value = '';
+    }
+  };
+
+  const handleSubmit = async () => {
+    const distance = form.race_distance === OTHER ? form.custom_distance.trim() : form.race_distance;
+    if (!form.race_name.trim() || !form.race_date || !distance || !form.finish_time.trim()) {
+      setError('Race name, date, distance and finish time are required. / 比赛名称、日期、距离和成绩为必填。');
+      return;
+    }
+    if (!TIME_PATTERN.test(form.finish_time.trim())) {
+      setError('Finish time must be H:MM:SS or MM:SS. / 成绩格式须为 H:MM:SS 或 MM:SS。');
+      return;
+    }
+    if (form.race_date > new Date().toISOString().slice(0, 10)) {
+      setError('Race date cannot be in the future. / 比赛日期不能是未来。');
+      return;
+    }
+
+    setSaving(true);
+    setError('');
+    const payload = {
+      race_name: form.race_name.trim(),
+      race_date: form.race_date,
+      race_distance: distance,
+      finish_time: form.finish_time.trim(),
+      proof_url: form.proof_url.trim() || null,
+      photo_url: form.photo_url || null,
+    };
+    try {
+      if (editSubmission) {
+        await updateRaceSubmission(editSubmission.id, payload, firebaseUid);
+      } else {
+        await createRaceSubmission(payload, firebaseUid);
+      }
+      onSubmitted();
+      onClose();
+    } catch (err) {
+      setError(err.message || 'Failed to submit. Please try again. / 提交失败，请重试。');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>
+        {editSubmission ? 'Edit Race Record / 编辑比赛成绩' : 'Add Race Record / 添加比赛成绩'}
+        <IconButton onClick={onClose} sx={{ position: 'absolute', right: 8, top: 8 }}>
+          <CloseIcon />
+        </IconButton>
+      </DialogTitle>
+      <DialogContent dividers>
+        <Typography sx={{ fontSize: '0.8rem', color: MUTED, mb: 2 }}>
+          Create the race and submit your result with proof. After committee review it is
+          posted to the NewBee leaderboard. / 创建比赛并提交成绩与证明，委员会审核通过后将登上纽蜂排行榜。
+        </Typography>
+        {error && <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>}
+        <Grid container spacing={2}>
+          <Grid item xs={12}>
+            <TextField
+              fullWidth
+              required
+              label="Race Name / 比赛名称"
+              value={form.race_name}
+              onChange={setField('race_name')}
+              placeholder="e.g., Boston Marathon"
+            />
+          </Grid>
+          <Grid item xs={12} sm={6}>
+            <TextField
+              fullWidth
+              required
+              type="date"
+              label="Race Date / 比赛日期"
+              value={form.race_date}
+              onChange={setField('race_date')}
+              InputLabelProps={{ shrink: true }}
+            />
+          </Grid>
+          <Grid item xs={12} sm={6}>
+            <FormControl fullWidth required>
+              <InputLabel>Distance / 距离</InputLabel>
+              <Select
+                value={form.race_distance}
+                onChange={setField('race_distance')}
+                label="Distance / 距离"
+              >
+                {DISTANCES.map((d) => (
+                  <MenuItem key={d} value={d}>{d}</MenuItem>
+                ))}
+                <MenuItem value={OTHER}>Other / 其他</MenuItem>
+              </Select>
+            </FormControl>
+          </Grid>
+          {form.race_distance === OTHER && (
+            <Grid item xs={12} sm={6}>
+              <TextField
+                fullWidth
+                required
+                label="Custom Distance / 自定义距离"
+                value={form.custom_distance}
+                onChange={setField('custom_distance')}
+                placeholder="e.g., 50K"
+              />
+            </Grid>
+          )}
+          <Grid item xs={12} sm={6}>
+            <TextField
+              fullWidth
+              required
+              label="Finish Time / 完赛成绩"
+              value={form.finish_time}
+              onChange={setField('finish_time')}
+              placeholder="3:25:58"
+              helperText="H:MM:SS or MM:SS"
+            />
+          </Grid>
+          <Grid item xs={12}>
+            <TextField
+              fullWidth
+              label="Official Results Link / 官方成绩链接"
+              value={form.proof_url}
+              onChange={setField('proof_url')}
+              placeholder="https://results.example.com/..."
+              helperText="Link to the race's official results page (proof for review) / 官方成绩页链接（审核证明）"
+            />
+          </Grid>
+          <Grid item xs={12}>
+            <input
+              type="file"
+              ref={fileInputRef}
+              onChange={handlePhotoUpload}
+              accept="image/*"
+              style={{ display: 'none' }}
+              data-testid="race-photo-input"
+            />
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+              <Button
+                variant="outlined"
+                startIcon={uploadingPhoto ? <CircularProgress size={14} /> : <CameraIcon />}
+                onClick={() => fileInputRef.current?.click()}
+                disabled={uploadingPhoto}
+                sx={{
+                  textTransform: 'none', fontWeight: 600, borderRadius: '99px',
+                  borderColor: ORANGE, color: ORANGE,
+                  '&:hover': { borderColor: ORANGE_DARK, backgroundColor: '#FFF6E8' },
+                }}
+              >
+                {form.photo_url ? 'Change Race Photo 更换照片' : 'Race Photo 比赛照片 (optional)'}
+              </Button>
+              {form.photo_url && (
+                <Box
+                  component="img"
+                  src={form.photo_url}
+                  alt="Race"
+                  sx={{ width: 72, height: 48, objectFit: 'cover', borderRadius: '8px', border: '1px solid #EEE7DC' }}
+                />
+              )}
+            </Box>
+          </Grid>
+        </Grid>
+      </DialogContent>
+      <DialogActions sx={{ px: 3, py: 2 }}>
+        <Button
+          onClick={onClose}
+          disabled={saving}
+          sx={{ textTransform: 'none', fontWeight: 600, borderRadius: '99px', color: MUTED }}
+        >
+          Cancel / 取消
+        </Button>
+        <Button
+          variant="contained"
+          onClick={handleSubmit}
+          disabled={saving || uploadingPhoto}
+          disableElevation
+          sx={{
+            backgroundColor: ORANGE, textTransform: 'none', fontWeight: 600,
+            borderRadius: '99px', px: 3,
+            '&:hover': { backgroundColor: ORANGE_DARK },
+          }}
+        >
+          {saving ? <CircularProgress size={20} /> : 'Submit for Review / 提交审核'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default AddRaceRecordDialog;

--- a/ProjectCode/client/src/components/AddRaceRecordDialog.test.js
+++ b/ProjectCode/client/src/components/AddRaceRecordDialog.test.js
@@ -1,0 +1,192 @@
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import AddRaceRecordDialog from './AddRaceRecordDialog';
+import { createRaceSubmission, updateRaceSubmission } from '../api/raceSubmissions';
+import { uploadBytes, getDownloadURL } from 'firebase/storage';
+
+jest.mock('../api/raceSubmissions', () => ({
+  createRaceSubmission: jest.fn(),
+  updateRaceSubmission: jest.fn(),
+}));
+
+const onClose = jest.fn();
+const onSubmitted = jest.fn();
+
+const renderDialog = (props = {}) =>
+  render(
+    <AddRaceRecordDialog
+      open
+      onClose={onClose}
+      onSubmitted={onSubmitted}
+      firebaseUid="uid-1"
+      editSubmission={null}
+      {...props}
+    />
+  );
+
+const fillRequired = () => {
+  fireEvent.change(screen.getByLabelText(/Race Name/), { target: { value: 'Boston Marathon' } });
+  fireEvent.change(screen.getByLabelText(/Race Date/), { target: { value: '2026-04-20' } });
+  fireEvent.change(screen.getByLabelText(/Finish Time/), { target: { value: '3:25:58' } });
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  createRaceSubmission.mockResolvedValue({});
+  updateRaceSubmission.mockResolvedValue({});
+  uploadBytes.mockResolvedValue({});
+  getDownloadURL.mockResolvedValue('https://cdn/race.jpg');
+});
+
+test('requires the mandatory fields before submitting', async () => {
+  renderDialog();
+  fireEvent.click(screen.getByRole('button', { name: /Submit for Review/ }));
+  expect(await screen.findByText(/are required/)).toBeInTheDocument();
+  expect(createRaceSubmission).not.toHaveBeenCalled();
+});
+
+test('validates the finish time format', async () => {
+  renderDialog();
+  fillRequired();
+  fireEvent.change(screen.getByLabelText(/Finish Time/), { target: { value: 'fast' } });
+  fireEvent.click(screen.getByRole('button', { name: /Submit for Review/ }));
+  expect(await screen.findByText(/Finish time must be/)).toBeInTheDocument();
+  expect(createRaceSubmission).not.toHaveBeenCalled();
+});
+
+test('rejects a future race date', async () => {
+  renderDialog();
+  fillRequired();
+  fireEvent.change(screen.getByLabelText(/Race Date/), { target: { value: '2099-01-01' } });
+  fireEvent.click(screen.getByRole('button', { name: /Submit for Review/ }));
+  expect(await screen.findByText(/cannot be in the future/)).toBeInTheDocument();
+  expect(createRaceSubmission).not.toHaveBeenCalled();
+});
+
+test('submits a new record and closes', async () => {
+  renderDialog();
+  fillRequired();
+  fireEvent.change(screen.getByLabelText(/Official Results Link/), { target: { value: 'https://baa.org/results' } });
+  fireEvent.click(screen.getByRole('button', { name: /Submit for Review/ }));
+
+  await waitFor(() =>
+    expect(createRaceSubmission).toHaveBeenCalledWith(
+      {
+        race_name: 'Boston Marathon',
+        race_date: '2026-04-20',
+        race_distance: 'Marathon',
+        finish_time: '3:25:58',
+        proof_url: 'https://baa.org/results',
+        photo_url: null,
+      },
+      'uid-1'
+    )
+  );
+  await waitFor(() => expect(onSubmitted).toHaveBeenCalled());
+  expect(onClose).toHaveBeenCalled();
+});
+
+test('custom distance replaces the preset when Other is chosen', async () => {
+  renderDialog();
+  fillRequired();
+
+  fireEvent.mouseDown(screen.getByRole('combobox'));
+  fireEvent.click(within(screen.getByRole('listbox')).getByRole('option', { name: /Other/ }));
+  fireEvent.change(screen.getByLabelText(/Custom Distance/), { target: { value: '50K' } });
+
+  fireEvent.click(screen.getByRole('button', { name: /Submit for Review/ }));
+  await waitFor(() =>
+    expect(createRaceSubmission).toHaveBeenCalledWith(
+      expect.objectContaining({ race_distance: '50K' }),
+      'uid-1'
+    )
+  );
+});
+
+test('shows the API error when submission fails', async () => {
+  createRaceSubmission.mockRejectedValueOnce(new Error('Race date cannot be in the future.'));
+  renderDialog();
+  fillRequired();
+  fireEvent.click(screen.getByRole('button', { name: /Submit for Review/ }));
+  expect(await screen.findByText('Race date cannot be in the future.')).toBeInTheDocument();
+  expect(onClose).not.toHaveBeenCalled();
+});
+
+test('uploads a race photo and includes its URL in the payload', async () => {
+  renderDialog();
+  fillRequired();
+
+  const input = screen.getByTestId('race-photo-input');
+  fireEvent.change(input, { target: { files: [new File(['img'], 'race.jpg', { type: 'image/jpeg' })] } });
+
+  expect(await screen.findByAltText('Race')).toHaveAttribute('src', 'https://cdn/race.jpg');
+  expect(screen.getByRole('button', { name: /Change Race Photo/ })).toBeInTheDocument();
+
+  fireEvent.click(screen.getByRole('button', { name: /Submit for Review/ }));
+  await waitFor(() =>
+    expect(createRaceSubmission).toHaveBeenCalledWith(
+      expect.objectContaining({ photo_url: 'https://cdn/race.jpg' }),
+      'uid-1'
+    )
+  );
+});
+
+test('photo upload validates type and size and surfaces failures', async () => {
+  renderDialog();
+  const input = screen.getByTestId('race-photo-input');
+
+  fireEvent.change(input, { target: { files: [new File(['t'], 'a.txt', { type: 'text/plain' })] } });
+  expect(await screen.findByText(/Please select an image file/)).toBeInTheDocument();
+
+  const big = new File(['x'], 'big.png', { type: 'image/png' });
+  Object.defineProperty(big, 'size', { value: 6 * 1024 * 1024 });
+  fireEvent.change(input, { target: { files: [big] } });
+  expect(await screen.findByText(/Image size must be less than 5MB/)).toBeInTheDocument();
+  expect(uploadBytes).not.toHaveBeenCalled();
+
+  uploadBytes.mockRejectedValueOnce(new Error('storage down'));
+  fireEvent.change(input, { target: { files: [new File(['x'], 'ok.png', { type: 'image/png' })] } });
+  expect(await screen.findByText(/Failed to upload photo/)).toBeInTheDocument();
+});
+
+test('edit mode pre-fills fields (including custom distance) and updates', async () => {
+  renderDialog({
+    editSubmission: {
+      id: 13, race_name: 'Backyard Ultra', race_date: '2025-10-01', race_distance: '50K',
+      finish_time: '5:00:00', proof_url: 'https://ultra/results', photo_url: 'https://img/u.jpg',
+    },
+  });
+
+  expect(screen.getByText('Edit Race Record / 编辑比赛成绩')).toBeInTheDocument();
+  expect(screen.getByLabelText(/Race Name/)).toHaveValue('Backyard Ultra');
+  expect(screen.getByLabelText(/Custom Distance/)).toHaveValue('50K');
+  expect(screen.getByAltText('Race')).toHaveAttribute('src', 'https://img/u.jpg');
+
+  fireEvent.change(screen.getByLabelText(/Finish Time/), { target: { value: '4:59:00' } });
+  fireEvent.click(screen.getByRole('button', { name: /Submit for Review/ }));
+
+  await waitFor(() =>
+    expect(updateRaceSubmission).toHaveBeenCalledWith(
+      13,
+      expect.objectContaining({ finish_time: '4:59:00', photo_url: 'https://img/u.jpg' }),
+      'uid-1'
+    )
+  );
+});
+
+test('edit mode pre-fills preset distances without the custom field', () => {
+  renderDialog({
+    editSubmission: {
+      id: 11, race_name: 'Jersey City Half', race_date: '2026-06-28', race_distance: 'Half Marathon',
+      finish_time: '1:36:40', proof_url: null, photo_url: null,
+    },
+  });
+  expect(screen.queryByLabelText(/Custom Distance/)).not.toBeInTheDocument();
+  expect(screen.getByRole('combobox')).toHaveTextContent('Half Marathon');
+});
+
+test('cancel closes without submitting', () => {
+  renderDialog();
+  fireEvent.click(screen.getByRole('button', { name: /Cancel/ }));
+  expect(onClose).toHaveBeenCalled();
+  expect(createRaceSubmission).not.toHaveBeenCalled();
+});

--- a/ProjectCode/client/src/components/RecordWall.js
+++ b/ProjectCode/client/src/components/RecordWall.js
@@ -1,0 +1,404 @@
+/**
+ * RecordWall — the profile "marathon record wall".
+ *
+ * Personal records hang as medal plaques (member's own race photo behind
+ * each). Poster Mode frames the wall as one shareable image: save as PNG,
+ * print, hang it on a real wall.
+ */
+import { useRef, useState } from 'react';
+import { Alert, Box, Button, Chip, CircularProgress, Typography } from '@mui/material';
+import {
+  Add as AddIcon,
+  CameraAlt as CameraIcon,
+  Download as DownloadIcon,
+  Print as PrintIcon,
+  Wallpaper as WallpaperIcon,
+} from '@mui/icons-material';
+import html2canvas from 'html2canvas';
+
+const ORANGE = '#FFA500';
+const ORANGE_DARK = '#F29400';
+const ORANGE_BG = '#FFF6E8';
+const LINE = '#EEE7DC';
+const INK = '#212121';
+const MUTED = '#757575';
+const GOLD = '#D4A017';
+const GREEN = '#2e7d32';
+const GREEN_BG = '#eaf5ea';
+const BLUE = '#1a63d0';
+const BLUE_BG = '#e8f0fe';
+
+// Order wall plaques longest distance first ("M" = miles in this dataset)
+export function distanceToMeters(distance) {
+  if (!distance) return 0;
+  const d = distance.trim();
+  const lower = d.toLowerCase();
+  if (lower.includes('half')) return 21097.5;
+  if (lower.includes('marathon')) return 42195;
+  const mileShort = d.match(/^(\d+\.?\d*)\s*(m|mi|mile|miles)$/i);
+  if (mileShort) return parseFloat(mileShort[1]) * 1609.34;
+  const km = d.match(/^(\d+\.?\d*)\s*(k|km)$/i);
+  if (km) return parseFloat(km[1]) * 1000;
+  const num = parseFloat(d);
+  return isNaN(num) ? 0 : num * 1000;
+}
+
+const DISTANCE_CN = {
+  'Marathon': '全程马拉松',
+  'Half Marathon': '半程马拉松',
+};
+
+// Source chip on each plaque
+const SourceChip = ({ entry }) => {
+  if (entry.pending) {
+    return (
+      <Chip
+        label="⧗ Pending Review 待审核"
+        size="small"
+        sx={{
+          backgroundColor: ORANGE_BG, color: ORANGE_DARK, fontWeight: 700,
+          fontSize: '0.65rem', height: 20, border: `1px dashed ${ORANGE}`, borderRadius: '99px',
+        }}
+      />
+    );
+  }
+  if (entry.onLeaderboard) {
+    return (
+      <Chip
+        label="✓ On Leaderboard 已上榜"
+        size="small"
+        sx={{
+          backgroundColor: GREEN_BG, color: GREEN, fontWeight: 700,
+          fontSize: '0.65rem', height: 20, borderRadius: '99px',
+        }}
+      />
+    );
+  }
+  return (
+    <Chip
+      label="NYRR Synced"
+      size="small"
+      sx={{
+        backgroundColor: BLUE_BG, color: BLUE, fontWeight: 700,
+        fontSize: '0.65rem', height: 20, borderRadius: '99px',
+      }}
+    />
+  );
+};
+
+// One medal plaque hanging on the wall
+const MedalPlaque = ({ entry, featured, posterMode, onChangePhoto }) => (
+  <Box
+    data-testid="medal-plaque"
+    sx={{
+      position: 'relative',
+      backgroundColor: 'white',
+      border: entry.pending ? `1.5px dashed ${ORANGE}` : `1px solid ${LINE}`,
+      borderRadius: '14px',
+      textAlign: 'center',
+      pb: 2,
+      overflow: 'hidden',
+      boxShadow: '0 3px 8px rgba(0,0,0,0.08)',
+      transition: 'all 0.25s ease',
+      '&:hover': posterMode ? {} : {
+        transform: 'translateY(-5px)',
+        boxShadow: '0 12px 28px rgba(255,165,0,0.35)',
+      },
+      '&:hover .race-photo-cam': { opacity: 1 },
+    }}
+  >
+    {/* photo from that race */}
+    <Box
+      sx={{
+        height: 128,
+        backgroundImage: entry.photoUrl ? `url("${entry.photoUrl}")` : 'none',
+        backgroundColor: entry.photoUrl ? 'transparent' : ORANGE_BG,
+        backgroundSize: 'cover',
+        backgroundPosition: 'center',
+        borderBottom: `2.5px solid ${ORANGE}`,
+        position: 'relative',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      {!entry.photoUrl && !posterMode && (
+        <Typography sx={{ fontSize: '0.75rem', color: ORANGE_DARK, fontWeight: 600, mt: 3 }}>
+          📷 Add your race photo 添加照片
+        </Typography>
+      )}
+      {!posterMode && (
+        <Button
+          className="race-photo-cam"
+          size="small"
+          startIcon={<CameraIcon sx={{ fontSize: 14 }} />}
+          onClick={() => onChangePhoto(entry)}
+          sx={{
+            position: 'absolute', right: 8, bottom: 8,
+            backgroundColor: 'rgba(0,0,0,0.6)', color: 'white',
+            fontSize: '0.65rem', fontWeight: 600, textTransform: 'none',
+            borderRadius: '99px', px: 1.25, py: 0.25, minWidth: 0,
+            opacity: { xs: 1, md: 0 },
+            transition: 'opacity 0.2s',
+            '&:hover': { backgroundColor: 'rgba(0,0,0,0.75)' },
+          }}
+        >
+          {entry.photoUrl ? 'Change 更换' : 'Add 添加'}
+        </Button>
+      )}
+    </Box>
+
+    {/* hanging ribbon */}
+    <Box sx={{ position: 'absolute', top: -2, left: '50%', transform: 'translateX(-50%)', width: 54, height: 40, zIndex: 2 }}>
+      <Box sx={{
+        position: 'absolute', top: 0, left: 2, width: 20, height: 38,
+        background: `linear-gradient(${ORANGE}, ${ORANGE_DARK})`,
+        transform: 'skewX(-14deg)', borderRadius: '0 0 4px 4px',
+      }} />
+      <Box sx={{
+        position: 'absolute', top: 0, right: 2, width: 20, height: 38,
+        background: `linear-gradient(${ORANGE}, ${ORANGE_DARK})`,
+        transform: 'skewX(14deg)', borderRadius: '0 0 4px 4px',
+      }} />
+    </Box>
+    {/* medal disc */}
+    <Box sx={{
+      position: 'absolute', top: 26, left: '50%', transform: 'translateX(-50%)',
+      width: 40, height: 40, borderRadius: '50%',
+      background: featured
+        ? 'radial-gradient(circle at 35% 30%, #ffd77a, #D4A017)'
+        : entry.pending
+          ? 'radial-gradient(circle at 35% 30%, #f2f2f2, #b9b9b9)'
+          : 'radial-gradient(circle at 35% 30%, #ffd77a, #D4A017)',
+      border: '2.5px solid white',
+      boxShadow: '0 2px 6px rgba(0,0,0,0.25)',
+      display: 'flex', alignItems: 'center', justifyContent: 'center',
+      fontSize: 17, zIndex: 3,
+    }}>
+      {featured ? '🏆' : entry.pending ? '⏱' : '🥇'}
+    </Box>
+
+    <Typography sx={{
+      mt: 2, fontSize: '0.7rem', fontWeight: 700, letterSpacing: 2.5,
+      color: MUTED, textTransform: 'uppercase',
+    }}>
+      {entry.distance}
+    </Typography>
+    <Typography sx={{ fontSize: '0.68rem', color: MUTED }}>
+      {DISTANCE_CN[entry.distance] || ' '}
+    </Typography>
+    <Typography sx={{
+      fontSize: featured ? '2.6rem' : '2.2rem', fontWeight: 800, lineHeight: 1.1,
+      color: featured ? ORANGE_DARK : INK, fontVariantNumeric: 'tabular-nums', my: 0.5,
+    }}>
+      {entry.time}
+    </Typography>
+    <Typography sx={{ fontSize: '0.78rem', fontWeight: 500, color: '#444', px: 1.5 }}>
+      {entry.race}
+    </Typography>
+    <Typography sx={{ fontSize: '0.7rem', color: MUTED }}>
+      {entry.date}{entry.pace ? ` · Pace ${entry.pace}` : ''}
+    </Typography>
+    <Box sx={{ mt: 1, display: 'flex', justifyContent: 'center', gap: 0.5, flexWrap: 'wrap', px: 1 }}>
+      <SourceChip entry={entry} />
+    </Box>
+  </Box>
+);
+
+const RecordWall = ({
+  memberName,
+  memberNameCn,
+  totalRaces,
+  prEntries,          // [{distance, time, race, date, pace, photoUrl, onLeaderboard, resultId}]
+  pendingEntries,     // [{distance, time, race, date, pace, photoUrl, pending:true, submissionId}]
+  onAddRecord,
+  onChangePhoto,
+}) => {
+  const wallRef = useRef(null);
+  const [posterMode, setPosterMode] = useState(false);
+  const [exporting, setExporting] = useState(false);
+  const [exportError, setExportError] = useState('');
+
+  const sorted = [...prEntries].sort(
+    (a, b) => distanceToMeters(b.distance) - distanceToMeters(a.distance)
+  );
+  const entries = [...sorted, ...pendingEntries];
+  const featuredKey = sorted.length > 0 ? `${sorted[0].distance}|${sorted[0].time}` : null;
+
+  const renderToCanvas = async () => {
+    return html2canvas(wallRef.current, {
+      useCORS: true,
+      backgroundColor: '#FBF8F2',
+      scale: 2,
+    });
+  };
+
+  const handleSaveImage = async () => {
+    setExporting(true);
+    setExportError('');
+    try {
+      const canvas = await renderToCanvas();
+      const link = document.createElement('a');
+      link.download = 'newbee-record-wall.png';
+      link.href = canvas.toDataURL('image/png');
+      link.click();
+    } catch (err) {
+      setExportError('Failed to export image. Please try again. / 导出图片失败，请重试。');
+    } finally {
+      setExporting(false);
+    }
+  };
+
+  const handlePrint = async () => {
+    setExporting(true);
+    setExportError('');
+    try {
+      const canvas = await renderToCanvas();
+      const printWindow = window.open('', '_blank');
+      if (printWindow) {
+        printWindow.document.write(
+          `<img src="${canvas.toDataURL('image/png')}" style="max-width:100%" onload="window.print()" />`
+        );
+        printWindow.document.close();
+      }
+    } catch (err) {
+      setExportError('Failed to prepare print view. Please try again. / 打印准备失败，请重试。');
+    } finally {
+      setExporting(false);
+    }
+  };
+
+  return (
+    <Box>
+      {/* poster action bar */}
+      <Box sx={{ display: 'flex', gap: 1, alignItems: 'center', flexWrap: 'wrap', mb: 2 }}>
+        <Button
+          variant={posterMode ? 'contained' : 'outlined'}
+          startIcon={<WallpaperIcon />}
+          onClick={() => setPosterMode(!posterMode)}
+          disableElevation
+          sx={{
+            textTransform: 'none', fontWeight: 600, borderRadius: '99px',
+            ...(posterMode
+              ? { backgroundColor: ORANGE, '&:hover': { backgroundColor: ORANGE_DARK } }
+              : { borderColor: ORANGE, color: ORANGE, '&:hover': { borderColor: ORANGE_DARK, backgroundColor: ORANGE_BG } }),
+          }}
+        >
+          Poster Mode 海报模式
+        </Button>
+        <Button
+          startIcon={exporting ? <CircularProgress size={14} /> : <DownloadIcon />}
+          onClick={handleSaveImage}
+          disabled={exporting || entries.length === 0}
+          sx={{ textTransform: 'none', fontWeight: 600, borderRadius: '99px', color: ORANGE, '&:hover': { backgroundColor: ORANGE_BG } }}
+        >
+          Save as Image 保存图片
+        </Button>
+        <Button
+          startIcon={<PrintIcon />}
+          onClick={handlePrint}
+          disabled={exporting || entries.length === 0}
+          sx={{ textTransform: 'none', fontWeight: 600, borderRadius: '99px', color: ORANGE, '&:hover': { backgroundColor: ORANGE_BG } }}
+        >
+          Print 打印
+        </Button>
+        <Typography sx={{ fontSize: '0.75rem', color: MUTED }}>
+          One image — frame it or share it to WeChat Moments 一张图，装裱上墙或分享朋友圈
+        </Typography>
+      </Box>
+      {exportError && <Alert severity="error" sx={{ mb: 2 }}>{exportError}</Alert>}
+
+      {/* the wall (export target) */}
+      <Box
+        ref={wallRef}
+        data-testid="record-wall"
+        sx={{
+          transition: 'all 0.3s ease',
+          ...(posterMode && {
+            border: '16px solid #1b1611',
+            outline: `3px solid ${GOLD}`,
+            outlineOffset: '-22px',
+            borderRadius: '4px',
+            p: { xs: 2.5, sm: 3.5 },
+            backgroundColor: '#FBF8F2',
+            boxShadow: '0 24px 60px rgba(0,0,0,0.4)',
+          }),
+        }}
+      >
+        {posterMode && (
+          <Box sx={{ textAlign: 'center', mb: 2.5 }}>
+            <Typography sx={{ fontSize: '1.5rem', fontWeight: 800, letterSpacing: 4, color: INK }}>
+              {memberName}
+              {memberNameCn ? <Box component="span" sx={{ color: ORANGE_DARK }}> · {memberNameCn}</Box> : null}
+            </Typography>
+            <Typography sx={{ fontSize: '0.72rem', color: MUTED, letterSpacing: 2, mt: 0.5 }}>
+              MY RECORD WALL 我的纪录墙 · {totalRaces} RACES · NEWBEE RUNNING CLUB
+            </Typography>
+          </Box>
+        )}
+
+        <Box
+          sx={{
+            backgroundColor: '#FBF8F2',
+            backgroundImage: 'radial-gradient(circle, #efe9dd 1px, transparent 1px)',
+            backgroundSize: '22px 22px',
+            border: posterMode ? 'none' : `1px solid ${LINE}`,
+            borderRadius: posterMode ? 0 : '16px',
+            p: { xs: 2, sm: 3.5 },
+            display: 'grid',
+            gridTemplateColumns: { xs: '1fr', sm: 'repeat(2, 1fr)', md: 'repeat(3, 1fr)' },
+            gap: 2.5,
+          }}
+        >
+          {entries.length === 0 && (
+            <Box sx={{ gridColumn: '1 / -1', textAlign: 'center', py: 4 }}>
+              <Typography sx={{ color: MUTED }}>
+                Your wall is waiting for its first medal. / 你的纪录墙在等待第一块奖牌。
+              </Typography>
+            </Box>
+          )}
+          {entries.map((entry) => (
+            <MedalPlaque
+              key={entry.submissionId ? `sub-${entry.submissionId}` : `pr-${entry.distance}|${entry.time}`}
+              entry={entry}
+              featured={!entry.pending && `${entry.distance}|${entry.time}` === featuredKey}
+              posterMode={posterMode}
+              onChangePhoto={onChangePhoto}
+            />
+          ))}
+          {!posterMode && (
+            <Box
+              data-testid="add-record-plaque"
+              onClick={onAddRecord}
+              sx={{
+                border: '2px dashed #d9d0bf', borderRadius: '14px', minHeight: 300,
+                display: 'flex', flexDirection: 'column', alignItems: 'center',
+                justifyContent: 'center', cursor: 'pointer', color: MUTED,
+                transition: 'all 0.2s',
+                '&:hover': { borderColor: ORANGE, color: ORANGE },
+              }}
+            >
+              <AddIcon sx={{ fontSize: 34, mb: 1 }} />
+              <Typography sx={{ fontWeight: 700, fontSize: '0.85rem' }}>
+                Add a record 添加成绩
+              </Typography>
+              <Typography sx={{ fontSize: '0.72rem', mt: 0.5, textAlign: 'center', px: 2 }}>
+                Race outside NYRR? Create the race & submit for review
+                <br />
+                创建比赛并提交审核
+              </Typography>
+            </Box>
+          )}
+        </Box>
+
+        {posterMode && (
+          <Typography sx={{ textAlign: 'center', mt: 2.5, fontSize: '0.7rem', color: MUTED, letterSpacing: 2 }}>
+            NEWBEERUNNINGCLUB.ORG · 纽蜂跑团
+          </Typography>
+        )}
+      </Box>
+    </Box>
+  );
+};
+
+export default RecordWall;

--- a/ProjectCode/client/src/components/RecordWall.test.js
+++ b/ProjectCode/client/src/components/RecordWall.test.js
@@ -1,0 +1,152 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import RecordWall, { distanceToMeters } from './RecordWall';
+import html2canvas from 'html2canvas';
+
+jest.mock('html2canvas', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+const prEntries = [
+  { distance: '5K', time: '0:20:00', race: 'Alpha 5K', date: '2024-01-01', pace: '6:26', resultId: 1, photoUrl: null, onLeaderboard: false, photoTarget: { type: 'result', id: 1 } },
+  { distance: 'Marathon', time: '3:25:58', race: 'Boston Marathon', date: '2026-04-20', pace: '7:52', resultId: 4, photoUrl: 'https://img/boston.jpg', onLeaderboard: true, photoTarget: { type: 'submission', id: 12 } },
+];
+
+const pendingEntries = [
+  { distance: 'Half Marathon', time: '1:36:40', race: 'Jersey City Half', date: '2026-06-28', pace: '07:23', pending: true, submissionId: 11, photoUrl: null, photoTarget: { type: 'submission', id: 11 } },
+];
+
+const defaultProps = {
+  memberName: 'Speedy',
+  memberNameCn: '飞毛腿',
+  totalRaces: 8,
+  prEntries,
+  pendingEntries,
+  onAddRecord: jest.fn(),
+  onChangePhoto: jest.fn(),
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  html2canvas.mockResolvedValue({ toDataURL: () => 'data:image/png;base64,MOCK' });
+});
+
+describe('distanceToMeters', () => {
+  test('parses known distance formats', () => {
+    expect(distanceToMeters('Marathon')).toBe(42195);
+    expect(distanceToMeters('Half Marathon')).toBe(21097.5);
+    expect(distanceToMeters('5K')).toBe(5000);
+    expect(distanceToMeters('10 km')).toBe(10000);
+    expect(distanceToMeters('10M')).toBeCloseTo(16093.4);
+    expect(distanceToMeters('4 miles')).toBeCloseTo(6437.36);
+    expect(distanceToMeters('8.5')).toBe(8500);
+    expect(distanceToMeters('weird')).toBe(0);
+    expect(distanceToMeters('')).toBe(0);
+    expect(distanceToMeters(null)).toBe(0);
+  });
+});
+
+test('renders plaques longest distance first with featured styling and chips', () => {
+  render(<RecordWall {...defaultProps} />);
+
+  const plaques = screen.getAllByTestId('medal-plaque');
+  expect(plaques).toHaveLength(3); // 2 PRs + 1 pending
+  // Marathon (longest) is first and featured
+  expect(plaques[0]).toHaveTextContent('Marathon'); // uppercased via CSS
+  expect(plaques[0]).toHaveTextContent('3:25:58');
+  expect(plaques[0]).toHaveTextContent('🏆');
+  expect(plaques[0]).toHaveTextContent('On Leaderboard 已上榜');
+  // 5K second, NYRR chip
+  expect(plaques[1]).toHaveTextContent('0:20:00');
+  expect(plaques[1]).toHaveTextContent('NYRR Synced');
+  // Pending plaque last
+  expect(plaques[2]).toHaveTextContent('Jersey City Half');
+  expect(plaques[2]).toHaveTextContent('Pending Review 待审核');
+  // No-photo hint appears on plaques without a photo
+  expect(screen.getAllByText(/Add your race photo/).length).toBe(2);
+});
+
+test('empty wall shows the waiting message and disables export buttons', () => {
+  render(<RecordWall {...defaultProps} prEntries={[]} pendingEntries={[]} />);
+  expect(screen.getByText(/Your wall is waiting for its first medal/)).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: /Save as Image/ })).toBeDisabled();
+  expect(screen.getByRole('button', { name: /Print/ })).toBeDisabled();
+});
+
+test('add-record plaque and photo buttons invoke callbacks', () => {
+  render(<RecordWall {...defaultProps} />);
+
+  fireEvent.click(screen.getByTestId('add-record-plaque'));
+  expect(defaultProps.onAddRecord).toHaveBeenCalled();
+
+  fireEvent.click(screen.getAllByRole('button', { name: /Add 添加|Change 更换/ })[0]);
+  expect(defaultProps.onChangePhoto).toHaveBeenCalledWith(
+    expect.objectContaining({ distance: 'Marathon' })
+  );
+});
+
+test('poster mode adds framed header/footer and hides editing affordances', () => {
+  render(<RecordWall {...defaultProps} />);
+
+  fireEvent.click(screen.getByRole('button', { name: /Poster Mode/ }));
+  expect(screen.getByText('Speedy')).toBeInTheDocument();
+  expect(screen.getByText(/· 飞毛腿/)).toBeInTheDocument();
+  expect(screen.getByText(/MY RECORD WALL 我的纪录墙 · 8 RACES/)).toBeInTheDocument();
+  expect(screen.getByText(/NEWBEERUNNINGCLUB.ORG/)).toBeInTheDocument();
+  // No add plaque or camera buttons in poster mode
+  expect(screen.queryByTestId('add-record-plaque')).not.toBeInTheDocument();
+  expect(screen.queryByRole('button', { name: /Add 添加|Change 更换/ })).not.toBeInTheDocument();
+
+  // Toggle back off
+  fireEvent.click(screen.getByRole('button', { name: /Poster Mode/ }));
+  expect(screen.queryByText(/NEWBEERUNNINGCLUB.ORG/)).not.toBeInTheDocument();
+  expect(screen.getByTestId('add-record-plaque')).toBeInTheDocument();
+});
+
+test('save as image renders the wall to a canvas and downloads it', async () => {
+  const clickSpy = jest.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
+  render(<RecordWall {...defaultProps} />);
+
+  fireEvent.click(screen.getByRole('button', { name: /Save as Image/ }));
+
+  await waitFor(() => expect(html2canvas).toHaveBeenCalledWith(
+    screen.getByTestId('record-wall'),
+    expect.objectContaining({ useCORS: true, scale: 2 })
+  ));
+  await waitFor(() => expect(clickSpy).toHaveBeenCalled());
+  clickSpy.mockRestore();
+});
+
+test('save as image failure shows an error alert', async () => {
+  html2canvas.mockRejectedValueOnce(new Error('canvas boom'));
+  render(<RecordWall {...defaultProps} />);
+
+  fireEvent.click(screen.getByRole('button', { name: /Save as Image/ }));
+  expect(await screen.findByText(/Failed to export image/)).toBeInTheDocument();
+});
+
+test('print renders the wall into a new window', async () => {
+  const write = jest.fn();
+  const close = jest.fn();
+  const openSpy = jest.spyOn(window, 'open').mockReturnValue({ document: { write, close } });
+  render(<RecordWall {...defaultProps} />);
+
+  fireEvent.click(screen.getByRole('button', { name: /Print/ }));
+
+  await waitFor(() => expect(write).toHaveBeenCalledWith(expect.stringContaining('data:image/png;base64,MOCK')));
+  expect(close).toHaveBeenCalled();
+  openSpy.mockRestore();
+});
+
+test('print tolerates a blocked popup and canvas failure', async () => {
+  const openSpy = jest.spyOn(window, 'open').mockReturnValue(null);
+  render(<RecordWall {...defaultProps} />);
+  fireEvent.click(screen.getByRole('button', { name: /Print/ }));
+  await waitFor(() => expect(html2canvas).toHaveBeenCalled());
+  await waitFor(() => expect(screen.getByRole('button', { name: /Print/ })).toBeEnabled());
+
+  html2canvas.mockRejectedValueOnce(new Error('boom'));
+  fireEvent.click(screen.getByRole('button', { name: /Print/ }));
+  expect(await screen.findByText(/Failed to prepare print view/)).toBeInTheDocument();
+  openSpy.mockRestore();
+});

--- a/ProjectCode/client/src/components/SubmissionsTracker.js
+++ b/ProjectCode/client/src/components/SubmissionsTracker.js
@@ -1,0 +1,190 @@
+/**
+ * SubmissionsTracker — "My Submissions" with a live 4-step progress tracker
+ * per race-record submission:
+ * Submitted → Committee Review → Approved → On Leaderboard.
+ */
+import { Box, Button, Chip, Link, Typography } from '@mui/material';
+import {
+  Check as CheckIcon,
+  Close as CloseIcon,
+  Edit as EditIcon,
+  DeleteOutline as DeleteIcon,
+} from '@mui/icons-material';
+
+const ORANGE = '#FFA500';
+const ORANGE_BG = '#FFF6E8';
+const ORANGE_DARK = '#F29400';
+const LINE = '#EEE7DC';
+const MUTED = '#757575';
+const GREEN = '#2e7d32';
+const GREEN_BG = '#eaf5ea';
+const RED = '#c62828';
+const RED_BG = '#fdecea';
+
+const STEPS = [
+  { en: 'Submitted', cn: '已提交' },
+  { en: 'Committee Review', cn: '委员会审核' },
+  { en: 'Approved', cn: '批准' },
+  { en: 'On Leaderboard', cn: '上榜' },
+];
+
+// Step index reached per status (rejected stops at review)
+function progressFor(status) {
+  if (status === 'approved') return 4;
+  if (status === 'rejected') return 2;
+  return 1; // pending: submitted done, review in progress
+}
+
+const StepDot = ({ state, index }) => {
+  const styles = {
+    done: { borderColor: GREEN, backgroundColor: GREEN_BG, color: GREEN },
+    now: { borderColor: ORANGE, backgroundColor: ORANGE_BG, color: ORANGE_DARK },
+    rejected: { borderColor: RED, backgroundColor: RED_BG, color: RED },
+    todo: { borderColor: '#ddd', backgroundColor: 'white', color: MUTED },
+  }[state];
+  return (
+    <Box sx={{
+      width: 26, height: 26, borderRadius: '50%', border: '2px solid',
+      display: 'flex', alignItems: 'center', justifyContent: 'center',
+      fontSize: '0.7rem', fontWeight: 700, flexShrink: 0,
+      ...styles,
+    }}>
+      {state === 'done' ? <CheckIcon sx={{ fontSize: 14 }} />
+        : state === 'rejected' ? <CloseIcon sx={{ fontSize: 14 }} />
+        : index + 1}
+    </Box>
+  );
+};
+
+const StatusChip = ({ status }) => {
+  const config = {
+    pending: { label: '⧗ In review 审核中', sx: { backgroundColor: ORANGE_BG, color: ORANGE_DARK, border: `1px dashed ${ORANGE}` } },
+    approved: { label: '✓ On Leaderboard 已上榜', sx: { backgroundColor: GREEN_BG, color: GREEN } },
+    rejected: { label: '✕ Rejected 已拒绝', sx: { backgroundColor: RED_BG, color: RED } },
+  }[status] || { label: status, sx: {} };
+  return (
+    <Chip
+      label={config.label}
+      size="small"
+      sx={{ fontWeight: 700, fontSize: '0.68rem', height: 22, borderRadius: '99px', ...config.sx }}
+    />
+  );
+};
+
+const SubmissionCard = ({ submission, onEdit, onWithdraw }) => {
+  const progress = progressFor(submission.status);
+  const rejected = submission.status === 'rejected';
+
+  return (
+    <Box
+      data-testid="submission-card"
+      sx={{
+        border: submission.status === 'pending' ? `1.5px dashed ${ORANGE}` : `1px solid ${LINE}`,
+        backgroundColor: submission.status === 'pending' ? '#FFFDF8' : 'white',
+        borderRadius: '12px', p: 2.5, mb: 2,
+        boxShadow: '0 2px 4px rgba(0,0,0,0.06)',
+      }}
+    >
+      <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 1.25, flexWrap: 'wrap' }}>
+        <Typography sx={{ fontWeight: 700, fontSize: '0.95rem' }}>{submission.race_name}</Typography>
+        <Typography sx={{ fontWeight: 700, color: ORANGE_DARK, fontVariantNumeric: 'tabular-nums' }}>
+          {submission.finish_time}
+        </Typography>
+        <Typography sx={{ fontSize: '0.75rem', color: MUTED }}>
+          {submission.race_distance} · {submission.race_date}
+        </Typography>
+        <StatusChip status={submission.status} />
+        <Box sx={{ marginLeft: 'auto', display: 'flex', gap: 0.5 }}>
+          {submission.status !== 'approved' && (
+            <>
+              <Button
+                size="small"
+                startIcon={<EditIcon sx={{ fontSize: 14 }} />}
+                onClick={() => onEdit(submission)}
+                sx={{ textTransform: 'none', fontWeight: 600, fontSize: '0.72rem', color: ORANGE, minWidth: 0 }}
+              >
+                {rejected ? 'Edit & resubmit 修改重交' : 'Edit 编辑'}
+              </Button>
+              <Button
+                size="small"
+                startIcon={<DeleteIcon sx={{ fontSize: 14 }} />}
+                onClick={() => onWithdraw(submission)}
+                sx={{ textTransform: 'none', fontWeight: 600, fontSize: '0.72rem', color: MUTED, minWidth: 0 }}
+              >
+                Withdraw 撤回
+              </Button>
+            </>
+          )}
+        </Box>
+      </Box>
+
+      <Typography sx={{ fontSize: '0.75rem', color: MUTED, mt: 0.5 }}>
+        {submission.proof_url ? (
+          <>
+            Proof 证明:{' '}
+            <Link href={submission.proof_url} target="_blank" rel="noopener noreferrer" sx={{ color: '#1a63d0' }}>
+              official results ↗
+            </Link>
+          </>
+        ) : (
+          'No proof link attached 未附证明链接'
+        )}
+        {submission.status === 'approved' && ' · visible on the club Records page 🎉'}
+      </Typography>
+      {rejected && submission.review_note && (
+        <Typography sx={{ fontSize: '0.78rem', color: RED, mt: 0.5 }}>
+          Committee note 审核备注: {submission.review_note}
+        </Typography>
+      )}
+
+      {/* 4-step tracker */}
+      <Box sx={{ display: 'flex', alignItems: 'flex-start', mt: 2 }}>
+        {STEPS.map((step, i) => {
+          let state = 'todo';
+          if (i < progress) state = 'done';
+          if (submission.status === 'pending' && i === 1) state = 'now';
+          if (rejected && i === 1) state = 'rejected';
+          const barDone = i + 1 < progress;
+          return (
+            <Box key={step.en} sx={{ display: 'flex', alignItems: 'flex-start', flex: i < STEPS.length - 1 ? 1 : 'none' }}>
+              <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 0.5, width: 92, textAlign: 'center' }}>
+                <StepDot state={state} index={i} />
+                <Typography sx={{
+                  fontSize: '0.62rem', lineHeight: 1.3,
+                  fontWeight: state === 'now' ? 700 : 400,
+                  color: state === 'done' ? GREEN : state === 'now' ? ORANGE_DARK : state === 'rejected' ? RED : MUTED,
+                }}>
+                  {rejected && i === 1 ? 'Rejected 已拒绝' : `${step.en} ${step.cn}`}
+                </Typography>
+              </Box>
+              {i < STEPS.length - 1 && (
+                <Box sx={{
+                  flex: 1, height: '2.5px', mt: '12px', mx: -2,
+                  backgroundColor: barDone ? GREEN : '#e8e2d5',
+                }} />
+              )}
+            </Box>
+          );
+        })}
+      </Box>
+    </Box>
+  );
+};
+
+const SubmissionsTracker = ({ submissions, onEdit, onWithdraw }) => {
+  if (!submissions || submissions.length === 0) return null;
+  return (
+    <Box>
+      {submissions.map((submission) => (
+        <SubmissionCard
+          key={submission.id}
+          submission={submission}
+          onEdit={onEdit}
+          onWithdraw={onWithdraw}
+        />
+      ))}
+    </Box>
+  );
+};
+
+export default SubmissionsTracker;

--- a/ProjectCode/client/src/components/SubmissionsTracker.test.js
+++ b/ProjectCode/client/src/components/SubmissionsTracker.test.js
@@ -1,0 +1,73 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import SubmissionsTracker from './SubmissionsTracker';
+
+const pending = {
+  id: 11, race_name: 'Jersey City Half', race_date: '2026-06-28', race_distance: 'Half Marathon',
+  finish_time: '1:36:40', proof_url: 'https://jch/results', status: 'pending', review_note: null,
+};
+const approved = {
+  id: 12, race_name: 'Boston Marathon', race_date: '2026-04-20', race_distance: 'Marathon',
+  finish_time: '3:25:58', proof_url: null, status: 'approved', review_note: null,
+};
+const rejected = {
+  id: 13, race_name: 'Backyard Ultra', race_date: '2025-10-01', race_distance: '50K',
+  finish_time: '5:00:00', proof_url: null, status: 'rejected', review_note: 'no proof attached',
+};
+
+const onEdit = jest.fn();
+const onWithdraw = jest.fn();
+
+beforeEach(() => jest.clearAllMocks());
+
+const renderTracker = (submissions) =>
+  render(<SubmissionsTracker submissions={submissions} onEdit={onEdit} onWithdraw={onWithdraw} />);
+
+test('renders nothing when there are no submissions', () => {
+  const { container } = renderTracker([]);
+  expect(container).toBeEmptyDOMElement();
+  const { container: c2 } = render(
+    <SubmissionsTracker submissions={null} onEdit={onEdit} onWithdraw={onWithdraw} />
+  );
+  expect(c2).toBeEmptyDOMElement();
+});
+
+test('pending submission shows in-review status, proof link and edit/withdraw', () => {
+  renderTracker([pending]);
+
+  expect(screen.getByText('Jersey City Half')).toBeInTheDocument();
+  expect(screen.getByText('1:36:40')).toBeInTheDocument();
+  expect(screen.getByText(/In review 审核中/)).toBeInTheDocument();
+  expect(screen.getByRole('link', { name: /official results/ })).toHaveAttribute('href', 'https://jch/results');
+  // Step 2 (committee review) is the active step
+  expect(screen.getByText(/Committee Review/)).toBeInTheDocument();
+
+  fireEvent.click(screen.getByRole('button', { name: /Edit 编辑/ }));
+  expect(onEdit).toHaveBeenCalledWith(pending);
+  fireEvent.click(screen.getByRole('button', { name: /Withdraw 撤回/ }));
+  expect(onWithdraw).toHaveBeenCalledWith(pending);
+});
+
+test('approved submission shows all steps done and no edit buttons', () => {
+  renderTracker([approved]);
+
+  expect(screen.getByText(/On Leaderboard 已上榜/)).toBeInTheDocument();
+  expect(screen.getByText(/visible on the club Records page/)).toBeInTheDocument();
+  expect(screen.getByText(/No proof link attached/)).toBeInTheDocument();
+  expect(screen.queryByRole('button', { name: /Edit/ })).not.toBeInTheDocument();
+  expect(screen.queryByRole('button', { name: /Withdraw/ })).not.toBeInTheDocument();
+});
+
+test('rejected submission shows the note and edit & resubmit', () => {
+  renderTracker([rejected]);
+
+  // Chip + step label both read "Rejected 已拒绝"
+  expect(screen.getAllByText(/Rejected 已拒绝/).length).toBeGreaterThanOrEqual(2);
+  expect(screen.getByText(/no proof attached/)).toBeInTheDocument();
+  fireEvent.click(screen.getByRole('button', { name: /Edit & resubmit/ }));
+  expect(onEdit).toHaveBeenCalledWith(rejected);
+});
+
+test('renders one card per submission', () => {
+  renderTracker([pending, approved, rejected]);
+  expect(screen.getAllByTestId('submission-card')).toHaveLength(3);
+});

--- a/ProjectCode/client/src/pages/AdminPanelPage.js
+++ b/ProjectCode/client/src/pages/AdminPanelPage.js
@@ -46,6 +46,7 @@ import { getDonationSummary } from '../api/donors';
 import { getAllBanners, createBanner, updateBanner, deleteBanner } from '../api/banners';
 import { getAllSections, createSection, updateSection, deleteSection } from '../api/homepageSections';
 import { getPendingActivities, verifyActivity, getMemberActivities } from '../api/activities';
+import { getPendingRaceSubmissions, reviewRaceSubmission } from '../api/raceSubmissions';
 import { getSettingsByCategory, updateSetting } from '../api/settings';
 import { useSocialLinks } from '../context';
 import { committeeMembers } from '../data/committeeMembers';
@@ -64,6 +65,7 @@ import ViewModuleIcon from '@mui/icons-material/ViewModule';
 import DirectionsRunIcon from '@mui/icons-material/DirectionsRun';
 import AdminPanelSettingsIcon from '@mui/icons-material/AdminPanelSettings';
 import AttachMoneyIcon from '@mui/icons-material/AttachMoney';
+import EmojiEventsIcon from '@mui/icons-material/EmojiEvents';
 import GroupsIcon from '@mui/icons-material/Groups';
 
 const ORANGE = '#FFA500';
@@ -143,6 +145,11 @@ export default function AdminPanelPage() {
   const [editMemberDialogOpen, setEditMemberDialogOpen] = useState(false);
   const [editingMember, setEditingMember] = useState(null);
   const [editMemberFormData, setEditMemberFormData] = useState({});
+
+  // Race record submission review state
+  const [pendingSubmissions, setPendingSubmissions] = useState([]);
+  const [rejectSubmissionDialog, setRejectSubmissionDialog] = useState(null); // submission being rejected
+  const [rejectSubmissionNote, setRejectSubmissionNote] = useState('');
 
   // Activity verification state
   const [pendingActivities, setPendingActivities] = useState([]);
@@ -268,14 +275,15 @@ export default function AdminPanelPage() {
       }
 
       try {
-        const [pending, members, eventList, donations, bannerList, sectionList, activities] = await Promise.all([
+        const [pending, members, eventList, donations, bannerList, sectionList, activities, raceSubmissions] = await Promise.all([
           getPendingMembers(currentUser.uid).catch(() => []),
           getAllMembers(currentUser.uid).catch(() => []),
           getAllEvents().catch(() => []),
           getDonationSummary().catch(() => []),
           getAllBanners(currentUser.uid).catch(() => []),
           getAllSections(currentUser.uid).catch(() => []),
-          getPendingActivities(currentUser.uid).catch(() => [])
+          getPendingActivities(currentUser.uid).catch(() => []),
+          getPendingRaceSubmissions(currentUser.uid).catch(() => [])
         ]);
 
         setPendingMembers(pending);
@@ -285,6 +293,7 @@ export default function AdminPanelPage() {
         setBanners(bannerList);
         setSections(sectionList);
         setPendingActivities(activities);
+        setPendingSubmissions(raceSubmissions);
         setError('');
       } catch (err) {
         console.error('Error fetching admin data:', err);
@@ -674,6 +683,26 @@ export default function AdminPanelPage() {
     setActivityDetailsOpen(true);
   };
 
+  const handleReviewSubmission = async (submission, approved, note = null) => {
+    setActionLoading(`submission-${submission.id}`);
+    try {
+      await reviewRaceSubmission(submission.id, approved, note, currentUser.uid);
+      setSuccessMessage(
+        approved
+          ? `"${submission.race_name}" approved — posted to the club leaderboard. / 已批准并上榜。`
+          : `"${submission.race_name}" rejected. / 已拒绝。`
+      );
+      setPendingSubmissions((prev) => prev.filter((s) => s.id !== submission.id));
+      setRejectSubmissionDialog(null);
+      setRejectSubmissionNote('');
+    } catch (err) {
+      console.error('Error reviewing submission:', err);
+      setError('Failed to review submission. Please try again.');
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
   const handleVerifyActivity = async (activityId, approved, rejectionReason = null) => {
     setActionLoading(`activity-${activityId}`);
     try {
@@ -921,6 +950,7 @@ export default function AdminPanelPage() {
             <Tab icon={<BarChartIcon />} label="Analytics" iconPosition="start" />
             <Tab icon={<DescriptionIcon />} label="Meeting Notes" iconPosition="start" />
             <Tab icon={<SettingsIcon />} label="Settings" iconPosition="start" />
+            <Tab icon={<EmojiEventsIcon />} label={`Race Records${pendingSubmissions.length > 0 ? ` (${pendingSubmissions.length})` : ''}`} iconPosition="start" />
             {isAdmin && <Tab icon={<AdminPanelSettingsIcon />} label="Committee Mgmt" iconPosition="start" />}
           </Tabs>
         </Paper>
@@ -1728,9 +1758,119 @@ export default function AdminPanelPage() {
           </Paper>
         </TabPanel>
 
-        {/* Tab 9: Committee Management (Admin Only) */}
+        {/* Tab 9: Race Record Submissions Review */}
+        <TabPanel value={tabValue} index={9}>
+          <Typography variant="h5" sx={{ fontWeight: 600, mb: 1 }}>
+            Race Record Submissions ({pendingSubmissions.length})
+          </Typography>
+          <Typography sx={{ color: MUTED, fontSize: '0.85rem', mb: 3 }}>
+            Members submit PRs from non-NYRR races with proof. Approved records are posted to the
+            member's profile and the club Records leaderboard. / 会员提交非NYRR比赛成绩，审核通过后登上俱乐部排行榜。
+          </Typography>
+
+          {pendingSubmissions.length === 0 ? (
+            <Alert severity="info">
+              No race records awaiting review. / 没有待审核的比赛成绩。
+            </Alert>
+          ) : (
+            <TableContainer component={Paper} elevation={0} sx={panelSx}>
+              <Table>
+                <TableHead>
+                  <TableRow sx={{ backgroundColor: ORANGE_BG }}>
+                    <TableCell><strong>Member</strong></TableCell>
+                    <TableCell><strong>Race</strong></TableCell>
+                    <TableCell><strong>Date</strong></TableCell>
+                    <TableCell><strong>Distance</strong></TableCell>
+                    <TableCell><strong>Time</strong></TableCell>
+                    <TableCell><strong>Proof</strong></TableCell>
+                    <TableCell align="right"><strong>Actions</strong></TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {pendingSubmissions.map((submission) => (
+                    <TableRow key={submission.id} hover>
+                      <TableCell>
+                        {submission.member_name || `Member #${submission.member_id}`}
+                        {submission.member_name_cn && (
+                          <Typography variant="caption" display="block" color="text.secondary">
+                            {submission.member_name_cn}
+                          </Typography>
+                        )}
+                        {!(submission.member_gender && submission.member_birth_year) && (
+                          <Typography variant="caption" display="block" sx={{ color: ORANGE_DARK }}>
+                            ⚠ no gender/birth year — won't rank on leaderboard
+                          </Typography>
+                        )}
+                      </TableCell>
+                      <TableCell>{submission.race_name}</TableCell>
+                      <TableCell>{submission.race_date}</TableCell>
+                      <TableCell>{submission.race_distance}</TableCell>
+                      <TableCell sx={{ fontWeight: 700 }}>
+                        {submission.finish_time}
+                        {submission.pace && (
+                          <Typography variant="caption" display="block" color="text.secondary">
+                            Pace {submission.pace}
+                          </Typography>
+                        )}
+                      </TableCell>
+                      <TableCell>
+                        {submission.proof_url ? (
+                          <Button
+                            size="small"
+                            href={submission.proof_url}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            sx={{ textTransform: 'none', fontSize: '0.72rem' }}
+                          >
+                            Results ↗
+                          </Button>
+                        ) : (
+                          <Typography variant="caption" color="text.secondary">—</Typography>
+                        )}
+                        {submission.photo_url && (
+                          <Box
+                            component="img"
+                            src={submission.photo_url}
+                            alt="Race proof"
+                            sx={{ display: 'block', width: 56, height: 38, objectFit: 'cover', borderRadius: '6px', mt: 0.5 }}
+                          />
+                        )}
+                      </TableCell>
+                      <TableCell align="right">
+                        <Tooltip title="Approve & post to leaderboard">
+                          <IconButton
+                            size="small"
+                            color="primary"
+                            onClick={() => handleReviewSubmission(submission, true)}
+                            disabled={actionLoading === `submission-${submission.id}`}
+                          >
+                            {actionLoading === `submission-${submission.id}` ?
+                              <CircularProgress size={16} /> :
+                              <CheckIcon fontSize="small" />
+                            }
+                          </IconButton>
+                        </Tooltip>
+                        <Tooltip title="Reject with note">
+                          <IconButton
+                            size="small"
+                            onClick={() => { setRejectSubmissionDialog(submission); setRejectSubmissionNote(''); }}
+                            disabled={actionLoading === `submission-${submission.id}`}
+                          >
+                            <CloseIcon fontSize="small" color="error" />
+                          </IconButton>
+                        </Tooltip>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </TableContainer>
+          )}
+        </TabPanel>
+
+        {/* Tab 10: Committee Management (Admin Only) */}
         {isAdmin && (
-          <TabPanel value={tabValue} index={9}>
+          <TabPanel value={tabValue} index={10}>
             <Typography variant="h5" sx={{ fontWeight: 600, mb: 3 }}>
               Committee Management
             </Typography>
@@ -2180,6 +2320,45 @@ export default function AdminPanelPage() {
       </Dialog>
 
       {/* Activity Details Dialog */}
+      {/* Reject Race Record Submission Dialog */}
+      <Dialog open={!!rejectSubmissionDialog} onClose={() => setRejectSubmissionDialog(null)} maxWidth="sm" fullWidth>
+        <DialogTitle>Reject Race Record / 拒绝比赛成绩</DialogTitle>
+        <DialogContent>
+          <DialogContentText sx={{ mb: 2 }}>
+            Rejecting "{rejectSubmissionDialog?.race_name}" ({rejectSubmissionDialog?.finish_time}) by{' '}
+            {rejectSubmissionDialog?.member_name}. A note is required — the member will see it and can
+            edit &amp; resubmit. / 请填写拒绝原因，会员可修改后重新提交。
+          </DialogContentText>
+          <TextField
+            autoFocus
+            fullWidth
+            multiline
+            rows={2}
+            label="Review Note / 审核备注"
+            value={rejectSubmissionNote}
+            onChange={(e) => setRejectSubmissionNote(e.target.value)}
+            placeholder="e.g., results link doesn't show this runner"
+          />
+        </DialogContent>
+        <DialogActions sx={{ px: 3, pb: 2 }}>
+          <Button
+            onClick={() => setRejectSubmissionDialog(null)}
+            sx={{ textTransform: 'none', fontWeight: 600, borderRadius: '99px', color: MUTED }}
+          >
+            Cancel / 取消
+          </Button>
+          <Button
+            variant="contained"
+            color="error"
+            disabled={!rejectSubmissionNote.trim() || actionLoading === `submission-${rejectSubmissionDialog?.id}`}
+            onClick={() => handleReviewSubmission(rejectSubmissionDialog, false, rejectSubmissionNote.trim())}
+            sx={{ textTransform: 'none', fontWeight: 600, borderRadius: '99px' }}
+          >
+            Reject / 拒绝
+          </Button>
+        </DialogActions>
+      </Dialog>
+
       <Dialog open={activityDetailsOpen} onClose={() => setActivityDetailsOpen(false)} maxWidth="md" fullWidth>
         <DialogTitle>
           Verify Activity / 验证活动

--- a/ProjectCode/client/src/pages/AdminPanelPage.test.js
+++ b/ProjectCode/client/src/pages/AdminPanelPage.test.js
@@ -9,6 +9,7 @@ import * as bannersApi from '../api/banners';
 import * as sectionsApi from '../api/homepageSections';
 import * as activitiesApi from '../api/activities';
 import * as settingsApi from '../api/settings';
+import * as raceSubmissionsApi from '../api/raceSubmissions';
 import { committeeMembers } from '../data/committeeMembers';
 
 jest.mock('../api/members');
@@ -18,6 +19,7 @@ jest.mock('../api/banners');
 jest.mock('../api/homepageSections');
 jest.mock('../api/activities');
 jest.mock('../api/settings');
+jest.mock('../api/raceSubmissions');
 
 const mockUseAuth = jest.fn();
 jest.mock('../context/AuthContext', () => ({
@@ -114,6 +116,23 @@ const memberActivitiesFixture = [
   { id: 38, activity_number: 3, status: 'rejected' },
 ];
 
+const raceSubmissionsFixture = [
+  {
+    id: 501, member_id: 102, member_name: 'Runner A', member_name_cn: '甲',
+    member_gender: 'M', member_birth_year: 1990,
+    race_name: 'Boston Marathon', race_date: '2026-04-20', race_distance: 'Marathon',
+    finish_time: '3:25:58', pace: '07:51',
+    proof_url: 'https://results.baa.org/x', photo_url: 'https://img/boston.jpg', status: 'pending',
+  },
+  {
+    id: 502, member_id: 104, member_name: 'user104', member_name_cn: null,
+    member_gender: null, member_birth_year: null,
+    race_name: 'Jersey City Half', race_date: '2026-06-28', race_distance: 'Half Marathon',
+    finish_time: '1:36:40', pace: null,
+    proof_url: null, photo_url: null, status: 'pending',
+  },
+];
+
 const socialSettingsFixture = [
   { key: 'social_instagram', value: 'https://insta' },
   { key: 'social_xiaohongshu', value: 'https://xhs' },
@@ -177,6 +196,8 @@ beforeEach(() => {
   activitiesApi.getPendingActivities.mockResolvedValue(activitiesFixture);
   activitiesApi.getMemberActivities.mockResolvedValue(memberActivitiesFixture);
   activitiesApi.verifyActivity.mockResolvedValue({});
+  raceSubmissionsApi.getPendingRaceSubmissions.mockResolvedValue(raceSubmissionsFixture);
+  raceSubmissionsApi.reviewRaceSubmission.mockResolvedValue({});
   settingsApi.getSettingsByCategory.mockImplementation((category) =>
     Promise.resolve(category === 'social' ? socialSettingsFixture : joinSettingsFixture)
   );
@@ -1072,5 +1093,84 @@ describe('empty states', () => {
     openTab('Analytics');
     expect(await screen.findByText('From 0 donors')).toBeInTheDocument();
     expect(screen.getAllByText('$0.00')).toHaveLength(2);
+  });
+});
+
+describe('race records tab', () => {
+  test('lists pending submissions with member info and proof', async () => {
+    renderPage();
+    await waitForDashboard();
+    openTab(/Race Records/);
+
+    expect(await screen.findByText('Race Record Submissions (2)')).toBeInTheDocument();
+    expect(screen.getByText('Boston Marathon')).toBeInTheDocument();
+    expect(screen.getByText('甲')).toBeInTheDocument();
+    expect(screen.getByText('3:25:58')).toBeInTheDocument();
+    expect(screen.getByText('Pace 07:51')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Results ↗' })).toHaveAttribute('href', 'https://results.baa.org/x');
+    expect(screen.getByAltText('Race proof')).toHaveAttribute('src', 'https://img/boston.jpg');
+    // member without gender/birth year gets a leaderboard warning
+    expect(screen.getByText(/no gender\/birth year/)).toBeInTheDocument();
+  });
+
+  test('shows tab badge count and empty state', async () => {
+    raceSubmissionsApi.getPendingRaceSubmissions.mockResolvedValue([]);
+    renderPage();
+    await waitForDashboard();
+    openTab('Race Records');
+    expect(await screen.findByText('No race records awaiting review. / 没有待审核的比赛成绩。')).toBeInTheDocument();
+  });
+
+  test('approves a submission and removes it from the list', async () => {
+    renderPage();
+    await waitForDashboard();
+    openTab(/Race Records/);
+    await screen.findByText('Boston Marathon');
+
+    fireEvent.click(screen.getAllByRole('button', { name: /Approve & post to leaderboard/i })[0]);
+
+    await waitFor(() => {
+      expect(raceSubmissionsApi.reviewRaceSubmission).toHaveBeenCalledWith(501, true, null, ADMIN_UID);
+    });
+    expect(await screen.findByText(/approved — posted to the club leaderboard/)).toBeInTheDocument();
+    expect(screen.queryByText('Boston Marathon')).not.toBeInTheDocument();
+    expect(screen.getByText('Jersey City Half')).toBeInTheDocument();
+  });
+
+  test('rejecting requires a note and sends it', async () => {
+    renderPage();
+    await waitForDashboard();
+    openTab(/Race Records/);
+    await screen.findByText('Boston Marathon');
+
+    fireEvent.click(screen.getAllByRole('button', { name: /Reject with note/i })[0]);
+    expect(await screen.findByText('Reject Race Record / 拒绝比赛成绩')).toBeInTheDocument();
+
+    // Reject button disabled until a note is entered
+    const rejectButton = screen.getByRole('button', { name: 'Reject / 拒绝' });
+    expect(rejectButton).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText('Review Note / 审核备注'), { target: { value: 'link broken' } });
+    fireEvent.click(rejectButton);
+
+    await waitFor(() => {
+      expect(raceSubmissionsApi.reviewRaceSubmission).toHaveBeenCalledWith(501, false, 'link broken', ADMIN_UID);
+    });
+    expect(await screen.findByText(/rejected/)).toBeInTheDocument();
+    expect(screen.queryByText('Boston Marathon')).not.toBeInTheDocument();
+  });
+
+  test('shows an error when review fails', async () => {
+    raceSubmissionsApi.reviewRaceSubmission.mockRejectedValue(new Error('boom'));
+    renderPage();
+    await waitForDashboard();
+    openTab(/Race Records/);
+    await screen.findByText('Boston Marathon');
+
+    fireEvent.click(screen.getAllByRole('button', { name: /Approve & post to leaderboard/i })[0]);
+
+    expect(await screen.findByText('Failed to review submission. Please try again.')).toBeInTheDocument();
+    // submission stays in the list
+    expect(screen.getByText('Boston Marathon')).toBeInTheDocument();
   });
 });

--- a/ProjectCode/client/src/pages/ProfilePage.js
+++ b/ProjectCode/client/src/pages/ProfilePage.js
@@ -53,6 +53,16 @@ import { ref, uploadBytes, getDownloadURL } from 'firebase/storage';
 import { getMemberByFirebaseUid, updateMember } from '../api/members';
 import { getMemberRaceResults } from '../api/results';
 import { getMemberCredits } from '../api/credits';
+import {
+  getMyRaceSubmissions,
+  getMyRacePhotos,
+  deleteRaceSubmission,
+  updateRaceSubmission,
+  upsertRacePhoto,
+} from '../api/raceSubmissions';
+import RecordWall from '../components/RecordWall';
+import SubmissionsTracker from '../components/SubmissionsTracker';
+import AddRaceRecordDialog from '../components/AddRaceRecordDialog';
 
 const ORANGE = '#FFA500';
 const ORANGE_DARK = '#F29400';
@@ -107,6 +117,14 @@ const ProfilePage = () => {
   const [editDialogOpen, setEditDialogOpen] = useState(false);
   const [editFormData, setEditFormData] = useState({});
   const [saving, setSaving] = useState(false);
+
+  // Race record submissions & race photos (record wall)
+  const [submissions, setSubmissions] = useState([]);
+  const [racePhotos, setRacePhotos] = useState({}); // result_id -> photo_url
+  const [recordDialogOpen, setRecordDialogOpen] = useState(false);
+  const [editSubmission, setEditSubmission] = useState(null);
+  const racePhotoInputRef = useRef(null);
+  const [racePhotoTarget, setRacePhotoTarget] = useState(null); // {type:'result'|'submission', id}
 
   // Default values for Tab auto-fill
   const profileDefaultValues = {
@@ -192,13 +210,30 @@ const ProfilePage = () => {
     }
   }, [currentUser?.uid]);
 
+  // Fetch race record submissions + per-race photos for the record wall
+  const fetchSubmissionsAndPhotos = useCallback(async () => {
+    if (!currentUser?.uid) return;
+    try {
+      const [mySubmissions, myPhotos] = await Promise.all([
+        getMyRaceSubmissions(currentUser.uid),
+        getMyRacePhotos(currentUser.uid),
+      ]);
+      setSubmissions(mySubmissions);
+      setRacePhotos(Object.fromEntries(myPhotos.map((p) => [p.result_id, p.photo_url])));
+    } catch (err) {
+      // Member may not exist in the database yet — the wall just stays empty
+      console.error('Failed to fetch race submissions:', err);
+    }
+  }, [currentUser?.uid]);
+
   useEffect(() => {
     if (!currentUser) {
       navigate('/login');
     } else {
       fetchMemberData();
+      fetchSubmissionsAndPhotos();
     }
-  }, [currentUser, navigate, fetchMemberData]);
+  }, [currentUser, navigate, fetchMemberData, fetchSubmissionsAndPhotos]);
 
   const handleLogout = async () => {
     setError('');
@@ -266,6 +301,75 @@ const ProfilePage = () => {
       // Clear the input
       if (fileInputRef.current) {
         fileInputRef.current.value = '';
+      }
+    }
+  };
+
+  // ---- Record wall handlers ----
+
+  const handleOpenAddRecord = () => {
+    setEditSubmission(null);
+    setRecordDialogOpen(true);
+  };
+
+  const handleEditSubmission = (submission) => {
+    setEditSubmission(submission);
+    setRecordDialogOpen(true);
+  };
+
+  const handleRecordSubmitted = () => {
+    setSuccess('Record submitted for committee review! / 成绩已提交委员会审核！');
+    fetchSubmissionsAndPhotos();
+  };
+
+  const handleWithdrawSubmission = async (submission) => {
+    if (!window.confirm(`Withdraw "${submission.race_name}"? / 撤回该提交？`)) return;
+    try {
+      await deleteRaceSubmission(submission.id, currentUser.uid);
+      setSuccess('Submission withdrawn. / 已撤回。');
+      fetchSubmissionsAndPhotos();
+    } catch (err) {
+      setError('Failed to withdraw submission. / 撤回失败。');
+    }
+  };
+
+  const handleChangeRacePhoto = (entry) => {
+    if (entry.photoTarget) {
+      setRacePhotoTarget(entry.photoTarget);
+      racePhotoInputRef.current?.click();
+    }
+  };
+
+  const handleRacePhotoSelected = async (event) => {
+    const file = event.target.files?.[0];
+    if (!file || !racePhotoTarget) return;
+    if (!file.type.startsWith('image/')) {
+      setError('Please select an image file. / 请选择图片文件。');
+      return;
+    }
+    if (file.size > 5 * 1024 * 1024) {
+      setError('Image size must be less than 5MB. / 图片大小不能超过5MB。');
+      return;
+    }
+    setError('');
+    try {
+      const storageRef = ref(storage, `race-photos/${currentUser.uid}/${Date.now()}_${file.name}`);
+      await uploadBytes(storageRef, file);
+      const url = await getDownloadURL(storageRef);
+      if (racePhotoTarget.type === 'submission') {
+        await updateRaceSubmission(racePhotoTarget.id, { photo_url: url }, currentUser.uid);
+      } else {
+        await upsertRacePhoto(racePhotoTarget.id, url, currentUser.uid);
+      }
+      setSuccess('Race photo updated! / 比赛照片已更新！');
+      fetchSubmissionsAndPhotos();
+    } catch (err) {
+      console.error('Error uploading race photo:', err);
+      setError('Failed to upload photo. Please try again. / 上传失败，请重试。');
+    } finally {
+      setRacePhotoTarget(null);
+      if (racePhotoInputRef.current) {
+        racePhotoInputRef.current.value = '';
       }
     }
   };
@@ -423,6 +527,47 @@ const ProfilePage = () => {
 
   const displayName = memberData?.nickname || memberData?.display_name || currentUser?.displayName || 'User';
 
+  // ---- Record wall entries ----
+  // PRs come from the results table (NYRR-synced + approved submissions);
+  // pending submissions hang on the wall as "challenger" plaques.
+  const approvedSubmissions = submissions.filter((s) => s.status === 'approved' && s.result_id);
+  const approvedResultIds = new Set(approvedSubmissions.map((s) => s.result_id));
+  const prEntries = Object.entries(raceData.stats.prs).map(([distance, pr]) => {
+    const match = (raceData.results || []).find(
+      (r) => r.race === pr.race && r.overall_time === pr.time
+    );
+    const resultId = match?.id;
+    const submissionForResult = approvedSubmissions.find((s) => s.result_id === resultId);
+    return {
+      distance,
+      time: pr.time,
+      race: pr.race,
+      date: pr.date,
+      pace: pr.pace,
+      resultId,
+      photoUrl: (resultId && racePhotos[resultId]) || submissionForResult?.photo_url || null,
+      onLeaderboard: resultId ? approvedResultIds.has(resultId) : false,
+      photoTarget: submissionForResult
+        ? { type: 'submission', id: submissionForResult.id }
+        : resultId
+          ? { type: 'result', id: resultId }
+          : null,
+    };
+  });
+  const pendingEntries = submissions
+    .filter((s) => s.status === 'pending')
+    .map((s) => ({
+      distance: s.race_distance,
+      time: s.finish_time,
+      race: s.race_name,
+      date: s.race_date,
+      pace: s.pace,
+      photoUrl: s.photo_url,
+      pending: true,
+      submissionId: s.id,
+      photoTarget: { type: 'submission', id: s.id },
+    }));
+
   return (
     <Container maxWidth="xl" sx={{ mt: { xs: 2, sm: 4 }, mb: { xs: 2, sm: 4 }, px: { xs: 1, sm: 2 } }}>
       {/* Hidden file input for photo upload */}
@@ -432,6 +577,16 @@ const ProfilePage = () => {
         onChange={handlePhotoUpload}
         accept="image/*"
         style={{ display: 'none' }}
+      />
+
+      {/* Hidden file input for race photo upload (record wall) */}
+      <input
+        type="file"
+        ref={racePhotoInputRef}
+        onChange={handleRacePhotoSelected}
+        accept="image/*"
+        style={{ display: 'none' }}
+        data-testid="race-wall-photo-input"
       />
 
       {/* Header Section */}
@@ -722,7 +877,7 @@ const ProfilePage = () => {
                 {loadingRaces ? <CircularProgress size={24} /> : Object.keys(raceData.stats.prs).length}
               </Typography>
               <Typography variant="body2" color="text.secondary">
-                NYRR Personal Records / 纽约路跑协会个人最佳
+                Personal Records / 个人纪录
               </Typography>
             </CardContent>
           </Card>
@@ -732,60 +887,47 @@ const ProfilePage = () => {
             <CardContent sx={{ textAlign: 'center' }}>
               <TimerIcon sx={{ fontSize: 40, color: 'success.main', mb: 1 }} />
               <Typography variant="h3" component="div">
-                {loadingRaces ? <CircularProgress size={24} /> : raceData.stats.recent_results.length}
+                {loadingRaces ? <CircularProgress size={24} /> : approvedSubmissions.length}
               </Typography>
               <Typography variant="body2" color="text.secondary">
-                Recent Races / 近期比赛
+                On Leaderboard / 榜上纪录
               </Typography>
             </CardContent>
           </Card>
         </Grid>
       </Grid>
 
-      {/* Personal Records Section */}
-      {Object.keys(raceData.stats.prs).length > 0 && (
+      {/* Record Wall Section */}
+      <Paper elevation={0} sx={{ ...panelSx, p: 3, mb: 3 }}>
+        <SectionHeader
+          icon={<TrophyIcon sx={{ color: ORANGE }} />}
+          en="My Record Wall"
+          cn="我的纪录墙"
+        />
+        <RecordWall
+          memberName={displayName}
+          memberNameCn={memberData?.display_name_cn}
+          totalRaces={raceData.stats.total_races}
+          prEntries={prEntries}
+          pendingEntries={pendingEntries}
+          onAddRecord={handleOpenAddRecord}
+          onChangePhoto={handleChangeRacePhoto}
+        />
+      </Paper>
+
+      {/* My Submissions Section */}
+      {submissions.length > 0 && (
         <Paper elevation={0} sx={{ ...panelSx, p: 3, mb: 3 }}>
           <SectionHeader
-            icon={<TrophyIcon sx={{ color: ORANGE }} />}
-            en="NYRR Personal Records"
-            cn="纽约路跑协会比赛个人最佳"
+            icon={<TimerIcon sx={{ color: ORANGE }} />}
+            en="My Submissions"
+            cn="我的提交"
           />
-          <Grid container spacing={2}>
-            {Object.entries(raceData.stats.prs).map(([distance, pr]) => (
-              <Grid item xs={12} sm={6} md={4} key={distance}>
-                <Card
-                  elevation={0}
-                  sx={{
-                    ...panelSx,
-                    transition: 'all 0.2s ease',
-                    '&:hover': {
-                      boxShadow: '0 8px 24px rgba(255,165,0,0.35)',
-                      transform: 'translateY(-3px)',
-                    },
-                  }}
-                >
-                  <CardContent>
-                    <Chip
-                      label={distance}
-                      size="small"
-                      sx={{
-                        mb: 0.5,
-                        backgroundColor: ORANGE_BG,
-                        color: ORANGE,
-                        fontWeight: 700,
-                        borderRadius: '99px',
-                      }}
-                    />
-                    <Typography variant="h5" color="primary">{pr.time}</Typography>
-                    <Typography variant="body2">{pr.race}</Typography>
-                    <Typography variant="caption" color="text.secondary">
-                      {pr.date} {pr.pace && `• Pace: ${pr.pace}`}
-                    </Typography>
-                  </CardContent>
-                </Card>
-              </Grid>
-            ))}
-          </Grid>
+          <SubmissionsTracker
+            submissions={submissions}
+            onEdit={handleEditSubmission}
+            onWithdraw={handleWithdrawSubmission}
+          />
         </Paper>
       )}
 
@@ -871,6 +1013,7 @@ const ProfilePage = () => {
                       Place / 名次
                     </TableSortLabel>
                   </TableCell>
+                  <TableCell>Source / 来源</TableCell>
                 </TableRow>
               </TableHead>
               <TableBody>
@@ -887,6 +1030,21 @@ const ProfilePage = () => {
                         <Typography variant="caption" display="block" color="text.secondary">
                           Gender: #{result.gender_place}
                         </Typography>
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      {approvedResultIds.has(result.id) ? (
+                        <Chip
+                          label="已上榜 Leaderboard"
+                          size="small"
+                          sx={{ backgroundColor: '#eaf5ea', color: '#2e7d32', fontWeight: 700, fontSize: '0.65rem', height: 20, borderRadius: '99px' }}
+                        />
+                      ) : (
+                        <Chip
+                          label="NYRR"
+                          size="small"
+                          sx={{ backgroundColor: '#e8f0fe', color: '#1a63d0', fontWeight: 700, fontSize: '0.65rem', height: 20, borderRadius: '99px' }}
+                        />
                       )}
                     </TableCell>
                   </TableRow>
@@ -1150,6 +1308,15 @@ const ProfilePage = () => {
           </Button>
         </DialogActions>
       </Dialog>
+
+      {/* Add / Edit Race Record Dialog */}
+      <AddRaceRecordDialog
+        open={recordDialogOpen}
+        onClose={() => setRecordDialogOpen(false)}
+        onSubmitted={handleRecordSubmitted}
+        firebaseUid={currentUser?.uid}
+        editSubmission={editSubmission}
+      />
     </Container>
   );
 };

--- a/ProjectCode/client/src/pages/ProfilePage.test.js
+++ b/ProjectCode/client/src/pages/ProfilePage.test.js
@@ -6,6 +6,14 @@ import { logout } from '../firebase/auth';
 import { getMemberByFirebaseUid, updateMember } from '../api/members';
 import { getMemberRaceResults } from '../api/results';
 import { getMemberCredits } from '../api/credits';
+import {
+  getMyRaceSubmissions,
+  getMyRacePhotos,
+  deleteRaceSubmission,
+  updateRaceSubmission,
+  upsertRacePhoto,
+  createRaceSubmission,
+} from '../api/raceSubmissions';
 import { uploadBytes, getDownloadURL } from 'firebase/storage';
 
 jest.mock('../context', () => ({ useAuth: jest.fn() }));
@@ -25,6 +33,20 @@ jest.mock('../api/members', () => ({
 }));
 jest.mock('../api/results', () => ({ getMemberRaceResults: jest.fn() }));
 jest.mock('../api/credits', () => ({ getMemberCredits: jest.fn() }));
+jest.mock('../api/raceSubmissions', () => ({
+  getMyRaceSubmissions: jest.fn(),
+  getMyRacePhotos: jest.fn(),
+  deleteRaceSubmission: jest.fn(),
+  updateRaceSubmission: jest.fn(),
+  upsertRacePhoto: jest.fn(),
+  createRaceSubmission: jest.fn(),
+}));
+jest.mock('html2canvas', () => ({
+  __esModule: true,
+  default: jest.fn(() =>
+    Promise.resolve({ toDataURL: () => 'data:image/png;base64,MOCK' })
+  ),
+}));
 
 const fbUser = {
   uid: 'uid-1',
@@ -99,12 +121,24 @@ const settle = async () => {
 
 const firstDataRowText = () => screen.getAllByRole('row')[1].textContent;
 
+const submissionsFixture = [
+  { id: 11, member_id: 7, race_name: 'Jersey City Half', race_date: '2026-06-28', race_distance: 'Half Marathon', finish_time: '1:36:40', pace: '07:23', proof_url: 'https://jch/results', photo_url: null, status: 'pending', result_id: null, review_note: null },
+  { id: 12, member_id: 7, race_name: 'Delta Marathon', race_date: '2022-11-01', race_distance: 'Marathon', finish_time: '3:30:00', pace: '8:00', proof_url: null, photo_url: 'https://img/delta.jpg', status: 'approved', result_id: 4, review_note: null },
+  { id: 13, member_id: 7, race_name: 'Backyard Ultra', race_date: '2025-10-01', race_distance: '50K', finish_time: '5:00:00', pace: null, proof_url: null, photo_url: null, status: 'rejected', result_id: null, review_note: 'no proof' },
+];
+
 beforeEach(() => {
   jest.clearAllMocks();
   useAuth.mockReturnValue({ currentUser: fbUser });
   getMemberByFirebaseUid.mockResolvedValue(member);
   getMemberCredits.mockResolvedValue(credits);
   getMemberRaceResults.mockResolvedValue(raceData);
+  getMyRaceSubmissions.mockResolvedValue([]);
+  getMyRacePhotos.mockResolvedValue([]);
+  deleteRaceSubmission.mockResolvedValue({});
+  updateRaceSubmission.mockResolvedValue({});
+  upsertRacePhoto.mockResolvedValue({});
+  createRaceSubmission.mockResolvedValue({});
   logout.mockResolvedValue({ error: null });
   updateMember.mockResolvedValue({});
 });
@@ -143,11 +177,11 @@ test('renders profile fields, credits, PRs, and race history from member data', 
   expect(screen.getByText('5')).toBeInTheDocument();
   expect(screen.getByText('3')).toBeInTheDocument();
 
-  // Race stats + PR cards
+  // Race stats + record wall plaques
   expect(screen.getByText('8')).toBeInTheDocument(); // total races
-  expect(screen.getByText('NYRR Personal Records')).toBeInTheDocument();
-  expect(screen.getAllByText('0:20:00').length).toBeGreaterThanOrEqual(2); // PR card + table
-  expect(screen.getByText(/Pace: 6:26/)).toBeInTheDocument();
+  expect(screen.getByText('My Record Wall')).toBeInTheDocument();
+  expect(screen.getAllByText('0:20:00').length).toBeGreaterThanOrEqual(2); // PR plaque + table
+  expect(screen.getByText(/Pace 6:26/)).toBeInTheDocument();
 
   // Race history rows (8 data rows + header)
   expect(screen.getAllByRole('row')).toHaveLength(9);
@@ -347,8 +381,8 @@ test('shows hints and empty race history when matching info is missing', async (
   ).toBe(2);
   expect(await screen.findByText(/No race results found/)).toBeInTheDocument();
   expect(screen.getByText(/Add your NYRR ID/)).toBeInTheDocument();
-  // No PR section, no Running Profile section
-  expect(screen.queryByText('NYRR Personal Records')).not.toBeInTheDocument();
+  // Empty record wall, no Running Profile section
+  expect(screen.getByText(/Your wall is waiting for its first medal/)).toBeInTheDocument();
   expect(screen.queryByText('Running Profile')).not.toBeInTheDocument();
 });
 
@@ -380,4 +414,191 @@ test('credits and race fetch errors do not break the page', async () => {
   const zeros = screen.getAllByText('0');
   expect(zeros.length).toBeGreaterThanOrEqual(4);
   errSpy.mockRestore();
+});
+
+describe('record wall & submissions', () => {
+  test('wall shows pending plaques, leaderboard chips and photos from submissions', async () => {
+    getMyRaceSubmissions.mockResolvedValue(submissionsFixture);
+    getMyRacePhotos.mockResolvedValue([
+      { id: 1, member_id: 7, result_id: 1, photo_url: 'https://img/alpha.jpg' },
+    ]);
+    renderProfile();
+    await settle();
+
+    // Pending submission hangs on the wall as a challenger plaque
+    expect((await screen.findAllByText('Jersey City Half')).length).toBeGreaterThanOrEqual(2); // wall plaque + tracker
+    expect(screen.getAllByText(/Pending Review 待审核/).length).toBeGreaterThanOrEqual(1);
+
+    // Approved submission (result_id 4 = Delta Marathon PR) shows the leaderboard seal
+    expect(screen.getAllByText(/On Leaderboard 已上榜/).length).toBeGreaterThanOrEqual(1);
+    // ...and its Source column chip in race history
+    expect(screen.getByText('已上榜 Leaderboard')).toBeInTheDocument();
+    expect(screen.getAllByText('NYRR').length).toBeGreaterThanOrEqual(1);
+
+    // Stat card counts approved submissions on the leaderboard
+    expect(screen.getByText('On Leaderboard / 榜上纪录')).toBeInTheDocument();
+
+    // Submissions tracker section lists all three with statuses
+    expect(screen.getByText('My Submissions')).toBeInTheDocument();
+    expect(screen.getByText('Backyard Ultra')).toBeInTheDocument();
+    expect(screen.getByText(/no proof/)).toBeInTheDocument(); // rejection note
+  });
+
+  test('add-record plaque opens the submission dialog and submits', async () => {
+    renderProfile();
+    await settle();
+
+    fireEvent.click(screen.getByTestId('add-record-plaque'));
+    expect(await screen.findByText('Add Race Record / 添加比赛成绩')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText(/Race Name/), { target: { value: 'Boston Marathon' } });
+    fireEvent.change(screen.getByLabelText(/Race Date/), { target: { value: '2026-04-20' } });
+    fireEvent.change(screen.getByLabelText(/Finish Time/), { target: { value: '3:25:58' } });
+    fireEvent.click(screen.getByRole('button', { name: /Submit for Review/ }));
+
+    await waitFor(() =>
+      expect(createRaceSubmission).toHaveBeenCalledWith(
+        expect.objectContaining({
+          race_name: 'Boston Marathon',
+          race_date: '2026-04-20',
+          race_distance: 'Marathon',
+          finish_time: '3:25:58',
+        }),
+        'uid-1'
+      )
+    );
+    expect(await screen.findByText(/Record submitted for committee review/)).toBeInTheDocument();
+    // Submissions are refetched after submitting
+    await waitFor(() => expect(getMyRaceSubmissions).toHaveBeenCalledTimes(2));
+  });
+
+  test('editing a rejected submission opens the dialog pre-filled and resubmits', async () => {
+    getMyRaceSubmissions.mockResolvedValue(submissionsFixture);
+    renderProfile();
+    await settle();
+    await screen.findByText('Backyard Ultra');
+
+    fireEvent.click(screen.getAllByRole('button', { name: /Edit & resubmit/ })[0]);
+    expect(await screen.findByText('Edit Race Record / 编辑比赛成绩')).toBeInTheDocument();
+    expect(screen.getByLabelText(/Race Name/)).toHaveValue('Backyard Ultra');
+    // 50K is not a preset distance -> custom field pre-filled
+    expect(screen.getByLabelText(/Custom Distance/)).toHaveValue('50K');
+
+    fireEvent.change(screen.getByLabelText(/Finish Time/), { target: { value: '4:59:00' } });
+    fireEvent.click(screen.getByRole('button', { name: /Submit for Review/ }));
+
+    await waitFor(() =>
+      expect(updateRaceSubmission).toHaveBeenCalledWith(
+        13,
+        expect.objectContaining({ finish_time: '4:59:00', race_distance: '50K' }),
+        'uid-1'
+      )
+    );
+  });
+
+  test('withdrawing a pending submission asks for confirmation', async () => {
+    getMyRaceSubmissions.mockResolvedValue(submissionsFixture);
+    const confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(true);
+    renderProfile();
+    await settle();
+    await screen.findAllByText('Jersey City Half');
+
+    fireEvent.click(screen.getAllByRole('button', { name: /Withdraw 撤回/ })[0]);
+    await waitFor(() => expect(deleteRaceSubmission).toHaveBeenCalledWith(11, 'uid-1'));
+    expect(await screen.findByText(/Submission withdrawn/)).toBeInTheDocument();
+
+    // Declining the confirm does nothing
+    deleteRaceSubmission.mockClear();
+    confirmSpy.mockReturnValue(false);
+    fireEvent.click(screen.getAllByRole('button', { name: /Withdraw 撤回/ })[0]);
+    expect(deleteRaceSubmission).not.toHaveBeenCalled();
+    confirmSpy.mockRestore();
+  });
+
+  test('withdraw failure shows an error', async () => {
+    getMyRaceSubmissions.mockResolvedValue(submissionsFixture);
+    deleteRaceSubmission.mockRejectedValueOnce(new Error('nope'));
+    jest.spyOn(window, 'confirm').mockReturnValue(true);
+    renderProfile();
+    await settle();
+    await screen.findAllByText('Jersey City Half');
+
+    fireEvent.click(screen.getAllByRole('button', { name: /Withdraw 撤回/ })[0]);
+    expect(await screen.findByText(/Failed to withdraw submission/)).toBeInTheDocument();
+    window.confirm.mockRestore();
+  });
+
+  test('changing a race photo on a synced PR uploads and saves via race-photos API', async () => {
+    uploadBytes.mockResolvedValue({});
+    getDownloadURL.mockResolvedValue('https://cdn/race.png');
+    renderProfile();
+    await settle();
+
+    // Wall plaques sort longest distance first: Marathon then 5K.
+    // Both are NYRR results -> photoTarget {type:'result'}.
+    const camButtons = screen.getAllByRole('button', { name: /Add 添加|Change 更换/ });
+    fireEvent.click(camButtons[0]); // Marathon plaque (result id 4)
+
+    const input = screen.getByTestId('race-wall-photo-input');
+    const file = new File(['img'], 'race.png', { type: 'image/png' });
+    fireEvent.change(input, { target: { files: [file] } });
+
+    await waitFor(() => expect(upsertRacePhoto).toHaveBeenCalledWith(4, 'https://cdn/race.png', 'uid-1'));
+    expect(await screen.findByText(/Race photo updated/)).toBeInTheDocument();
+  });
+
+  test('changing a photo on a pending submission updates the submission', async () => {
+    getMyRaceSubmissions.mockResolvedValue(submissionsFixture);
+    uploadBytes.mockResolvedValue({});
+    getDownloadURL.mockResolvedValue('https://cdn/jch.png');
+    renderProfile();
+    await settle();
+    await screen.findAllByText('Jersey City Half');
+
+    // Last plaque cam button belongs to the pending submission plaque
+    const camButtons = screen.getAllByRole('button', { name: /Add 添加|Change 更换/ });
+    fireEvent.click(camButtons[camButtons.length - 1]);
+
+    const input = screen.getByTestId('race-wall-photo-input');
+    fireEvent.change(input, { target: { files: [new File(['x'], 'jch.png', { type: 'image/png' })] } });
+
+    await waitFor(() =>
+      expect(updateRaceSubmission).toHaveBeenCalledWith(11, { photo_url: 'https://cdn/jch.png' }, 'uid-1')
+    );
+  });
+
+  test('race photo input validates type and size and surfaces upload errors', async () => {
+    renderProfile();
+    await settle();
+
+    const camButtons = screen.getAllByRole('button', { name: /Add 添加|Change 更换/ });
+    fireEvent.click(camButtons[0]);
+    const input = screen.getByTestId('race-wall-photo-input');
+
+    fireEvent.change(input, { target: { files: [new File(['t'], 'a.txt', { type: 'text/plain' })] } });
+    expect(await screen.findByText(/Please select an image file/)).toBeInTheDocument();
+
+    fireEvent.click(camButtons[0]);
+    const big = new File(['x'], 'big.png', { type: 'image/png' });
+    Object.defineProperty(big, 'size', { value: 6 * 1024 * 1024 });
+    fireEvent.change(input, { target: { files: [big] } });
+    expect(await screen.findByText(/Image size must be less than 5MB/)).toBeInTheDocument();
+
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    uploadBytes.mockRejectedValueOnce(new Error('storage down'));
+    fireEvent.click(camButtons[0]);
+    fireEvent.change(input, { target: { files: [new File(['x'], 'ok.png', { type: 'image/png' })] } });
+    expect(await screen.findByText(/Failed to upload photo/)).toBeInTheDocument();
+    errSpy.mockRestore();
+  });
+
+  test('submissions fetch failure leaves the wall usable', async () => {
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    getMyRaceSubmissions.mockRejectedValueOnce(new Error('api down'));
+    renderProfile();
+    await settle();
+    expect(screen.getByText('My Record Wall')).toBeInTheDocument();
+    expect(screen.queryByText('My Submissions')).not.toBeInTheDocument();
+    errSpy.mockRestore();
+  });
 });


### PR DESCRIPTION
## Summary

Frontend half of the race-record submissions feature — the backend API shipped in #70, but the profile/admin UI was missed in that PR, so prod still shows the old profile page.

- **ProfilePage → "My Record Wall 我的纪录墙"**: PRs hang as medal plaques with the member's own photo from each race (hover 📷 to change); Poster Mode frames the wall as one printable/shareable image (Save as Image via html2canvas + Print); "My Submissions" tracker (Submitted → Committee Review → Approved → On Leaderboard); Add Race Record dialog where members create a race (name/date/distance/time/proof link/photo) and submit for review; race history gains a Source column.
- **AdminPanelPage → "Race Records" tab** (committee-accessible, pending-count badge): review queue with proof links/photos, one-click approve (posts to leaderboard), reject with required note. Committee Mgmt moves to tab index 10.
- New components: `RecordWall`, `SubmissionsTracker`, `AddRaceRecordDialog` + full test suites.

## Testing

- Frontend: 1064 tests / 71 suites pass, 98.8% lines / 90.6% branches (new files 97–100%).
- Backend flow E2E-verified locally in the previous PR: submit → committee approve → appears on profile PRs and men's leaderboard.

## Deploy notes

- `npm install` before `npm run build` (html2canvas dependency — already in package.json from #70).
- No backend/server changes in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)