### PR TITLE
Record full thank-you acknowledgment in donation notes

### DIFF
--- a/ProjectCode/client/src/components/DonationLedger.js
+++ b/ProjectCode/client/src/components/DonationLedger.js
@@ -546,7 +546,7 @@ export default function DonationLedger({ onLedgerChange }) {
                             </Box>
                           )}
                           {donation.notes && (
-                            <Typography sx={{ fontSize: '0.75rem', color: MUTED, lineHeight: 1.6 }}>
+                            <Typography sx={{ fontSize: '0.75rem', color: MUTED, lineHeight: 1.6, whiteSpace: 'pre-line' }}>
                               Notes 备注: {donation.notes}
                             </Typography>
                           )}

--- a/ProjectCode/server/routes/donors.py
+++ b/ProjectCode/server/routes/donors.py
@@ -349,7 +349,17 @@ def send_thank_you(
             detail="Failed to send the email — check the server email configuration"
         )
 
-    donor.thank_you_sent_at = datetime.utcnow()
+    sent_at = datetime.utcnow()
+    donor.thank_you_sent_at = sent_at
+    # Audit trail: record the full acknowledgment in the notes so the ledger
+    # shows exactly what was sent, to whom, and when
+    ack_record = (
+        f"—— Thank-you email 感谢邮件 ——\n"
+        f"Sent to {request.email} on {sent_at.strftime('%b %d, %Y %H:%M')} UTC\n"
+        f"Subject: {subject}\n\n"
+        f"{body_text}"
+    )
+    donor.notes = f"{donor.notes}\n\n{ack_record}" if donor.notes else ack_record
     db.commit()
     db.refresh(donor)
     return donor

--- a/ProjectCode/server/tests/test_donation_ledger.py
+++ b/ProjectCode/server/tests/test_donation_ledger.py
@@ -335,11 +335,32 @@ def test_send_thank_you_sends_and_stamps(client, db_session, committee_member, m
                        json={'email': 'kevin@example.com'},
                        headers=auth(committee_member))
     assert resp.status_code == 200
-    assert resp.json()['thank_you_sent_at'] is not None
+    body = resp.json()
+    assert body['thank_you_sent_at'] is not None
     assert sent['to'] == 'kevin@example.com'
     assert 'Thank you' in sent['subject']
     assert 'Kevin Gu' in sent['html'] and '$15.00' in sent['html']
     assert '新蜂跑团' in sent['text']
+    # Full acknowledgment recorded in the notes as an audit trail
+    assert 'Sent to kevin@example.com' in body['notes']
+    assert sent['subject'] in body['notes']
+    assert sent['text'] in body['notes']
+
+
+def test_send_thank_you_appends_ack_to_existing_notes(client, db_session, committee_member, monkeypatch):
+    import email_service
+    monkeypatch.setattr(email_service.EmailService, 'send_email',
+                        staticmethod(lambda *a, **k: True))
+
+    donor = seed_donation(db_session, 'C1', notes='Zelle Transaction #24271147625')
+    resp = client.post(f'/api/donors/donations/{donor.donation_id}/send-thank-you',
+                       json={'email': 'donor@example.com'},
+                       headers=auth(committee_member))
+    notes = resp.json()['notes']
+    # Original note preserved, acknowledgment appended after it
+    assert notes.startswith('Zelle Transaction #24271147625')
+    assert 'Thank-you email 感谢邮件' in notes
+    assert 'Sent to donor@example.com' in notes
 
 
 def test_send_thank_you_502_when_email_fails(client, db_session, committee_member, monkeypatch):


### PR DESCRIPTION
When a thank-you email is sent from the ledger, the donation's notes now gain a full audit record — recipient address, sent timestamp, subject, and the complete letter text — visible in the expanded row (notes render multiline). Existing notes are preserved; the acknowledgment is appended.

Note: the two thank-yous sent before this change (Kevin Gu, Ci Ping Wu) predate the logging, so their notes only show the ✓ Sent date.

Tests: backend 834 / frontend 1076 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)