### PR TITLE
Two-state donation review: auto-ignore carpool/gear, remove ledger delete

### DIFF
--- a/ProjectCode/client/src/components/DonationLedger.js
+++ b/ProjectCode/client/src/components/DonationLedger.js
@@ -11,11 +11,10 @@ import ReceiptLongIcon from '@mui/icons-material/ReceiptLong';
 import CheckIcon from '@mui/icons-material/Check';
 import CloseIcon from '@mui/icons-material/Close';
 import ReplayIcon from '@mui/icons-material/Replay';
-import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 import { useAuth } from '../context';
 import {
   getDonationLedger, approveDonation, dismissDonation, revertDonation,
-  deleteDonor, sendThankYou, runGmailSync, downloadTaxReport
+  sendThankYou, runGmailSync, downloadTaxReport
 } from '../api/donors';
 
 // Design tokens (match HomePage / NavBar design language)
@@ -129,7 +128,6 @@ export default function DonationLedger({ onLedgerChange }) {
   const [syncing, setSyncing] = useState(false);
   const [actingId, setActingId] = useState(null);
   const [pendingTypes, setPendingTypes] = useState({});
-  const [deleteTarget, setDeleteTarget] = useState(null);
   const [thankTarget, setThankTarget] = useState(null);
   const [thankEmail, setThankEmail] = useState('');
   const [sendingThanks, setSendingThanks] = useState(false);
@@ -206,23 +204,6 @@ export default function DonationLedger({ onLedgerChange }) {
     } catch (err) {
       console.error('Error reverting donation:', err);
       setError('Failed to un-approve donation. / 撤回捐款失败。');
-    } finally {
-      setActingId(null);
-    }
-  };
-
-  const handleConfirmDelete = async () => {
-    if (!deleteTarget) return;
-    setActingId(deleteTarget.donation_id);
-    setError('');
-    try {
-      await deleteDonor(deleteTarget.donor_id, firebaseUid);
-      setDeleteTarget(null);
-      await fetchLedger();
-      if (onLedgerChange) onLedgerChange();
-    } catch (err) {
-      console.error('Error deleting donation:', err);
-      setError('Failed to delete donation. / 删除捐款失败。');
     } finally {
       setActingId(null);
     }
@@ -538,13 +519,6 @@ export default function DonationLedger({ onLedgerChange }) {
                                 </IconButton>
                               </span>
                             </Tooltip>
-                            <Tooltip title="Delete permanently / 永久删除">
-                              <span>
-                                <IconButton size="small" onClick={() => setDeleteTarget(donation)} disabled={acting} aria-label="Delete 删除">
-                                  <DeleteOutlineIcon sx={{ fontSize: 16, color: '#c62828' }} />
-                                </IconButton>
-                              </span>
-                            </Tooltip>
                           </Box>
                         )}
                         <KeyboardArrowDownIcon sx={{
@@ -634,31 +608,6 @@ export default function DonationLedger({ onLedgerChange }) {
             sx={pillButtonSx(true)}
           >
             {sendingThanks ? <CircularProgress size={18} sx={{ color: 'white' }} /> : 'Send 发送'}
-          </Button>
-        </DialogActions>
-      </Dialog>
-
-      {/* Delete confirmation dialog */}
-      <Dialog open={Boolean(deleteTarget)} onClose={() => setDeleteTarget(null)} maxWidth="xs" fullWidth>
-        <DialogTitle>Delete donation? / 删除捐款？</DialogTitle>
-        <DialogContent>
-          <Typography sx={{ fontSize: '0.875rem' }}>
-            {deleteTarget?.name} · {formatAmount(deleteTarget?.amount)} · {formatDate(deleteTarget?.donation_date)}
-          </Typography>
-          <Typography sx={{ fontSize: '0.78125rem', color: MUTED, mt: 1 }}>
-            This permanently removes the record from the ledger. To just take it off the public page, use Un-approve instead. / 此操作将从账本中永久删除该记录；若只想从公开页面移除，请使用「撤回」。
-          </Typography>
-        </DialogContent>
-        <DialogActions sx={{ px: 3, py: 2 }}>
-          <Button onClick={() => setDeleteTarget(null)}>Cancel 取消</Button>
-          <Button
-            variant="contained"
-            color="error"
-            onClick={handleConfirmDelete}
-            disabled={actingId === deleteTarget?.donation_id}
-            sx={{ textTransform: 'none', fontWeight: 700, borderRadius: '99px', boxShadow: 'none' }}
-          >
-            {actingId === deleteTarget?.donation_id ? <CircularProgress size={18} sx={{ color: 'white' }} /> : 'Delete 删除'}
           </Button>
         </DialogActions>
       </Dialog>

--- a/ProjectCode/client/src/components/DonationLedger.test.js
+++ b/ProjectCode/client/src/components/DonationLedger.test.js
@@ -6,7 +6,6 @@ import {
   approveDonation,
   dismissDonation,
   revertDonation,
-  deleteDonor,
   sendThankYou,
   runGmailSync,
   downloadTaxReport,
@@ -20,7 +19,6 @@ jest.mock('../api/donors', () => ({
   approveDonation: jest.fn(),
   dismissDonation: jest.fn(),
   revertDonation: jest.fn(),
-  deleteDonor: jest.fn(),
   sendThankYou: jest.fn(),
   runGmailSync: jest.fn(),
   downloadTaxReport: jest.fn(),
@@ -106,7 +104,6 @@ beforeEach(() => {
   approveDonation.mockResolvedValue({});
   dismissDonation.mockResolvedValue({});
   revertDonation.mockResolvedValue({});
-  deleteDonor.mockResolvedValue({});
   sendThankYou.mockResolvedValue({});
   runGmailSync.mockResolvedValue({ emails_found: 1, inserted: 1 });
   downloadTaxReport.mockResolvedValue({
@@ -298,12 +295,14 @@ test('dismiss calls the API and refreshes', async () => {
   await waitFor(() => expect(getDonationLedger).toHaveBeenCalledTimes(2));
 });
 
-test('confirmed rows show un-approve and delete actions; pending rows do not', async () => {
+test('reviewed rows show un-approve but never a delete action', async () => {
   render(<DonationLedger />);
   await screen.findByText('Li Chen');
   // 3 non-pending rows (Li Chen, Golden Wheat, dismissed Spam Sender)
   expect(screen.getAllByLabelText('Un-approve 撤回')).toHaveLength(3);
-  expect(screen.getAllByLabelText('Delete 删除')).toHaveLength(3);
+  // Deleting is not offered: the ignored row is what stops the Gmail sync
+  // from re-importing the same transaction
+  expect(screen.queryByLabelText('Delete 删除')).not.toBeInTheDocument();
 });
 
 test('un-approve sends the donation back to pending', async () => {
@@ -316,48 +315,12 @@ test('un-approve sends the donation back to pending', async () => {
   expect(getDonationLedger).toHaveBeenCalledTimes(2);
 });
 
-test('delete asks for confirmation then deletes by donor_id', async () => {
-  const onLedgerChange = jest.fn();
-  render(<DonationLedger onLedgerChange={onLedgerChange} />);
-  await screen.findByText('Li Chen');
-
-  fireEvent.click(screen.getAllByLabelText('Delete 删除')[0]);
-  expect(await screen.findByText('Delete donation? / 删除捐款？')).toBeInTheDocument();
-  expect(deleteDonor).not.toHaveBeenCalled();
-
-  fireEvent.click(screen.getByText('Delete 删除'));
-  await waitFor(() => expect(deleteDonor).toHaveBeenCalledWith('IND_11', 'admin-uid'));
-  await waitFor(() => expect(onLedgerChange).toHaveBeenCalled());
-});
-
-test('delete confirmation can be cancelled', async () => {
-  render(<DonationLedger />);
-  await screen.findByText('Li Chen');
-  fireEvent.click(screen.getAllByLabelText('Delete 删除')[0]);
-  await screen.findByText('Delete donation? / 删除捐款？');
-  fireEvent.click(screen.getByText('Cancel 取消'));
-  await waitFor(() =>
-    expect(screen.queryByText('Delete donation? / 删除捐款？')).not.toBeInTheDocument()
-  );
-  expect(deleteDonor).not.toHaveBeenCalled();
-});
-
 test('shows an error when un-approve fails', async () => {
   revertDonation.mockRejectedValue(new Error('nope'));
   render(<DonationLedger />);
   await screen.findByText('Li Chen');
   fireEvent.click(screen.getAllByLabelText('Un-approve 撤回')[0]);
   expect(await screen.findByText(/Failed to un-approve donation/)).toBeInTheDocument();
-});
-
-test('shows an error when delete fails', async () => {
-  deleteDonor.mockRejectedValue(new Error('nope'));
-  render(<DonationLedger />);
-  await screen.findByText('Li Chen');
-  fireEvent.click(screen.getAllByLabelText('Delete 删除')[0]);
-  await screen.findByText('Delete donation? / 删除捐款？');
-  fireEvent.click(screen.getByText('Delete 删除'));
-  expect(await screen.findByText(/Failed to delete donation/)).toBeInTheDocument();
 });
 
 test('sync status line and Sync now button', async () => {

--- a/ProjectCode/server/sync_zelle_donations.py
+++ b/ProjectCode/server/sync_zelle_donations.py
@@ -357,6 +357,28 @@ def parse_venmo_email(raw_email):
     }
 
 
+# Payments that are almost certainly not donations (carpool fees, team-gear
+# purchases). They are still imported — the ledger row is what stops the next
+# sync from re-importing the same transaction — but arrive pre-ignored so the
+# committee doesn't dismiss them one by one. The ledger's Approve button
+# flips any false positive.
+AUTO_IGNORE_MEMO_KEYWORDS = [
+    '拼车', 'carpool', '车费', '🚗',
+    '队服', '衣服', 't-shirt', 'tshirt', 't shirt', 'tee', 'shirt', 'jersey',
+]
+
+
+def auto_ignore_keyword(memo):
+    """Return the matched keyword if the memo marks a non-donation payment."""
+    if not memo:
+        return None
+    lowered = memo.lower()
+    for keyword in AUTO_IGNORE_MEMO_KEYWORDS:
+        if keyword in lowered:
+            return keyword
+    return None
+
+
 def is_duplicate(session, transaction_number):
     """
     Check if a donation with this transaction number already exists.
@@ -507,9 +529,18 @@ def _process_provider_emails(mail, email_ids, parser, provider, session, stats,
 
             record = build_donor_record(parsed, status=status, provider=provider)
 
+            # Non-donation payments (carpool, gear) come in pre-ignored,
+            # regardless of the requested status — even confirmed backfills
+            # shouldn't publish a carpool fee as a donation
+            matched = auto_ignore_keyword(parsed["memo"])
+            if matched:
+                record["status"] = "dismissed"
+                record["notes"] += f" · Auto-ignored 自动忽略: memo matched '{matched}'"
+
             if dry_run:
                 print(
-                    f"  [{provider} {i}] Would insert: {record['name']} - "
+                    f"  [{provider} {i}] Would insert ({record['status']}): "
+                    f"{record['name']} - "
                     f"${record['amount']} on {record['donation_date']} "
                     f"| source: {record['source']} "
                     f"| notes: {record['notes']}"
@@ -520,7 +551,8 @@ def _process_provider_emails(mail, email_ids, parser, provider, session, stats,
                 session.add(donor)
                 session.commit()
                 print(
-                    f"  [{provider} {i}] Inserted: {record['name']} - "
+                    f"  [{provider} {i}] Inserted ({record['status']}): "
+                    f"{record['name']} - "
                     f"${record['amount']} on {record['donation_date']}"
                 )
 

--- a/ProjectCode/server/tests/test_zelle_sync.py
+++ b/ProjectCode/server/tests/test_zelle_sync.py
@@ -290,6 +290,69 @@ def test_sync_skips_venmo_when_folder_missing(db_session, monkeypatch):
     assert stats['errors'] == 0
 
 
+# ---------------------------------------------------------------- auto-ignore
+
+def test_auto_ignore_keyword_matches_carpool_and_gear():
+    assert zelle.auto_ignore_keyword('拼车 nuo chen') == '拼车'
+    assert zelle.auto_ignore_keyword('Bear Mountain Carpool for Tiffany') == 'carpool'
+    assert zelle.auto_ignore_keyword('熊山车费') == '车费'
+    assert zelle.auto_ignore_keyword('🚗') == '🚗'
+    assert zelle.auto_ignore_keyword('1 red + 1 white 队服') == '队服'
+    assert zelle.auto_ignore_keyword('newbee white t-shirt') == 't-shirt'
+    assert zelle.auto_ignore_keyword('TEE red') == 'tee'
+
+
+def test_auto_ignore_keyword_leaves_real_donations_alone():
+    assert zelle.auto_ignore_keyword('Happy 10th anniversary!') is None
+    assert zelle.auto_ignore_keyword('梅老板加油 🇦🇷') is None
+    assert zelle.auto_ignore_keyword('英格兰过关西瓜🍉') is None
+    assert zelle.auto_ignore_keyword(None) is None
+    assert zelle.auto_ignore_keyword('') is None
+
+
+def test_sync_auto_ignores_carpool_payments(db_session, monkeypatch):
+    from sqlalchemy.orm import sessionmaker as _sessionmaker
+
+    class FakeMail:
+        def __init__(self, emails):
+            self.emails = emails
+
+        def select(self, folder, readonly=False):
+            return ('OK', [b''])
+
+        def fetch(self, eid, spec):
+            return ('OK', [(b'1 (RFC822)', self.emails[eid])])
+
+        def close(self):
+            pass
+
+        def logout(self):
+            pass
+
+    venmo_emails = {
+        b'v1': make_venmo_email(sender='Ryan Young', memo='拼车费用',
+                                txn_link='https://venmo.com/story/111'),
+        b'v2': make_venmo_email(sender='Yue Ma', memo='Happy 10th anniversary!',
+                                txn_link='https://venmo.com/story/222'),
+    }
+    monkeypatch.setattr(zelle, 'Session', _sessionmaker(bind=db_session.get_bind()))
+    monkeypatch.setattr(zelle.time, 'sleep', lambda seconds: None)
+    monkeypatch.setattr(zelle, 'connect_to_gmail', lambda: FakeMail(venmo_emails))
+    monkeypatch.setattr(zelle, 'search_zelle_emails', lambda m, since=None: [])
+    monkeypatch.setattr(zelle, 'search_venmo_emails',
+                        lambda m, since=None: list(venmo_emails.keys()))
+
+    # Even a confirmed backfill must not publish a carpool fee
+    stats = zelle.sync_zelle_donations(status='confirmed')
+    assert stats['inserted'] == 2
+
+    donors = {d.name: d for d in db_session.query(Donor).all()}
+    assert donors['Ryan Young'].status == 'dismissed'
+    assert "Auto-ignored 自动忽略: memo matched '拼车'" in donors['Ryan Young'].notes
+    assert donors['Yue Ma'].status == 'confirmed'
+    assert 'Auto-ignored' not in donors['Yue Ma'].notes
+
+
 # ---------------------------------------------------------------- dedup + sync status
 
 def test_is_duplicate_matches_transaction_number(db_session):


### PR DESCRIPTION
Fixes the re-sync loophole the committee found: deleting a ledger row erased the dedup memory, so the same payment came back as pending on the next sync.

- **Delete removed from the ledger** — the review model is two-state (approved / ignored); the ignored row is the permanent record that blocks re-import. Un-approve (↩) remains for moving rows between states via pending.
- **Auto-ignore at sync time** — memos matching 拼车 / carpool / 车费 / 🚗 / 队服 / 衣服 / t-shirt / tee / shirt / jersey are imported directly as ignored (visible, dedup-protected, noted with the matched keyword). The Approve button flips false positives. Applies to confirmed backfills too.

## Test plan
Backend 833 tests pass (new: keyword matcher, auto-ignore flow incl. confirmed-backfill override); frontend 1076 tests pass (delete absent, un-approve intact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)