### PR TITLE
Send dialog: switch between thank-you templates

### DIFF
--- a/ProjectCode/client/src/api/donors.js
+++ b/ProjectCode/client/src/api/donors.js
@@ -180,14 +180,17 @@ export async function sendThankYou(donationId, { email, subject, message, attach
 }
 
 /**
- * The letter a donation would receive (matched tier template, rendered),
- * for review/editing in the send dialog
+ * The rendered letter for a donation, for review/editing in the send dialog.
+ * Auto-matches a template by amount; pass templateId to render a specific
+ * one (0 = built-in default).
  * @param {number} donationId - Donation ID
  * @param {string} firebaseUid - Committee/admin Firebase UID
- * @returns {Promise<Object>} { subject, body, template_name }
+ * @param {number} [templateId] - Specific template to render
+ * @returns {Promise<Object>} { subject, body, template_name, template_id }
  */
-export async function getThankYouPreview(donationId, firebaseUid) {
-  return api.get(`/api/donors/donations/${donationId}/thank-you-preview`, {},
+export async function getThankYouPreview(donationId, firebaseUid, templateId) {
+  const params = templateId === undefined ? {} : { template_id: templateId };
+  return api.get(`/api/donors/donations/${donationId}/thank-you-preview`, params,
     { 'X-Firebase-UID': firebaseUid }, { skipCache: true });
 }
 

--- a/ProjectCode/client/src/api/donors.test.js
+++ b/ProjectCode/client/src/api/donors.test.js
@@ -164,6 +164,19 @@ test('getThankYouPreview GETs the rendered letter, skipping cache', async () => 
   );
 });
 
+test('getThankYouPreview passes an explicit template id (0 = built-in)', async () => {
+  await getThankYouPreview(7, 'uid-1', 5);
+  expect(api.get).toHaveBeenCalledWith(
+    '/api/donors/donations/7/thank-you-preview', { template_id: 5 },
+    { 'X-Firebase-UID': 'uid-1' }, { skipCache: true }
+  );
+  await getThankYouPreview(7, 'uid-1', 0);
+  expect(api.get).toHaveBeenCalledWith(
+    '/api/donors/donations/7/thank-you-preview', { template_id: 0 },
+    { 'X-Firebase-UID': 'uid-1' }, { skipCache: true }
+  );
+});
+
 test('template CRUD helpers hit the right endpoints with auth', async () => {
   await getThankYouTemplates('uid-1');
   expect(api.get).toHaveBeenCalledWith(

--- a/ProjectCode/client/src/components/DonationLedger.js
+++ b/ProjectCode/client/src/components/DonationLedger.js
@@ -148,7 +148,8 @@ export default function DonationLedger({ onLedgerChange }) {
   const [thankEmail, setThankEmail] = useState('');
   const [thankSubject, setThankSubject] = useState('');
   const [thankMessage, setThankMessage] = useState('');
-  const [thankTemplateName, setThankTemplateName] = useState(null);
+  const [thankTemplateId, setThankTemplateId] = useState(0);
+  const [thankTemplates, setThankTemplates] = useState([]);
   const [thankAttach, setThankAttach] = useState(true);
   const [sendingThanks, setSendingThanks] = useState(false);
   const [ignoredOpen, setIgnoredOpen] = useState(false);
@@ -232,16 +233,34 @@ export default function DonationLedger({ onLedgerChange }) {
     setThankEmail('');
     setThankSubject('');
     setThankMessage('');
-    setThankTemplateName(null);
+    setThankTemplateId(0);
+    setThankTemplates([]);
     setThankAttach(true);
     try {
-      const preview = await getThankYouPreview(donation.donation_id, firebaseUid);
+      const [preview, templateList] = await Promise.all([
+        getThankYouPreview(donation.donation_id, firebaseUid),
+        getThankYouTemplates(firebaseUid),
+      ]);
       setThankSubject(preview.subject || '');
       setThankMessage(preview.body || '');
-      setThankTemplateName(preview.template_name);
+      setThankTemplateId(preview.template_id || 0);
+      setThankTemplates(templateList);
     } catch (err) {
       console.error('Error loading thank-you preview:', err);
       setError('Failed to load the letter preview. / 加载感谢信预览失败。');
+    }
+  };
+
+  const handleSwitchTemplate = async (templateId) => {
+    if (!thankTarget) return;
+    setThankTemplateId(templateId);
+    try {
+      const preview = await getThankYouPreview(thankTarget.donation_id, firebaseUid, templateId);
+      setThankSubject(preview.subject || '');
+      setThankMessage(preview.body || '');
+    } catch (err) {
+      console.error('Error switching template:', err);
+      setError('Failed to load that template. / 切换模板失败。');
     }
   };
 
@@ -846,13 +865,26 @@ export default function DonationLedger({ onLedgerChange }) {
           <Typography sx={{ fontSize: '0.875rem', fontWeight: 600, mb: 1 }}>
             {thankTarget?.name} · {formatAmount(thankTarget?.amount)} · {formatDate(thankTarget?.donation_date)}
           </Typography>
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, backgroundColor: PURPLE_BG, borderRadius: '9px', px: 1.5, py: 1, mb: 2 }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap', backgroundColor: PURPLE_BG, borderRadius: '9px', px: 1.5, py: 1, mb: 2 }}>
             <Typography sx={{ fontSize: '0.75rem', color: PURPLE, fontWeight: 600 }}>
-              Matched template 匹配模板:
+              Template 模板:
             </Typography>
-            <Chip size="small" label={thankTemplateName || 'Built-in default 内置模板'} sx={{ fontSize: '0.65625rem', fontWeight: 700, backgroundColor: PURPLE, color: 'white', borderRadius: '99px', height: 20 }} />
+            <Select
+              size="small"
+              value={thankTemplateId}
+              onChange={(e) => handleSwitchTemplate(e.target.value)}
+              inputProps={{ 'aria-label': 'Template 模板' }}
+              sx={{ fontSize: '0.78125rem', fontWeight: 700, color: PURPLE, borderRadius: '8px', backgroundColor: 'white', minWidth: 220, '& .MuiSelect-select': { py: 0.5 } }}
+            >
+              {thankTemplates.map((template) => (
+                <MenuItem key={template.id} value={template.id} sx={{ fontSize: '0.8125rem' }}>
+                  {template.name} · ≥ {formatAmount(template.min_amount)}
+                </MenuItem>
+              ))}
+              <MenuItem value={0} sx={{ fontSize: '0.8125rem' }}>Built-in default 内置模板</MenuItem>
+            </Select>
             <Typography sx={{ fontSize: '0.71875rem', color: PURPLE }}>
-              — edit anything below before sending 发送前可任意修改
+              switching refills the letter; edit anything before sending 切换模板会重新填充，可再修改
             </Typography>
           </Box>
           <TextField

--- a/ProjectCode/client/src/components/DonationLedger.test.js
+++ b/ProjectCode/client/src/components/DonationLedger.test.js
@@ -122,6 +122,7 @@ beforeEach(() => {
     subject: 'Thank you for supporting NewBee Running Club!',
     body: 'Dear donor, thank you for your generous donation.',
     template_name: null,
+    template_id: 0,
   });
   getThankYouTemplates.mockResolvedValue([]);
   createThankYouTemplate.mockResolvedValue({});
@@ -279,6 +280,32 @@ test('send dialog prefills the matched letter and sends the edited version', asy
     expect(screen.queryByText('✉ Send thank-you email 发送感谢邮件')).not.toBeInTheDocument()
   );
   expect(getDonationLedger).toHaveBeenCalledTimes(2);
+});
+
+test('switching templates in the send dialog refills the letter', async () => {
+  getThankYouTemplates.mockResolvedValue([
+    { id: 5, name: 'Major donor', min_amount: '300', subject: 'S', body: 'B' },
+  ]);
+  getThankYouPreview
+    .mockResolvedValueOnce({
+      subject: 'Auto subject', body: 'Auto body', template_name: null, template_id: 0,
+    })
+    .mockResolvedValueOnce({
+      subject: 'Major subject', body: 'Major body for Golden Wheat',
+      template_name: 'Major donor', template_id: 5,
+    });
+
+  render(<DonationLedger />);
+  await screen.findByText('Golden Wheat Bakery');
+  fireEvent.click(screen.getByText('Send thank-you 发送感谢'));
+  await screen.findByDisplayValue('Auto body');
+
+  fireEvent.mouseDown(screen.getByLabelText('Template 模板').closest('[role="combobox"]') || screen.getAllByRole('combobox')[0]);
+  fireEvent.click(await screen.findByText(/Major donor · ≥ \$300\.00/));
+
+  await waitFor(() => expect(getThankYouPreview).toHaveBeenCalledWith(12, 'admin-uid', 5));
+  expect(await screen.findByDisplayValue('Major body for Golden Wheat')).toBeInTheDocument();
+  expect(screen.getByDisplayValue('Major subject')).toBeInTheDocument();
 });
 
 test('attach-receipt checkbox can be unchecked before sending', async () => {

--- a/ProjectCode/server/routes/donors.py
+++ b/ProjectCode/server/routes/donors.py
@@ -421,19 +421,42 @@ def _compose_thank_you(db: Session, donor):
 @router.get("/donations/{donation_id}/thank-you-preview")
 def thank_you_preview(
     donation_id: int,
+    template_id: Optional[int] = None,
     db: Session = Depends(get_db),
     current_admin: Member = Depends(get_current_committee_or_admin)
 ):
-    """The letter this donation would get (matched template rendered with
-    the donor's details), for committee to review and edit before sending."""
+    """The rendered letter for this donation, for committee to review and
+    edit before sending. By default the amount-matched template is used;
+    pass template_id to render a specific one (0 = built-in default)."""
     donor = db.query(Donor).filter(Donor.donation_id == donation_id).first()
     if not donor:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Donation {donation_id} not found"
         )
-    subject, _, body_text, template_name = _compose_thank_you(db, donor)
-    return {"subject": subject, "body": body_text, "template_name": template_name}
+
+    if template_id is not None and template_id != 0:
+        template = db.query(ThankYouTemplate).filter(
+            ThankYouTemplate.id == template_id).first()
+        if not template:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Template {template_id} not found"
+            )
+    elif template_id == 0:
+        template = None  # explicitly the built-in default
+    else:
+        template = _select_template(db, donor)  # auto-match by amount
+
+    if template:
+        subject = _render_placeholders(template.subject, donor)
+        body_text = _render_placeholders(template.body, donor)
+        return {"subject": subject, "body": body_text,
+                "template_name": template.name, "template_id": template.id}
+
+    subject, _, body_text = _thank_you_email(donor)
+    return {"subject": subject, "body": body_text,
+            "template_name": None, "template_id": 0}
 
 
 @router.post("/donations/{donation_id}/send-thank-you", response_model=DonorLedgerEntry)

--- a/ProjectCode/server/tests/test_thankyou_templates.py
+++ b/ProjectCode/server/tests/test_thankyou_templates.py
@@ -121,7 +121,45 @@ def test_preview_falls_back_to_builtin_without_templates(client, db_session, com
     preview = client.get(f'/api/donors/donations/{donor.donation_id}/thank-you-preview',
                          headers=auth(committee_member)).json()
     assert preview['template_name'] is None
+    assert preview['template_id'] == 0
     assert '新蜂跑团' in preview['body']
+
+
+def test_preview_with_explicit_template_id(client, db_session, committee_member):
+    """Committee can override the auto-match and pick any template."""
+    seed_template(db_session, 'Standard', min_amount=0)
+    major = seed_template(db_session, 'Major', min_amount=1000,
+                          subject='Major thanks {name}', body='Major body {amount}')
+    donor = seed_donation(db_session, 'D1', name='Kevin Gu', amount=15)
+
+    # Auto-match picks Standard for $15...
+    auto = client.get(f'/api/donors/donations/{donor.donation_id}/thank-you-preview',
+                      headers=auth(committee_member)).json()
+    assert auto['template_name'] == 'Standard'
+
+    # ...but an explicit template_id renders the chosen one
+    picked = client.get(
+        f'/api/donors/donations/{donor.donation_id}/thank-you-preview',
+        params={'template_id': major.id}, headers=auth(committee_member)).json()
+    assert picked['template_name'] == 'Major'
+    assert picked['template_id'] == major.id
+    assert picked['subject'] == 'Major thanks Kevin Gu'
+    assert picked['body'] == 'Major body $15.00'
+
+    # template_id=0 explicitly requests the built-in default
+    builtin = client.get(
+        f'/api/donors/donations/{donor.donation_id}/thank-you-preview',
+        params={'template_id': 0}, headers=auth(committee_member)).json()
+    assert builtin['template_name'] is None
+    assert '新蜂跑团' in builtin['body']
+
+
+def test_preview_unknown_template_404(client, db_session, committee_member):
+    donor = seed_donation(db_session, 'D1')
+    resp = client.get(
+        f'/api/donors/donations/{donor.donation_id}/thank-you-preview',
+        params={'template_id': 999}, headers=auth(committee_member))
+    assert resp.status_code == 404
 
 
 # ---------------------------------------------------------------- send with edits + receipt


### PR DESCRIPTION
The send dialog's matched-template banner is now a **dropdown**: it defaults to the amount-matched tier but committee can pick any template (or the built-in default), and the subject/body instantly refill with the chosen template's placeholders rendered. Backend preview endpoint accepts `template_id` (0 = built-in).

Tests: backend 851 / frontend 1087 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)