### PR TITLE
Finance module: Books Grid — the website runs the club's full bookkeeping

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,6 +124,17 @@ python main.py                                    # Run on localhost:8000
 - `GET /api/donors/donations/{id}/thank-you-preview` - Rendered letter (matched tier) for the send dialog
 - `GET /api/donors/donations/{id}/receipt` - Official donation receipt PDF (server/assets holds the letterhead logo + authorized signature)
 
+### Finance module (committee/admin, X-Firebase-UID header) — Books Grid at /finance
+- `GET/POST/PUT /api/finance/categories[/{id}]` - Coded categories: events 1xxx, income types 2xxx, expense cats 5xxx (mirrors the club's Google Sheet)
+- `GET /api/finance/income`, `POST /api/finance/income/classify`, `POST /api/finance/income/manual` - Two-layer income classification (income_type × event_code); only `donation` rows publish publicly
+- `GET /api/finance/expenses`, `POST /api/finance/expenses/classify`, `DELETE /api/finance/expenses/{id}`, `POST /api/finance/bank-import` - Chase CSV import (outflows→expenses, non-Zelle/Venmo inflows→income; BANK| dedup)
+- `GET/PUT/DELETE /api/finance/directory[/{id}]` - Donor name↔email memory (+ is_insider for the 509 test)
+- `GET /api/finance/ack-queue`, `POST /api/finance/send-acks` - Batch acknowledgments (tiered templates + receipts); weekly auto-send scheduler job `auto_ack_donations` behind the `finance_auto_ack` setting
+- `GET /api/finance/reports/by-event[?year]` (+ `/export` CSV), `/reports/yoy`, `/reports/public-support` - Cash-basis reports incl. 509(a)(1)/(a)(2) tests
+- `GET /api/finance/year-end/preview?year`, `POST /api/finance/year-end/send` - Annual per-donor statements (double-send guarded)
+- `GET/PUT /api/finance/settings` - auto_ack_enabled, org_start, fye_month
+- Migration: `migrate_finance_module.py` (donors.income_type/event_code + seeds + backfill)
+
 Weekly Gmail sync: APScheduler job `sync_zelle_donations` (Mon 4:30 AM UTC) reads
 Chase Zelle emails (Gmail label "NewBee Finance/Chase") and Venmo payment
 emails (label "NewBee Finance/Venmo") via IMAP (`sync_zelle_donations.py`) and

--- a/ProjectCode/client/src/App.js
+++ b/ProjectCode/client/src/App.js
@@ -13,6 +13,7 @@ import HomePage from "./pages/HomePage";
 const AboutPage = React.lazy(() => import("./pages/AboutPage"));
 const AdminPanelPage = React.lazy(() => import("./pages/AdminPanelPage"));
 const CalendarPage = React.lazy(() => import("./pages/CalendarPage"));
+const FinancePage = React.lazy(() => import("./pages/FinancePage"));
 const GalleryPage = React.lazy(() => import("./pages/GalleryPage"));
 const HighlightsPage = React.lazy(() => import("./pages/HighlightsPage"));
 const JoinPage = React.lazy(() => import("./pages/JoinPage"));
@@ -82,6 +83,7 @@ export default function App() {
                   <Route path="/register" element={<RegisterPage />} />
                   <Route path="/profile" element={<ProfilePage />} />
                   <Route path="/admin" element={<AdminPanelPage />} />
+                  <Route path="/finance" element={<FinancePage />} />
                   {/* Gallery Route */}
                   <Route path="/events/:eventId/gallery" element={<GalleryPage />} />
                 </Routes>

--- a/ProjectCode/client/src/api/finance.js
+++ b/ProjectCode/client/src/api/finance.js
@@ -1,0 +1,234 @@
+/**
+ * Finance (Books Grid) API functions — committee/admin only.
+ * Every call carries the X-Firebase-UID auth header.
+ */
+
+import { api } from './client';
+
+const API_BASE_URL = process.env.REACT_APP_API_BASE_URL || 'http://localhost:8000';
+
+const authHeader = (firebaseUid) => ({ 'X-Firebase-UID': firebaseUid });
+
+/**
+ * Get all finance categories grouped by kind
+ * @param {string} firebaseUid - Committee/admin Firebase UID
+ * @returns {Promise<Object>} { events, income_types, expenses } — each an array of {id, kind, code, name, is_active}
+ */
+export async function getFinanceCategories(firebaseUid) {
+  return api.get('/api/finance/categories', {}, authHeader(firebaseUid), { skipCache: true });
+}
+
+/**
+ * Create a finance category (code auto-assigned when omitted)
+ * @param {Object} data - { kind: 'event'|'income_type'|'expense', name, code? }
+ * @param {string} firebaseUid - Committee/admin Firebase UID
+ * @returns {Promise<Object>} Created category
+ */
+export async function createFinanceCategory(data, firebaseUid) {
+  return api.post('/api/finance/categories', data, authHeader(firebaseUid));
+}
+
+/**
+ * Update a finance category (rename / archive)
+ * @param {number} categoryId - Category ID
+ * @param {Object} data - { name?, is_active? }
+ * @param {string} firebaseUid - Committee/admin Firebase UID
+ * @returns {Promise<Object>} Updated category
+ */
+export async function updateFinanceCategory(categoryId, data, firebaseUid) {
+  return api.put(`/api/finance/categories/${categoryId}`, data, authHeader(firebaseUid));
+}
+
+/**
+ * Get all income rows (unclassified first)
+ * @param {string} firebaseUid - Committee/admin Firebase UID
+ * @returns {Promise<Array>} Donation ledger rows with income_type / event_code
+ */
+export async function getIncome(firebaseUid) {
+  return api.get('/api/finance/income', {}, authHeader(firebaseUid), { skipCache: true });
+}
+
+/**
+ * Classify one or more income rows
+ * @param {Object} data - { donation_ids: [int], income_type, event_code? }
+ * @param {string} firebaseUid - Committee/admin Firebase UID
+ * @returns {Promise<Object>} { updated }
+ */
+export async function classifyIncome(data, firebaseUid) {
+  return api.post('/api/finance/income/classify', data, authHeader(firebaseUid));
+}
+
+/**
+ * Record a manual income row (cash, check, ...)
+ * @param {Object} data - { name, amount, donation_date?, method?, memo?, income_type, event_code? }
+ * @param {string} firebaseUid - Committee/admin Firebase UID
+ * @returns {Promise<Object>} Created row
+ */
+export async function addManualIncome(data, firebaseUid) {
+  return api.post('/api/finance/income/manual', data, authHeader(firebaseUid));
+}
+
+/**
+ * Get all expense rows (unclassified first)
+ * @param {string} firebaseUid - Committee/admin Firebase UID
+ * @returns {Promise<Array>} [{id, expense_date, vendor, amount, method, bank_description, event_code, expense_category_code}]
+ */
+export async function getExpenses(firebaseUid) {
+  return api.get('/api/finance/expenses', {}, authHeader(firebaseUid), { skipCache: true });
+}
+
+/**
+ * Classify one or more expense rows
+ * @param {Object} data - { expense_ids: [int], event_code?, expense_category_code? }
+ * @param {string} firebaseUid - Committee/admin Firebase UID
+ * @returns {Promise<Object>} { updated }
+ */
+export async function classifyExpenses(data, firebaseUid) {
+  return api.post('/api/finance/expenses/classify', data, authHeader(firebaseUid));
+}
+
+/**
+ * Delete an expense row
+ * @param {number} expenseId - Expense ID
+ * @param {string} firebaseUid - Committee/admin Firebase UID
+ * @returns {Promise<Object>} Deletion result
+ */
+export async function deleteExpense(expenseId, firebaseUid) {
+  return api.delete(`/api/finance/expenses/${expenseId}`, authHeader(firebaseUid));
+}
+
+/**
+ * Import a Chase bank CSV (expenses + income; duplicates skipped)
+ * @param {string} csvText - Raw CSV file contents
+ * @param {string} firebaseUid - Committee/admin Firebase UID
+ * @returns {Promise<Object>} { expenses_added, income_added, duplicates, skipped_gmail_synced, errors }
+ */
+export async function importBankCsv(csvText, firebaseUid) {
+  return api.post('/api/finance/bank-import', { csv_text: csvText }, authHeader(firebaseUid));
+}
+
+/**
+ * Get the donor email directory
+ * @param {string} firebaseUid - Committee/admin Firebase UID
+ * @returns {Promise<Array>} [{id, name, email, is_insider}]
+ */
+export async function getDirectory(firebaseUid) {
+  return api.get('/api/finance/directory', {}, authHeader(firebaseUid), { skipCache: true });
+}
+
+/**
+ * Upsert a directory entry (matched by name)
+ * @param {Object} data - { name, email, is_insider? }
+ * @param {string} firebaseUid - Committee/admin Firebase UID
+ * @returns {Promise<Object>} Upserted entry
+ */
+export async function upsertDirectoryEntry(data, firebaseUid) {
+  return api.put('/api/finance/directory', data, authHeader(firebaseUid));
+}
+
+/**
+ * Delete a directory entry
+ * @param {number} entryId - Directory entry ID
+ * @param {string} firebaseUid - Committee/admin Firebase UID
+ * @returns {Promise<Object>} Deletion result
+ */
+export async function deleteDirectoryEntry(entryId, firebaseUid) {
+  return api.delete(`/api/finance/directory/${entryId}`, authHeader(firebaseUid));
+}
+
+/**
+ * Get the acknowledgment queue (classified donations not yet thanked)
+ * @param {string} firebaseUid - Committee/admin Firebase UID
+ * @returns {Promise<Array>} [{donation_id, name, amount, donation_date, event_code, email|null}]
+ */
+export async function getAckQueue(firebaseUid) {
+  return api.get('/api/finance/ack-queue', {}, authHeader(firebaseUid), { skipCache: true });
+}
+
+/**
+ * Send acknowledgment emails for the queue (or a subset)
+ * @param {number[]} [donationIds] - Specific donations; omit to send the whole queue
+ * @param {string} firebaseUid - Committee/admin Firebase UID
+ * @returns {Promise<Object>} { results, sent, skipped }
+ */
+export async function sendAcks(donationIds, firebaseUid) {
+  const payload = donationIds ? { donation_ids: donationIds } : {};
+  return api.post('/api/finance/send-acks', payload, authHeader(firebaseUid));
+}
+
+/**
+ * By-event income/expense matrix report
+ * @param {number|string} [year] - Calendar year; omit for all years
+ * @param {string} firebaseUid - Committee/admin Firebase UID
+ * @returns {Promise<Object>} { year, events, totals }
+ */
+export async function getReportByEvent(year, firebaseUid) {
+  const params = year ? { year } : {};
+  return api.get('/api/finance/reports/by-event', params, authHeader(firebaseUid), { skipCache: true });
+}
+
+/**
+ * Year-over-year comparison per event
+ * @param {string} firebaseUid - Committee/admin Firebase UID
+ * @returns {Promise<Object>} { years, events }
+ */
+export async function getReportYoy(firebaseUid) {
+  return api.get('/api/finance/reports/yoy', {}, authHeader(firebaseUid), { skipCache: true });
+}
+
+/**
+ * Public support test report — 509(a)(1) and 509(a)(2)
+ * @param {string} firebaseUid - Committee/admin Firebase UID
+ * @returns {Promise<Object>} Support totals, both tests, headroom, watch list
+ */
+export async function getReportPublicSupport(firebaseUid) {
+  return api.get('/api/finance/reports/public-support', {}, authHeader(firebaseUid), { skipCache: true });
+}
+
+/**
+ * Get finance settings
+ * @param {string} firebaseUid - Committee/admin Firebase UID
+ * @returns {Promise<Object>} { auto_ack_enabled, org_start, fye_month }
+ */
+export async function getFinanceSettings(firebaseUid) {
+  return api.get('/api/finance/settings', {}, authHeader(firebaseUid), { skipCache: true });
+}
+
+/**
+ * Update finance settings
+ * @param {Object} data - { auto_ack_enabled?, org_start?, fye_month? }
+ * @param {string} firebaseUid - Committee/admin Firebase UID
+ * @returns {Promise<Object>} Updated settings
+ */
+export async function updateFinanceSettings(data, firebaseUid) {
+  return api.put('/api/finance/settings', data, authHeader(firebaseUid));
+}
+
+/**
+ * Download the by-event report as a CSV file.
+ * Raw fetch because the response is a file, not JSON.
+ * @param {number|string} [year] - Calendar year; omit for all years
+ * @param {string} firebaseUid - Committee/admin Firebase UID
+ * @returns {Promise<{blob: Blob, filename: string}>}
+ */
+export async function downloadByEventCsv(year, firebaseUid) {
+  const query = year ? `?${new URLSearchParams({ year }).toString()}` : '';
+  const response = await fetch(`${API_BASE_URL}/api/finance/reports/by-event/export${query}`, {
+    headers: { 'X-Firebase-UID': firebaseUid },
+  });
+  if (!response.ok) {
+    let detail = `Request failed with status ${response.status}`;
+    try {
+      const data = await response.json();
+      detail = data?.detail || detail;
+    } catch {
+      // Response body is not JSON
+    }
+    throw new Error(detail);
+  }
+  const disposition = response.headers.get('content-disposition') || '';
+  const match = disposition.match(/filename="?([^";]+)"?/);
+  const filename = match ? match[1] : `newbee-finance-by-event${year ? `-${year}` : ''}.csv`;
+  const blob = await response.blob();
+  return { blob, filename };
+}

--- a/ProjectCode/client/src/api/finance.test.js
+++ b/ProjectCode/client/src/api/finance.test.js
@@ -1,0 +1,220 @@
+import { api } from './client';
+import {
+  getFinanceCategories,
+  createFinanceCategory,
+  updateFinanceCategory,
+  getIncome,
+  classifyIncome,
+  addManualIncome,
+  getExpenses,
+  classifyExpenses,
+  deleteExpense,
+  importBankCsv,
+  getDirectory,
+  upsertDirectoryEntry,
+  deleteDirectoryEntry,
+  getAckQueue,
+  sendAcks,
+  getReportByEvent,
+  getReportYoy,
+  getReportPublicSupport,
+  getFinanceSettings,
+  updateFinanceSettings,
+  downloadByEventCsv,
+} from './finance';
+
+jest.mock('./client', () => ({
+  api: { get: jest.fn(), post: jest.fn(), put: jest.fn(), delete: jest.fn() },
+}));
+
+const AUTH = { 'X-Firebase-UID': 'uid-1' };
+const SKIP = { skipCache: true };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  api.get.mockResolvedValue('GET');
+  api.post.mockResolvedValue('POST');
+  api.put.mockResolvedValue('PUT');
+  api.delete.mockResolvedValue('DELETE');
+});
+
+test('getFinanceCategories GETs categories with auth, skipping cache', async () => {
+  await expect(getFinanceCategories('uid-1')).resolves.toBe('GET');
+  expect(api.get).toHaveBeenCalledWith('/api/finance/categories', {}, AUTH, SKIP);
+});
+
+test('createFinanceCategory POSTs the new category', async () => {
+  await expect(createFinanceCategory({ kind: 'event', name: 'Bear Mt. Run' }, 'uid-1')).resolves.toBe('POST');
+  expect(api.post).toHaveBeenCalledWith(
+    '/api/finance/categories', { kind: 'event', name: 'Bear Mt. Run' }, AUTH
+  );
+});
+
+test('updateFinanceCategory PUTs the rename/archive payload', async () => {
+  await expect(updateFinanceCategory(3, { name: 'Gala', is_active: false }, 'uid-1')).resolves.toBe('PUT');
+  expect(api.put).toHaveBeenCalledWith(
+    '/api/finance/categories/3', { name: 'Gala', is_active: false }, AUTH
+  );
+});
+
+test('getIncome GETs income rows with auth, skipping cache', async () => {
+  await expect(getIncome('uid-1')).resolves.toBe('GET');
+  expect(api.get).toHaveBeenCalledWith('/api/finance/income', {}, AUTH, SKIP);
+});
+
+test('classifyIncome POSTs the ids, type and event', async () => {
+  const payload = { donation_ids: [1, 2], income_type: 'pass_through', event_code: 12 };
+  await expect(classifyIncome(payload, 'uid-1')).resolves.toBe('POST');
+  expect(api.post).toHaveBeenCalledWith('/api/finance/income/classify', payload, AUTH);
+});
+
+test('addManualIncome POSTs the manual row', async () => {
+  const payload = { name: 'Cash box', amount: 40, income_type: 'event_revenue' };
+  await expect(addManualIncome(payload, 'uid-1')).resolves.toBe('POST');
+  expect(api.post).toHaveBeenCalledWith('/api/finance/income/manual', payload, AUTH);
+});
+
+test('getExpenses GETs expense rows with auth, skipping cache', async () => {
+  await expect(getExpenses('uid-1')).resolves.toBe('GET');
+  expect(api.get).toHaveBeenCalledWith('/api/finance/expenses', {}, AUTH, SKIP);
+});
+
+test('classifyExpenses POSTs ids with event and category codes', async () => {
+  const payload = { expense_ids: [7], event_code: 11, expense_category_code: 201 };
+  await expect(classifyExpenses(payload, 'uid-1')).resolves.toBe('POST');
+  expect(api.post).toHaveBeenCalledWith('/api/finance/expenses/classify', payload, AUTH);
+});
+
+test('deleteExpense DELETEs the expense', async () => {
+  await expect(deleteExpense(9, 'uid-1')).resolves.toBe('DELETE');
+  expect(api.delete).toHaveBeenCalledWith('/api/finance/expenses/9', AUTH);
+});
+
+test('importBankCsv POSTs the raw CSV text', async () => {
+  await expect(importBankCsv('Date,Amount\n1/2/26,-30', 'uid-1')).resolves.toBe('POST');
+  expect(api.post).toHaveBeenCalledWith(
+    '/api/finance/bank-import', { csv_text: 'Date,Amount\n1/2/26,-30' }, AUTH
+  );
+});
+
+test('getDirectory GETs the directory with auth, skipping cache', async () => {
+  await expect(getDirectory('uid-1')).resolves.toBe('GET');
+  expect(api.get).toHaveBeenCalledWith('/api/finance/directory', {}, AUTH, SKIP);
+});
+
+test('upsertDirectoryEntry PUTs the entry', async () => {
+  const payload = { name: 'Li Chen', email: 'li@example.com', is_insider: true };
+  await expect(upsertDirectoryEntry(payload, 'uid-1')).resolves.toBe('PUT');
+  expect(api.put).toHaveBeenCalledWith('/api/finance/directory', payload, AUTH);
+});
+
+test('deleteDirectoryEntry DELETEs the entry', async () => {
+  await expect(deleteDirectoryEntry(4, 'uid-1')).resolves.toBe('DELETE');
+  expect(api.delete).toHaveBeenCalledWith('/api/finance/directory/4', AUTH);
+});
+
+test('getAckQueue GETs the queue with auth, skipping cache', async () => {
+  await expect(getAckQueue('uid-1')).resolves.toBe('GET');
+  expect(api.get).toHaveBeenCalledWith('/api/finance/ack-queue', {}, AUTH, SKIP);
+});
+
+test('sendAcks POSTs specific donation ids when given', async () => {
+  await expect(sendAcks([1, 2, 3], 'uid-1')).resolves.toBe('POST');
+  expect(api.post).toHaveBeenCalledWith(
+    '/api/finance/send-acks', { donation_ids: [1, 2, 3] }, AUTH
+  );
+});
+
+test('sendAcks POSTs an empty payload to send the whole queue', async () => {
+  await sendAcks(undefined, 'uid-1');
+  expect(api.post).toHaveBeenCalledWith('/api/finance/send-acks', {}, AUTH);
+});
+
+test('getReportByEvent GETs the matrix, passing the year when given', async () => {
+  await expect(getReportByEvent(2026, 'uid-1')).resolves.toBe('GET');
+  expect(api.get).toHaveBeenCalledWith(
+    '/api/finance/reports/by-event', { year: 2026 }, AUTH, SKIP
+  );
+});
+
+test('getReportByEvent omits the year param for all years', async () => {
+  await getReportByEvent(undefined, 'uid-1');
+  expect(api.get).toHaveBeenCalledWith('/api/finance/reports/by-event', {}, AUTH, SKIP);
+});
+
+test('getReportYoy GETs the year-over-year report', async () => {
+  await expect(getReportYoy('uid-1')).resolves.toBe('GET');
+  expect(api.get).toHaveBeenCalledWith('/api/finance/reports/yoy', {}, AUTH, SKIP);
+});
+
+test('getReportPublicSupport GETs the 509(a) report', async () => {
+  await expect(getReportPublicSupport('uid-1')).resolves.toBe('GET');
+  expect(api.get).toHaveBeenCalledWith('/api/finance/reports/public-support', {}, AUTH, SKIP);
+});
+
+test('getFinanceSettings GETs settings with auth, skipping cache', async () => {
+  await expect(getFinanceSettings('uid-1')).resolves.toBe('GET');
+  expect(api.get).toHaveBeenCalledWith('/api/finance/settings', {}, AUTH, SKIP);
+});
+
+test('updateFinanceSettings PUTs the settings payload', async () => {
+  const payload = { auto_ack_enabled: true, fye_month: 12 };
+  await expect(updateFinanceSettings(payload, 'uid-1')).resolves.toBe('PUT');
+  expect(api.put).toHaveBeenCalledWith('/api/finance/settings', payload, AUTH);
+});
+
+describe('downloadByEventCsv', () => {
+  afterEach(() => {
+    delete global.fetch;
+  });
+
+  test('fetches the CSV with the year and returns blob + filename', async () => {
+    const blob = new Blob(['csv']);
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      headers: { get: () => 'attachment; filename="newbee-finance-2026.csv"' },
+      blob: () => Promise.resolve(blob),
+    });
+
+    const result = await downloadByEventCsv(2026, 'uid-1');
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/api/finance/reports/by-event/export?year=2026'),
+      { headers: { 'X-Firebase-UID': 'uid-1' } }
+    );
+    expect(result.blob).toBe(blob);
+    expect(result.filename).toBe('newbee-finance-2026.csv');
+  });
+
+  test('omits the query and falls back to a default filename', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      headers: { get: () => null },
+      blob: () => Promise.resolve(new Blob(['csv'])),
+    });
+
+    const result = await downloadByEventCsv(undefined, 'uid-1');
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringMatching(/\/api\/finance\/reports\/by-event\/export$/),
+      { headers: { 'X-Firebase-UID': 'uid-1' } }
+    );
+    expect(result.filename).toBe('newbee-finance-by-event.csv');
+  });
+
+  test('throws the API detail message on failure', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 403,
+      json: () => Promise.resolve({ detail: 'Committee access required' }),
+    });
+    await expect(downloadByEventCsv(2026, 'uid-1')).rejects.toThrow('Committee access required');
+  });
+
+  test('throws a status message when the error body is not JSON', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: () => Promise.reject(new Error('not json')),
+    });
+    await expect(downloadByEventCsv(2026, 'uid-1')).rejects.toThrow('Request failed with status 500');
+  });
+});

--- a/ProjectCode/client/src/components/DonationLedger.js
+++ b/ProjectCode/client/src/components/DonationLedger.js
@@ -11,6 +11,7 @@ import ReceiptLongIcon from '@mui/icons-material/ReceiptLong';
 import CheckIcon from '@mui/icons-material/Check';
 import CloseIcon from '@mui/icons-material/Close';
 import FileDownloadOutlinedIcon from '@mui/icons-material/FileDownloadOutlined';
+import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../context';
 import {
   getDonationLedger, approveDonation, dismissDonation, sendThankYou,
@@ -134,6 +135,7 @@ function SourceChip({ donation }) {
 
 export default function DonationLedger({ onLedgerChange }) {
   const { currentUser } = useAuth();
+  const navigate = useNavigate();
   const firebaseUid = currentUser?.uid;
 
   const [ledger, setLedger] = useState(null);
@@ -523,6 +525,17 @@ export default function DonationLedger({ onLedgerChange }) {
 
         <Box sx={{ flexGrow: 1 }} />
 
+        <Button
+          size="small"
+          onClick={() => navigate('/finance')}
+          sx={{
+            textTransform: 'none', fontWeight: 700, borderRadius: '99px', px: 2,
+            border: `1.5px solid ${LINE}`, color: MUTED, boxShadow: 'none',
+            '&:hover': { borderColor: ORANGE, color: ORANGE },
+          }}
+        >
+          📚 Finance 财务工作台 →
+        </Button>
         <Button
           size="small"
           onClick={openTemplates}

--- a/ProjectCode/client/src/components/DonationLedger.test.js
+++ b/ProjectCode/client/src/components/DonationLedger.test.js
@@ -20,6 +20,11 @@ import {
 jest.mock('../context', () => ({
   useAuth: jest.fn(),
 }));
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+}));
 jest.mock('../api/donors', () => ({
   getDonationLedger: jest.fn(),
   approveDonation: jest.fn(),
@@ -563,4 +568,11 @@ test('renders nothing to fetch without a logged-in user', () => {
   useAuth.mockReturnValue({ currentUser: null });
   render(<DonationLedger />);
   expect(getDonationLedger).not.toHaveBeenCalled();
+});
+
+test('links to the finance workbench', async () => {
+  render(<DonationLedger />);
+  await screen.findByText('Ming Zhao');
+  fireEvent.click(screen.getByText('📚 Finance 财务工作台 →'));
+  expect(mockNavigate).toHaveBeenCalledWith('/finance');
 });

--- a/ProjectCode/client/src/components/finance/DirectoryTab.js
+++ b/ProjectCode/client/src/components/finance/DirectoryTab.js
@@ -1,0 +1,249 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  Alert, Box, Button, Checkbox, CircularProgress, IconButton, Paper, Table,
+  TableBody, TableCell, TableContainer, TableHead, TableRow, TextField, Typography,
+} from '@mui/material';
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
+import { useAuth } from '../../context';
+import { getDirectory, upsertDirectoryEntry, deleteDirectoryEntry } from '../../api/finance';
+
+// Design tokens (homepage design language)
+const ORANGE = '#FFA500';
+const ORANGE_DARK = '#F29400';
+const LINE = '#EEE7DC';
+const MUTED = '#757575';
+const RED = '#c62828';
+
+const pillButtonSx = {
+  textTransform: 'none',
+  fontWeight: 700,
+  borderRadius: '99px',
+  px: 2,
+  boxShadow: 'none',
+  color: 'white',
+  backgroundColor: ORANGE,
+  '&:hover': { backgroundColor: ORANGE_DARK, boxShadow: 'none' },
+};
+
+export default function DirectoryTab() {
+  const { currentUser } = useAuth();
+  const firebaseUid = currentUser?.uid;
+
+  const [entries, setEntries] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [drafts, setDrafts] = useState({}); // id -> { email, is_insider }
+  const [savingId, setSavingId] = useState(null);
+  const [newEntry, setNewEntry] = useState({ name: '', email: '', is_insider: false });
+  const [adding, setAdding] = useState(false);
+
+  const fetchData = useCallback(async () => {
+    if (!firebaseUid) return;
+    setLoading(true);
+    setError('');
+    try {
+      setEntries(await getDirectory(firebaseUid));
+      setDrafts({});
+    } catch (err) {
+      console.error('Error loading directory:', err);
+      setError('Failed to load the directory. / 加载通讯录失败。');
+    } finally {
+      setLoading(false);
+    }
+  }, [firebaseUid]);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  const draftFor = (entry) => drafts[entry.id] || { email: entry.email, is_insider: Boolean(entry.is_insider) };
+
+  const setDraft = (entry, patch) => {
+    setDrafts((prev) => ({ ...prev, [entry.id]: { ...draftFor(entry), ...patch } }));
+  };
+
+  const isDirty = (entry) => {
+    const d = drafts[entry.id];
+    return Boolean(d) && (d.email !== entry.email || d.is_insider !== Boolean(entry.is_insider));
+  };
+
+  const handleSave = async (entry) => {
+    const d = draftFor(entry);
+    setSavingId(entry.id);
+    setError('');
+    try {
+      await upsertDirectoryEntry({ name: entry.name, email: d.email, is_insider: d.is_insider }, firebaseUid);
+      await fetchData();
+    } catch (err) {
+      console.error('Error saving directory entry:', err);
+      setError('Failed to save the entry. / 保存通讯录失败。');
+    } finally {
+      setSavingId(null);
+    }
+  };
+
+  const handleDelete = async (entry) => {
+    setError('');
+    try {
+      await deleteDirectoryEntry(entry.id, firebaseUid);
+      await fetchData();
+    } catch (err) {
+      console.error('Error deleting directory entry:', err);
+      setError('Failed to delete the entry. / 删除失败。');
+    }
+  };
+
+  const handleAdd = async () => {
+    setAdding(true);
+    setError('');
+    try {
+      await upsertDirectoryEntry(newEntry, firebaseUid);
+      setNewEntry({ name: '', email: '', is_insider: false });
+      await fetchData();
+    } catch (err) {
+      console.error('Error adding directory entry:', err);
+      setError('Failed to add the entry. / 添加失败。');
+    } finally {
+      setAdding(false);
+    }
+  };
+
+  if (loading && entries.length === 0) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', py: 6 }}>
+        <CircularProgress sx={{ color: ORANGE }} />
+      </Box>
+    );
+  }
+
+  return (
+    <Box>
+      {error && (
+        <Alert severity="error" onClose={() => setError('')} sx={{ mb: 1.5 }}>
+          {error}
+        </Alert>
+      )}
+
+      <Typography sx={{ fontSize: '0.75rem', color: MUTED, mb: 1.5 }}>
+        Payer name → email, used to send acknowledgments automatically. Mark committee members and their
+        families as insiders for the 509(a) tests. / 付款人姓名对应邮箱，用于自动发送致谢；请将委员会成员及家属标记为内部人，用于 509(a) 测试。
+      </Typography>
+
+      <TableContainer component={Paper} elevation={0} sx={{
+        border: `1px solid ${ORANGE}`,
+        borderRadius: '0 10px 10px 10px',
+        boxShadow: '0 2px 8px rgba(0,0,0,0.06)',
+      }}>
+        <Table size="small">
+          <TableHead>
+            <TableRow sx={{ backgroundColor: '#FDFBF7' }}>
+              {['Name 姓名', 'Email 邮箱', 'Insider 内部人', ''].map((h, i) => (
+                <TableCell key={`${h}-${i}`} sx={{
+                  fontSize: '0.625rem', fontWeight: 700, color: MUTED,
+                  textTransform: 'uppercase', letterSpacing: '0.4px',
+                  borderBottom: `1px solid ${LINE}`,
+                }}>
+                  {h}
+                </TableCell>
+              ))}
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {entries.length === 0 && (
+              <TableRow>
+                <TableCell colSpan={4} sx={{ textAlign: 'center', py: 4, color: MUTED }}>
+                  No entries yet. / 暂无通讯录条目。
+                </TableCell>
+              </TableRow>
+            )}
+            {entries.map((entry) => {
+              const d = draftFor(entry);
+              return (
+                <TableRow key={entry.id} hover>
+                  <TableCell sx={{ fontSize: '0.78125rem', fontWeight: 600, whiteSpace: 'nowrap' }}>
+                    {entry.name}
+                  </TableCell>
+                  <TableCell>
+                    <TextField
+                      size="small"
+                      fullWidth
+                      value={d.email}
+                      onChange={(e) => setDraft(entry, { email: e.target.value })}
+                      inputProps={{ 'aria-label': `Email for ${entry.name}` }}
+                      sx={{ '& .MuiInputBase-input': { fontSize: '0.78125rem', py: 0.5 } }}
+                    />
+                  </TableCell>
+                  <TableCell>
+                    <Checkbox
+                      size="small"
+                      checked={d.is_insider}
+                      onChange={(e) => setDraft(entry, { is_insider: e.target.checked })}
+                      inputProps={{ 'aria-label': `Insider for ${entry.name}` }}
+                      sx={{ color: ORANGE, '&.Mui-checked': { color: ORANGE } }}
+                    />
+                  </TableCell>
+                  <TableCell sx={{ whiteSpace: 'nowrap', textAlign: 'right' }}>
+                    {isDirty(entry) && (
+                      <Button
+                        size="small"
+                        onClick={() => handleSave(entry)}
+                        disabled={savingId === entry.id}
+                        sx={{ ...pillButtonSx, fontSize: '0.6875rem', py: 0.25, mr: 0.5 }}
+                      >
+                        {savingId === entry.id
+                          ? <CircularProgress size={12} sx={{ color: 'white' }} />
+                          : 'Save 保存'}
+                      </Button>
+                    )}
+                    <IconButton
+                      size="small"
+                      aria-label={`Delete ${entry.name}`}
+                      onClick={() => handleDelete(entry)}
+                    >
+                      <DeleteOutlineIcon sx={{ fontSize: 17, color: MUTED, '&:hover': { color: RED } }} />
+                    </IconButton>
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+      </TableContainer>
+
+      {/* Add row form */}
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, mt: 1.5, flexWrap: 'wrap' }}>
+        <TextField
+          label="Name 姓名"
+          size="small"
+          value={newEntry.name}
+          onChange={(e) => setNewEntry({ ...newEntry, name: e.target.value })}
+        />
+        <TextField
+          label="Email 邮箱"
+          size="small"
+          type="email"
+          value={newEntry.email}
+          onChange={(e) => setNewEntry({ ...newEntry, email: e.target.value })}
+        />
+        <Box sx={{ display: 'flex', alignItems: 'center' }}>
+          <Checkbox
+            size="small"
+            checked={newEntry.is_insider}
+            onChange={(e) => setNewEntry({ ...newEntry, is_insider: e.target.checked })}
+            inputProps={{ 'aria-label': 'New entry insider 内部人' }}
+            sx={{ color: ORANGE, '&.Mui-checked': { color: ORANGE } }}
+          />
+          <Typography sx={{ fontSize: '0.78125rem', color: MUTED }}>Insider 内部人</Typography>
+        </Box>
+        <Button
+          size="small"
+          onClick={handleAdd}
+          disabled={adding || !newEntry.name || !newEntry.email.includes('@')}
+          sx={pillButtonSx}
+        >
+          {adding ? <CircularProgress size={14} sx={{ color: 'white' }} /> : '＋ Add 添加'}
+        </Button>
+      </Box>
+    </Box>
+  );
+}

--- a/ProjectCode/client/src/components/finance/DirectoryTab.test.js
+++ b/ProjectCode/client/src/components/finance/DirectoryTab.test.js
@@ -1,0 +1,146 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import DirectoryTab from './DirectoryTab';
+import { useAuth } from '../../context';
+import { getDirectory, upsertDirectoryEntry, deleteDirectoryEntry } from '../../api/finance';
+
+jest.mock('../../context', () => ({
+  useAuth: jest.fn(),
+}));
+jest.mock('../../api/finance', () => ({
+  getDirectory: jest.fn(),
+  upsertDirectoryEntry: jest.fn(),
+  deleteDirectoryEntry: jest.fn(),
+}));
+
+const entries = [
+  { id: 1, name: 'Li Chen', email: 'li@example.com', is_insider: false },
+  { id: 2, name: 'Brandon Li', email: 'brandon@example.com', is_insider: true },
+];
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  useAuth.mockReturnValue({ currentUser: { uid: 'admin-uid' } });
+  getDirectory.mockResolvedValue(entries);
+  upsertDirectoryEntry.mockResolvedValue({});
+  deleteDirectoryEntry.mockResolvedValue({});
+});
+
+test('renders directory rows with emails and insider checkboxes', async () => {
+  render(<DirectoryTab />);
+  expect(await screen.findByText('Li Chen')).toBeInTheDocument();
+  expect(screen.getByText('Brandon Li')).toBeInTheDocument();
+  expect(screen.getByLabelText('Email for Li Chen')).toHaveValue('li@example.com');
+  expect(screen.getByLabelText('Insider for Li Chen')).not.toBeChecked();
+  expect(screen.getByLabelText('Insider for Brandon Li')).toBeChecked();
+});
+
+test('editing an email reveals Save and upserts the entry', async () => {
+  render(<DirectoryTab />);
+  await screen.findByText('Li Chen');
+  expect(screen.queryByText('Save 保存')).not.toBeInTheDocument();
+
+  fireEvent.change(screen.getByLabelText('Email for Li Chen'), {
+    target: { value: 'lichen@newbee.org' },
+  });
+  fireEvent.click(await screen.findByText('Save 保存'));
+
+  await waitFor(() => expect(upsertDirectoryEntry).toHaveBeenCalledWith(
+    { name: 'Li Chen', email: 'lichen@newbee.org', is_insider: false }, 'admin-uid'
+  ));
+  // Reloads the list afterwards
+  await waitFor(() => expect(getDirectory).toHaveBeenCalledTimes(2));
+});
+
+test('toggling the insider checkbox marks the row dirty and saves it', async () => {
+  render(<DirectoryTab />);
+  await screen.findByText('Li Chen');
+
+  fireEvent.click(screen.getByLabelText('Insider for Li Chen'));
+  fireEvent.click(await screen.findByText('Save 保存'));
+
+  await waitFor(() => expect(upsertDirectoryEntry).toHaveBeenCalledWith(
+    { name: 'Li Chen', email: 'li@example.com', is_insider: true }, 'admin-uid'
+  ));
+});
+
+test('reverting a draft hides the Save button again', async () => {
+  render(<DirectoryTab />);
+  await screen.findByText('Li Chen');
+  fireEvent.click(screen.getByLabelText('Insider for Li Chen'));
+  expect(await screen.findByText('Save 保存')).toBeInTheDocument();
+  fireEvent.click(screen.getByLabelText('Insider for Li Chen'));
+  await waitFor(() => expect(screen.queryByText('Save 保存')).not.toBeInTheDocument());
+});
+
+test('adds a new entry through the add form', async () => {
+  render(<DirectoryTab />);
+  await screen.findByText('Li Chen');
+
+  const addButton = screen.getByText('＋ Add 添加');
+  expect(addButton.closest('button')).toBeDisabled();
+
+  fireEvent.change(screen.getByLabelText('Name 姓名'), { target: { value: 'Yue Ma' } });
+  fireEvent.change(screen.getByLabelText('Email 邮箱'), { target: { value: 'yue@example.com' } });
+  fireEvent.click(screen.getByLabelText('New entry insider 内部人'));
+  expect(addButton.closest('button')).not.toBeDisabled();
+  fireEvent.click(addButton);
+
+  await waitFor(() => expect(upsertDirectoryEntry).toHaveBeenCalledWith(
+    { name: 'Yue Ma', email: 'yue@example.com', is_insider: true }, 'admin-uid'
+  ));
+  // Form resets after adding
+  await waitFor(() => expect(screen.getByLabelText('Name 姓名')).toHaveValue(''));
+});
+
+test('deletes an entry', async () => {
+  render(<DirectoryTab />);
+  await screen.findByText('Li Chen');
+  fireEvent.click(screen.getByLabelText('Delete Li Chen'));
+  await waitFor(() => expect(deleteDirectoryEntry).toHaveBeenCalledWith(1, 'admin-uid'));
+  await waitFor(() => expect(getDirectory).toHaveBeenCalledTimes(2));
+});
+
+test('shows an error when deleting fails', async () => {
+  deleteDirectoryEntry.mockRejectedValue(new Error('500'));
+  render(<DirectoryTab />);
+  await screen.findByText('Li Chen');
+  fireEvent.click(screen.getByLabelText('Delete Li Chen'));
+  expect(await screen.findByText(/删除失败/)).toBeInTheDocument();
+});
+
+test('shows an error when saving fails', async () => {
+  upsertDirectoryEntry.mockRejectedValue(new Error('422'));
+  render(<DirectoryTab />);
+  await screen.findByText('Li Chen');
+  fireEvent.click(screen.getByLabelText('Insider for Li Chen'));
+  fireEvent.click(await screen.findByText('Save 保存'));
+  expect(await screen.findByText(/保存通讯录失败/)).toBeInTheDocument();
+});
+
+test('shows an error when adding fails', async () => {
+  upsertDirectoryEntry.mockRejectedValue(new Error('422'));
+  render(<DirectoryTab />);
+  await screen.findByText('Li Chen');
+  fireEvent.change(screen.getByLabelText('Name 姓名'), { target: { value: 'X' } });
+  fireEvent.change(screen.getByLabelText('Email 邮箱'), { target: { value: 'x@y.com' } });
+  fireEvent.click(screen.getByText('＋ Add 添加'));
+  expect(await screen.findByText(/添加失败/)).toBeInTheDocument();
+});
+
+test('shows an error when loading fails', async () => {
+  getDirectory.mockRejectedValue(new Error('500'));
+  render(<DirectoryTab />);
+  expect(await screen.findByText(/加载通讯录失败/)).toBeInTheDocument();
+});
+
+test('shows an empty state without entries', async () => {
+  getDirectory.mockResolvedValue([]);
+  render(<DirectoryTab />);
+  expect(await screen.findByText(/暂无通讯录条目/)).toBeInTheDocument();
+});
+
+test('fetches nothing without a logged-in user', () => {
+  useAuth.mockReturnValue({ currentUser: null });
+  render(<DirectoryTab />);
+  expect(getDirectory).not.toHaveBeenCalled();
+});

--- a/ProjectCode/client/src/components/finance/ExpensesGrid.js
+++ b/ProjectCode/client/src/components/finance/ExpensesGrid.js
@@ -1,0 +1,422 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  Alert, Box, Button, Checkbox, Chip, CircularProgress, Dialog, DialogActions,
+  DialogContent, DialogTitle, IconButton, Menu, MenuItem, Paper, Select, Table,
+  TableBody, TableCell, TableContainer, TableHead, TableRow, Typography,
+} from '@mui/material';
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
+import { useAuth } from '../../context';
+import {
+  getExpenses, getFinanceCategories, classifyExpenses, deleteExpense,
+} from '../../api/finance';
+
+// Design tokens (homepage design language + finance chip colors)
+const ORANGE = '#FFA500';
+const ORANGE_DARK = '#F29400';
+const ORANGE_BG = '#FFF6E8';
+const LINE = '#EEE7DC';
+const INK = '#212121';
+const MUTED = '#757575';
+const TEAL = '#00796b';
+const TEAL_BG = '#e0f2f1';
+const PURPLE = '#7b3ff2';
+const PURPLE_BG = '#f3e8ff';
+const RED = '#c62828';
+
+const pillButtonSx = {
+  textTransform: 'none',
+  fontWeight: 700,
+  borderRadius: '99px',
+  px: 2,
+  boxShadow: 'none',
+  color: 'white',
+  backgroundColor: ORANGE,
+  '&:hover': { backgroundColor: ORANGE_DARK, boxShadow: 'none' },
+};
+
+const formatAmount = (amount) =>
+  `$${parseFloat(amount || 0).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+
+const formatDate = (dateStr) => {
+  if (!dateStr) return '';
+  const d = new Date(`${String(dateStr).slice(0, 10)}T00:00:00`);
+  if (Number.isNaN(d.getTime())) return dateStr;
+  const opts = { month: 'short', day: 'numeric' };
+  if (d.getFullYear() !== new Date().getFullYear()) opts.year = 'numeric';
+  return d.toLocaleDateString('en-US', opts);
+};
+
+function CellChip({ label, color, bg, dashed, onClick, ariaLabel }) {
+  return (
+    <Chip
+      size="small"
+      label={label}
+      onClick={onClick}
+      aria-label={ariaLabel}
+      sx={{
+        fontSize: '0.65625rem',
+        fontWeight: 700,
+        borderRadius: '99px',
+        cursor: 'pointer',
+        height: 22,
+        backgroundColor: dashed ? 'white' : bg,
+        color: dashed ? ORANGE : color,
+        border: dashed ? `1.5px dashed ${ORANGE}` : '1px dashed transparent',
+        '&:hover': { borderColor: ORANGE, backgroundColor: dashed ? ORANGE_BG : bg },
+      }}
+    />
+  );
+}
+
+export default function ExpensesGrid({ refreshKey = 0, onChanged }) {
+  const { currentUser } = useAuth();
+  const firebaseUid = currentUser?.uid;
+
+  const [rows, setRows] = useState([]);
+  const [events, setEvents] = useState([]);
+  const [expenseCategories, setExpenseCategories] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [selected, setSelected] = useState([]);
+  const [eventMenu, setEventMenu] = useState(null); // { anchorEl, row }
+  const [categoryMenu, setCategoryMenu] = useState(null); // { anchorEl, row }
+  const [bulkEvent, setBulkEvent] = useState('');
+  const [bulkCategory, setBulkCategory] = useState('');
+  const [applying, setApplying] = useState(false);
+  const [deleteTarget, setDeleteTarget] = useState(null);
+  const [deleting, setDeleting] = useState(false);
+
+  const fetchData = useCallback(async () => {
+    if (!firebaseUid) return;
+    setLoading(true);
+    setError('');
+    try {
+      const [expenses, categories] = await Promise.all([
+        getExpenses(firebaseUid),
+        getFinanceCategories(firebaseUid),
+      ]);
+      setRows(expenses);
+      setEvents((categories.events || []).filter((c) => c.is_active !== false));
+      setExpenseCategories((categories.expenses || []).filter((c) => c.is_active !== false));
+    } catch (err) {
+      console.error('Error loading expenses:', err);
+      setError('Failed to load expenses. / 加载支出记录失败。');
+    } finally {
+      setLoading(false);
+    }
+  }, [firebaseUid]);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData, refreshKey]);
+
+  const eventName = (code) => events.find((e) => e.code === code)?.name || `#${code}`;
+  const categoryName = (code) =>
+    expenseCategories.find((c) => c.code === code)?.name || `#${code}`;
+
+  const toggleSelected = (id) => {
+    setSelected((prev) =>
+      prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]);
+  };
+
+  const allSelected = rows.length > 0 && rows.every((r) => selected.includes(r.id));
+  const toggleAll = () => {
+    setSelected(allSelected ? [] : rows.map((r) => r.id));
+  };
+
+  const runClassify = async (payload) => {
+    setError('');
+    try {
+      await classifyExpenses(payload, firebaseUid);
+      await fetchData();
+      if (onChanged) onChanged();
+    } catch (err) {
+      console.error('Error classifying expenses:', err);
+      setError('Failed to classify. / 分类失败。');
+    }
+  };
+
+  const handlePickEvent = async (row, eventCode) => {
+    setEventMenu(null);
+    await runClassify({ expense_ids: [row.id], event_code: eventCode });
+  };
+
+  const handlePickCategory = async (row, categoryCode) => {
+    setCategoryMenu(null);
+    await runClassify({ expense_ids: [row.id], expense_category_code: categoryCode });
+  };
+
+  const handleBulkApply = async () => {
+    setApplying(true);
+    const payload = { expense_ids: selected };
+    if (bulkEvent !== '') payload.event_code = bulkEvent;
+    if (bulkCategory !== '') payload.expense_category_code = bulkCategory;
+    await runClassify(payload);
+    setSelected([]);
+    setApplying(false);
+  };
+
+  const handleDelete = async () => {
+    if (!deleteTarget) return;
+    setDeleting(true);
+    setError('');
+    try {
+      await deleteExpense(deleteTarget.id, firebaseUid);
+      setDeleteTarget(null);
+      await fetchData();
+      if (onChanged) onChanged();
+    } catch (err) {
+      console.error('Error deleting expense:', err);
+      setError('Failed to delete the expense. / 删除支出失败。');
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  if (loading && rows.length === 0) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', py: 6 }}>
+        <CircularProgress sx={{ color: ORANGE }} />
+      </Box>
+    );
+  }
+
+  return (
+    <Box>
+      {error && (
+        <Alert severity="error" onClose={() => setError('')} sx={{ mb: 1.5 }}>
+          {error}
+        </Alert>
+      )}
+
+      {/* Import hint banner */}
+      <Box sx={{
+        backgroundColor: ORANGE_BG, border: `1px dashed ${ORANGE}`, borderRadius: '10px',
+        px: 2, py: 1, mb: 1.5,
+      }}>
+        <Typography sx={{ fontSize: '0.75rem', color: MUTED }}>
+          ⬆ Use <b>Import Chase CSV 导入账单</b> in the toolbar above — duplicates are skipped automatically.
+          用上方工具栏导入 Chase 账单，重复记录自动跳过。
+        </Typography>
+      </Box>
+
+      {/* Expenses grid */}
+      <TableContainer component={Paper} elevation={0} sx={{
+        border: `1px solid ${ORANGE}`,
+        borderRadius: '0 10px 10px 10px',
+        boxShadow: '0 2px 8px rgba(0,0,0,0.06)',
+      }}>
+        <Table size="small">
+          <TableHead>
+            <TableRow sx={{ backgroundColor: '#FDFBF7' }}>
+              <TableCell padding="checkbox" sx={{ borderBottom: `1px solid ${LINE}` }}>
+                <Checkbox
+                  size="small"
+                  checked={allSelected}
+                  onChange={toggleAll}
+                  inputProps={{ 'aria-label': 'Select all expenses 全选' }}
+                  sx={{ color: ORANGE, '&.Mui-checked': { color: ORANGE } }}
+                />
+              </TableCell>
+              {['Date', 'Vendor 商家', 'Amount', 'Method', 'Bank description 银行描述', 'Event 活动 ▾', 'Category 类别 ▾', ''].map((h, i) => (
+                <TableCell key={`${h}-${i}`} sx={{
+                  fontSize: '0.625rem', fontWeight: 700, color: MUTED,
+                  textTransform: 'uppercase', letterSpacing: '0.4px',
+                  borderBottom: `1px solid ${LINE}`,
+                  textAlign: h === 'Amount' ? 'right' : 'left',
+                }}>
+                  {h}
+                </TableCell>
+              ))}
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {rows.length === 0 && (
+              <TableRow>
+                <TableCell colSpan={8} sx={{ textAlign: 'center', py: 4, color: MUTED }}>
+                  No expenses yet — import a Chase CSV to get started. / 暂无支出，请先导入账单。
+                </TableCell>
+              </TableRow>
+            )}
+            {rows.map((row) => {
+              const unclassified = !row.event_code && !row.expense_category_code;
+              return (
+                <TableRow key={row.id} hover sx={{ backgroundColor: unclassified ? '#FFFDF8' : 'inherit' }}>
+                  <TableCell padding="checkbox">
+                    <Checkbox
+                      size="small"
+                      checked={selected.includes(row.id)}
+                      onChange={() => toggleSelected(row.id)}
+                      inputProps={{ 'aria-label': `Select expense ${row.id}` }}
+                      sx={{ color: ORANGE, '&.Mui-checked': { color: ORANGE } }}
+                    />
+                  </TableCell>
+                  <TableCell sx={{ whiteSpace: 'nowrap', fontSize: '0.78125rem' }}>
+                    {formatDate(row.expense_date)}
+                  </TableCell>
+                  <TableCell sx={{ fontSize: '0.78125rem', fontWeight: 600 }}>
+                    {row.vendor}
+                  </TableCell>
+                  <TableCell sx={{ fontWeight: 700, color: RED, whiteSpace: 'nowrap', textAlign: 'right', fontSize: '0.78125rem' }}>
+                    -{formatAmount(row.amount)}
+                  </TableCell>
+                  <TableCell sx={{ fontSize: '0.78125rem', whiteSpace: 'nowrap' }}>
+                    {row.method || ''}
+                  </TableCell>
+                  <TableCell sx={{ maxWidth: 240 }}>
+                    <Typography sx={{ fontSize: '0.71875rem', color: MUTED }} noWrap>
+                      {row.bank_description || ''}
+                    </Typography>
+                  </TableCell>
+                  <TableCell>
+                    {row.event_code ? (
+                      <CellChip
+                        label={`${eventName(row.event_code)} ▾`}
+                        color={PURPLE}
+                        bg={PURPLE_BG}
+                        ariaLabel={`Event for expense ${row.id}`}
+                        onClick={(e) => setEventMenu({ anchorEl: e.currentTarget, row })}
+                      />
+                    ) : (
+                      <CellChip
+                        label="＋ event"
+                        dashed
+                        ariaLabel={`Event for expense ${row.id}`}
+                        onClick={(e) => setEventMenu({ anchorEl: e.currentTarget, row })}
+                      />
+                    )}
+                  </TableCell>
+                  <TableCell>
+                    {row.expense_category_code ? (
+                      <CellChip
+                        label={`${categoryName(row.expense_category_code)} ▾`}
+                        color={TEAL}
+                        bg={TEAL_BG}
+                        ariaLabel={`Category for expense ${row.id}`}
+                        onClick={(e) => setCategoryMenu({ anchorEl: e.currentTarget, row })}
+                      />
+                    ) : (
+                      <CellChip
+                        label="＋ category 类别"
+                        dashed
+                        ariaLabel={`Category for expense ${row.id}`}
+                        onClick={(e) => setCategoryMenu({ anchorEl: e.currentTarget, row })}
+                      />
+                    )}
+                  </TableCell>
+                  <TableCell sx={{ textAlign: 'right', width: 44 }}>
+                    <IconButton
+                      size="small"
+                      aria-label={`Delete expense ${row.id}`}
+                      onClick={() => setDeleteTarget(row)}
+                    >
+                      <DeleteOutlineIcon sx={{ fontSize: 17, color: MUTED, '&:hover': { color: RED } }} />
+                    </IconButton>
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+      </TableContainer>
+
+      {/* Bulk classify bar */}
+      {selected.length > 0 && (
+        <Box sx={{
+          display: 'flex', alignItems: 'center', gap: 1.25, flexWrap: 'wrap',
+          backgroundColor: INK, color: 'white', borderRadius: '12px',
+          px: 2, py: 1.25, mt: 1.5,
+        }}>
+          <Typography sx={{ fontSize: '0.78125rem', fontWeight: 700 }}>
+            ☑ {selected.length} rows selected 已选 {selected.length} 行 →
+          </Typography>
+          <Typography sx={{ fontSize: '0.78125rem' }}>set Event:</Typography>
+          <Select
+            size="small"
+            value={bulkEvent}
+            onChange={(e) => setBulkEvent(e.target.value)}
+            displayEmpty
+            inputProps={{ 'aria-label': 'Bulk event 批量活动' }}
+            sx={{ backgroundColor: 'white', borderRadius: '8px', fontSize: '0.75rem', fontWeight: 700, '& .MuiSelect-select': { py: 0.5 } }}
+          >
+            <MenuItem value="" sx={{ fontSize: '0.8125rem' }}>— keep 保持 —</MenuItem>
+            {events.map((ev) => (
+              <MenuItem key={ev.code} value={ev.code} sx={{ fontSize: '0.8125rem' }}>{ev.name}</MenuItem>
+            ))}
+          </Select>
+          <Typography sx={{ fontSize: '0.78125rem' }}>set Category 类别:</Typography>
+          <Select
+            size="small"
+            value={bulkCategory}
+            onChange={(e) => setBulkCategory(e.target.value)}
+            displayEmpty
+            inputProps={{ 'aria-label': 'Bulk category 批量类别' }}
+            sx={{ backgroundColor: 'white', borderRadius: '8px', fontSize: '0.75rem', fontWeight: 700, '& .MuiSelect-select': { py: 0.5 } }}
+          >
+            <MenuItem value="" sx={{ fontSize: '0.8125rem' }}>— keep 保持 —</MenuItem>
+            {expenseCategories.map((c) => (
+              <MenuItem key={c.code} value={c.code} sx={{ fontSize: '0.8125rem' }}>{c.name}</MenuItem>
+            ))}
+          </Select>
+          <Button
+            size="small"
+            onClick={handleBulkApply}
+            disabled={applying || (bulkEvent === '' && bulkCategory === '')}
+            sx={pillButtonSx}
+          >
+            {applying ? <CircularProgress size={14} sx={{ color: 'white' }} /> : 'Apply 应用'}
+          </Button>
+          <Button size="small" onClick={() => setSelected([])} sx={{ textTransform: 'none', color: 'rgba(255,255,255,0.7)', fontSize: '0.71875rem' }}>
+            Clear 清除
+          </Button>
+        </Box>
+      )}
+
+      {/* Event chip menu */}
+      <Menu anchorEl={eventMenu?.anchorEl} open={Boolean(eventMenu)} onClose={() => setEventMenu(null)}>
+        {events.map((ev) => (
+          <MenuItem
+            key={ev.code}
+            onClick={() => handlePickEvent(eventMenu.row, ev.code)}
+            sx={{ fontSize: '0.8125rem', fontWeight: 600, color: PURPLE }}
+          >
+            {ev.name}
+          </MenuItem>
+        ))}
+      </Menu>
+
+      {/* Category chip menu */}
+      <Menu anchorEl={categoryMenu?.anchorEl} open={Boolean(categoryMenu)} onClose={() => setCategoryMenu(null)}>
+        {expenseCategories.map((c) => (
+          <MenuItem
+            key={c.code}
+            onClick={() => handlePickCategory(categoryMenu.row, c.code)}
+            sx={{ fontSize: '0.8125rem', fontWeight: 600, color: TEAL }}
+          >
+            {c.name}
+          </MenuItem>
+        ))}
+      </Menu>
+
+      {/* Delete confirm dialog */}
+      <Dialog open={Boolean(deleteTarget)} onClose={() => setDeleteTarget(null)} maxWidth="xs" fullWidth>
+        <DialogTitle>Delete expense 删除支出?</DialogTitle>
+        <DialogContent>
+          <Typography sx={{ fontSize: '0.8125rem', color: MUTED }}>
+            {deleteTarget?.vendor} · -{formatAmount(deleteTarget?.amount)} · {formatDate(deleteTarget?.expense_date)}
+          </Typography>
+        </DialogContent>
+        <DialogActions sx={{ px: 3, py: 2 }}>
+          <Button onClick={() => setDeleteTarget(null)} disabled={deleting}>Cancel 取消</Button>
+          <Button
+            onClick={handleDelete}
+            disabled={deleting}
+            sx={{ ...pillButtonSx, backgroundColor: RED, '&:hover': { backgroundColor: '#a51f1f', boxShadow: 'none' } }}
+          >
+            {deleting ? <CircularProgress size={16} sx={{ color: 'white' }} /> : 'Delete 删除'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  );
+}

--- a/ProjectCode/client/src/components/finance/ExpensesGrid.test.js
+++ b/ProjectCode/client/src/components/finance/ExpensesGrid.test.js
@@ -1,0 +1,220 @@
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import ExpensesGrid from './ExpensesGrid';
+import { useAuth } from '../../context';
+import {
+  getExpenses, getFinanceCategories, classifyExpenses, deleteExpense,
+} from '../../api/finance';
+
+jest.mock('../../context', () => ({
+  useAuth: jest.fn(),
+}));
+jest.mock('../../api/finance', () => ({
+  getExpenses: jest.fn(),
+  getFinanceCategories: jest.fn(),
+  classifyExpenses: jest.fn(),
+  deleteExpense: jest.fn(),
+}));
+
+const currentYear = new Date().getFullYear();
+
+const expenseRows = [
+  {
+    id: 1,
+    expense_date: `${currentYear}-07-02`,
+    vendor: 'NYRR',
+    amount: '120.00',
+    method: 'Card',
+    bank_description: 'NYRR RACE FEE 0234',
+    event_code: null,
+    expense_category_code: null,
+  },
+  {
+    id: 2,
+    expense_date: `${currentYear}-06-20`,
+    vendor: 'Costco',
+    amount: '80.50',
+    method: 'Card',
+    bank_description: 'COSTCO WHSE #344',
+    event_code: 1002,
+    expense_category_code: 201,
+  },
+];
+
+const categories = {
+  events: [
+    { id: 1, kind: 'event', code: 1001, name: 'General', is_active: true },
+    { id: 2, kind: 'event', code: 1002, name: 'Bear Mt. Run', is_active: true },
+  ],
+  income_types: [],
+  expenses: [
+    { id: 9, kind: 'expense', code: 201, name: 'Supplies 物资', is_active: true },
+    { id: 10, kind: 'expense', code: 202, name: 'Race fees 报名费', is_active: true },
+    { id: 11, kind: 'expense', code: 203, name: 'Retired', is_active: false },
+  ],
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  useAuth.mockReturnValue({ currentUser: { uid: 'admin-uid' } });
+  getExpenses.mockResolvedValue(expenseRows);
+  getFinanceCategories.mockResolvedValue(categories);
+  classifyExpenses.mockResolvedValue({ updated: 1 });
+  deleteExpense.mockResolvedValue({});
+});
+
+test('renders expenses with negative red amounts, descriptions and chips', async () => {
+  render(<ExpensesGrid />);
+  expect(await screen.findByText('NYRR')).toBeInTheDocument();
+  expect(screen.getByText('-$120.00')).toBeInTheDocument();
+  expect(screen.getByText('-$80.50')).toBeInTheDocument();
+  expect(screen.getByText('NYRR RACE FEE 0234')).toBeInTheDocument();
+  expect(screen.getByText('Bear Mt. Run ▾')).toBeInTheDocument();
+  expect(screen.getByText('Supplies 物资 ▾')).toBeInTheDocument();
+  expect(screen.getByText('＋ event')).toBeInTheDocument();
+  expect(screen.getByText('＋ category 类别')).toBeInTheDocument();
+  // Import hint banner
+  expect(screen.getByText(/duplicates are skipped automatically/)).toBeInTheDocument();
+});
+
+test('classifies a single expense to an event from the chip menu', async () => {
+  const onChanged = jest.fn();
+  render(<ExpensesGrid onChanged={onChanged} />);
+  await screen.findByText('NYRR');
+
+  fireEvent.click(screen.getByText('＋ event'));
+  const menu = await screen.findByRole('menu');
+  fireEvent.click(within(menu).getByText('Bear Mt. Run'));
+
+  await waitFor(() => expect(classifyExpenses).toHaveBeenCalledWith(
+    { expense_ids: [1], event_code: 1002 }, 'admin-uid'
+  ));
+  await waitFor(() => expect(onChanged).toHaveBeenCalled());
+  expect(getExpenses).toHaveBeenCalledTimes(2);
+});
+
+test('classifies a single expense to a category from the chip menu', async () => {
+  render(<ExpensesGrid />);
+  await screen.findByText('NYRR');
+
+  fireEvent.click(screen.getByText('＋ category 类别'));
+  const menu = await screen.findByRole('menu');
+  fireEvent.click(within(menu).getByText('Race fees 报名费'));
+
+  await waitFor(() => expect(classifyExpenses).toHaveBeenCalledWith(
+    { expense_ids: [1], expense_category_code: 202 }, 'admin-uid'
+  ));
+});
+
+test('inactive expense categories are hidden from the menu', async () => {
+  render(<ExpensesGrid />);
+  await screen.findByText('NYRR');
+  fireEvent.click(screen.getByText('＋ category 类别'));
+  const menu = await screen.findByRole('menu');
+  expect(within(menu).queryByText('Retired')).not.toBeInTheDocument();
+});
+
+test('bulk bar applies event and category to the checked rows', async () => {
+  render(<ExpensesGrid />);
+  await screen.findByText('NYRR');
+
+  fireEvent.click(screen.getByLabelText('Select expense 1'));
+  fireEvent.click(screen.getByLabelText('Select expense 2'));
+  expect(screen.getByText(/2 rows selected 已选 2 行/)).toBeInTheDocument();
+
+  fireEvent.mouseDown(screen.getByLabelText('Bulk event 批量活动').closest('[role="combobox"]'));
+  fireEvent.click(await screen.findByRole('option', { name: 'General' }));
+
+  fireEvent.mouseDown(screen.getByLabelText('Bulk category 批量类别').closest('[role="combobox"]'));
+  fireEvent.click(await screen.findByRole('option', { name: 'Supplies 物资' }));
+
+  fireEvent.click(screen.getByText('Apply 应用'));
+  await waitFor(() => expect(classifyExpenses).toHaveBeenCalledWith(
+    { expense_ids: [1, 2], event_code: 1001, expense_category_code: 201 }, 'admin-uid'
+  ));
+  await waitFor(() => expect(screen.queryByText(/rows selected/)).not.toBeInTheDocument());
+});
+
+test('bulk Apply stays disabled until an event or category is chosen', async () => {
+  render(<ExpensesGrid />);
+  await screen.findByText('NYRR');
+  fireEvent.click(screen.getByLabelText('Select expense 1'));
+  expect(screen.getByText('Apply 应用').closest('button')).toBeDisabled();
+  fireEvent.mouseDown(screen.getByLabelText('Bulk event 批量活动').closest('[role="combobox"]'));
+  fireEvent.click(await screen.findByRole('option', { name: 'General' }));
+  expect(screen.getByText('Apply 应用').closest('button')).not.toBeDisabled();
+});
+
+test('the header checkbox selects every row and Clear empties it', async () => {
+  render(<ExpensesGrid />);
+  await screen.findByText('NYRR');
+  fireEvent.click(screen.getByLabelText('Select all expenses 全选'));
+  expect(screen.getByText(/2 rows selected/)).toBeInTheDocument();
+  fireEvent.click(screen.getByText('Clear 清除'));
+  await waitFor(() => expect(screen.queryByText(/rows selected/)).not.toBeInTheDocument());
+});
+
+test('deletes an expense after the confirm dialog', async () => {
+  render(<ExpensesGrid />);
+  await screen.findByText('NYRR');
+
+  fireEvent.click(screen.getByLabelText('Delete expense 1'));
+  expect(await screen.findByText('Delete expense 删除支出?')).toBeInTheDocument();
+  fireEvent.click(screen.getByText('Delete 删除'));
+
+  await waitFor(() => expect(deleteExpense).toHaveBeenCalledWith(1, 'admin-uid'));
+  await waitFor(() => expect(screen.queryByText('Delete expense 删除支出?')).not.toBeInTheDocument());
+  expect(getExpenses).toHaveBeenCalledTimes(2);
+});
+
+test('cancelling the confirm dialog deletes nothing', async () => {
+  render(<ExpensesGrid />);
+  await screen.findByText('NYRR');
+  fireEvent.click(screen.getByLabelText('Delete expense 1'));
+  fireEvent.click(await screen.findByText('Cancel 取消'));
+  await waitFor(() => expect(screen.queryByText('Delete expense 删除支出?')).not.toBeInTheDocument());
+  expect(deleteExpense).not.toHaveBeenCalled();
+});
+
+test('shows an error when deleting fails', async () => {
+  deleteExpense.mockRejectedValue(new Error('500'));
+  render(<ExpensesGrid />);
+  await screen.findByText('NYRR');
+  fireEvent.click(screen.getByLabelText('Delete expense 1'));
+  fireEvent.click(await screen.findByText('Delete 删除'));
+  expect(await screen.findByText(/删除支出失败/)).toBeInTheDocument();
+});
+
+test('shows an error when classification fails', async () => {
+  classifyExpenses.mockRejectedValue(new Error('403'));
+  render(<ExpensesGrid />);
+  await screen.findByText('NYRR');
+  fireEvent.click(screen.getByText('＋ event'));
+  const menu = await screen.findByRole('menu');
+  fireEvent.click(within(menu).getByText('General'));
+  expect(await screen.findByText(/分类失败/)).toBeInTheDocument();
+});
+
+test('shows an error when loading fails', async () => {
+  getExpenses.mockRejectedValue(new Error('500'));
+  render(<ExpensesGrid />);
+  expect(await screen.findByText(/加载支出记录失败/)).toBeInTheDocument();
+});
+
+test('shows an empty state before any import', async () => {
+  getExpenses.mockResolvedValue([]);
+  render(<ExpensesGrid />);
+  expect(await screen.findByText(/暂无支出，请先导入账单/)).toBeInTheDocument();
+});
+
+test('fetches nothing without a logged-in user', () => {
+  useAuth.mockReturnValue({ currentUser: null });
+  render(<ExpensesGrid />);
+  expect(getExpenses).not.toHaveBeenCalled();
+});
+
+test('refetches when refreshKey changes', async () => {
+  const { rerender } = render(<ExpensesGrid refreshKey={0} />);
+  await screen.findByText('NYRR');
+  rerender(<ExpensesGrid refreshKey={1} />);
+  await waitFor(() => expect(getExpenses).toHaveBeenCalledTimes(2));
+});

--- a/ProjectCode/client/src/components/finance/FinanceSettingsTab.js
+++ b/ProjectCode/client/src/components/finance/FinanceSettingsTab.js
@@ -1,0 +1,265 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  Alert, Box, Button, Chip, CircularProgress, FormControlLabel, MenuItem, Paper,
+  Select, Switch, TextField, Typography,
+} from '@mui/material';
+import { useAuth } from '../../context';
+import {
+  getFinanceSettings, updateFinanceSettings, getFinanceCategories,
+  createFinanceCategory, updateFinanceCategory,
+} from '../../api/finance';
+
+// Design tokens (homepage design language)
+const ORANGE = '#FFA500';
+const ORANGE_DARK = '#F29400';
+const LINE = '#EEE7DC';
+const MUTED = '#757575';
+
+const MONTHS = [
+  'January', 'February', 'March', 'April', 'May', 'June',
+  'July', 'August', 'September', 'October', 'November', 'December',
+];
+
+const CATEGORY_KINDS = [
+  { kind: 'event', listKey: 'events', title: 'Events 活动' },
+  { kind: 'income_type', listKey: 'income_types', title: 'Income types 收入属性' },
+  { kind: 'expense', listKey: 'expenses', title: 'Expense categories 支出类别' },
+];
+
+const pillButtonSx = {
+  textTransform: 'none',
+  fontWeight: 700,
+  borderRadius: '99px',
+  px: 2,
+  boxShadow: 'none',
+  color: 'white',
+  backgroundColor: ORANGE,
+  '&:hover': { backgroundColor: ORANGE_DARK, boxShadow: 'none' },
+};
+
+export default function FinanceSettingsTab() {
+  const { currentUser } = useAuth();
+  const firebaseUid = currentUser?.uid;
+
+  const [settings, setSettings] = useState(null);
+  const [categories, setCategories] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [orgStartDraft, setOrgStartDraft] = useState('');
+  const [editing, setEditing] = useState(null); // { id, name }
+  const [newNames, setNewNames] = useState({}); // kind -> name
+
+  const fetchData = useCallback(async () => {
+    if (!firebaseUid) return;
+    setLoading(true);
+    setError('');
+    try {
+      const [settingsData, categoriesData] = await Promise.all([
+        getFinanceSettings(firebaseUid),
+        getFinanceCategories(firebaseUid),
+      ]);
+      setSettings(settingsData);
+      setOrgStartDraft(settingsData.org_start || '');
+      setCategories(categoriesData);
+    } catch (err) {
+      console.error('Error loading finance settings:', err);
+      setError('Failed to load settings. / 加载设置失败。');
+    } finally {
+      setLoading(false);
+    }
+  }, [firebaseUid]);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  const saveSettings = async (patch) => {
+    setError('');
+    try {
+      await updateFinanceSettings(patch, firebaseUid);
+      setSettings((prev) => ({ ...prev, ...patch }));
+    } catch (err) {
+      console.error('Error saving finance settings:', err);
+      setError('Failed to save settings. / 保存设置失败。');
+    }
+  };
+
+  const refreshCategories = async () => {
+    setCategories(await getFinanceCategories(firebaseUid));
+  };
+
+  const handleAddCategory = async (kind) => {
+    const name = (newNames[kind] || '').trim();
+    if (!name) return;
+    setError('');
+    try {
+      await createFinanceCategory({ kind, name }, firebaseUid);
+      setNewNames((prev) => ({ ...prev, [kind]: '' }));
+      await refreshCategories();
+    } catch (err) {
+      console.error('Error adding category:', err);
+      setError('Failed to add the category. / 添加类别失败。');
+    }
+  };
+
+  const handleRename = async () => {
+    if (!editing || !editing.name.trim()) return;
+    setError('');
+    try {
+      await updateFinanceCategory(editing.id, { name: editing.name.trim() }, firebaseUid);
+      setEditing(null);
+      await refreshCategories();
+    } catch (err) {
+      console.error('Error renaming category:', err);
+      setError('Failed to rename the category. / 重命名失败。');
+    }
+  };
+
+  if (loading && !settings) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', py: 6 }}>
+        <CircularProgress sx={{ color: ORANGE }} />
+      </Box>
+    );
+  }
+
+  return (
+    <Box>
+      {error && (
+        <Alert severity="error" onClose={() => setError('')} sx={{ mb: 1.5 }}>
+          {error}
+        </Alert>
+      )}
+
+      {/* Acknowledgment + 509(a) parameters */}
+      <Paper elevation={0} sx={{ border: `1px solid ${LINE}`, borderRadius: '12px', p: 2.5, mb: 2 }}>
+        <FormControlLabel
+          control={
+            <Switch
+              checked={Boolean(settings?.auto_ack_enabled)}
+              onChange={(e) => saveSettings({ auto_ack_enabled: e.target.checked })}
+              inputProps={{ 'aria-label': 'Auto-send acknowledgments weekly 每周自动致谢' }}
+              sx={{
+                '& .MuiSwitch-switchBase.Mui-checked': { color: ORANGE },
+                '& .MuiSwitch-switchBase.Mui-checked + .MuiSwitch-track': { backgroundColor: ORANGE },
+              }}
+            />
+          }
+          label={
+            <Typography sx={{ fontSize: '0.84375rem', fontWeight: 600 }}>
+              Auto-send acknowledgments weekly 每周自动致谢
+            </Typography>
+          }
+        />
+        <Typography sx={{ fontSize: '0.71875rem', color: MUTED, mb: 2 }}>
+          Donations with a directory email get a thank-you automatically each week. / 通讯录中有邮箱的捐款每周自动发送致谢。
+        </Typography>
+
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, flexWrap: 'wrap' }}>
+          <TextField
+            label="Org start 组织成立日 (990)"
+            type="date"
+            size="small"
+            value={orgStartDraft}
+            onChange={(e) => setOrgStartDraft(e.target.value)}
+            onBlur={() => {
+              if (orgStartDraft && orgStartDraft !== settings?.org_start) {
+                saveSettings({ org_start: orgStartDraft });
+              }
+            }}
+            InputLabelProps={{ shrink: true }}
+            inputProps={{ 'aria-label': 'Org start 组织成立日' }}
+          />
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <Typography sx={{ fontSize: '0.78125rem', color: MUTED }}>
+              Fiscal year end 财年截止月:
+            </Typography>
+            <Select
+              size="small"
+              value={settings?.fye_month || 12}
+              onChange={(e) => saveSettings({ fye_month: e.target.value })}
+              inputProps={{ 'aria-label': 'Fiscal year end month 财年截止月' }}
+              sx={{ borderRadius: '8px', fontSize: '0.78125rem' }}
+            >
+              {MONTHS.map((m, i) => (
+                <MenuItem key={m} value={i + 1} sx={{ fontSize: '0.8125rem' }}>{m}</MenuItem>
+              ))}
+            </Select>
+          </Box>
+          <Typography sx={{ fontSize: '0.71875rem', color: '#9a9a9a' }}>
+            Both feed the 509(a) public support tests. / 两者用于 509(a) 公共支持测试。
+          </Typography>
+        </Box>
+      </Paper>
+
+      {/* Category management */}
+      <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap', alignItems: 'flex-start' }}>
+        {CATEGORY_KINDS.map(({ kind, listKey, title }) => (
+          <Paper key={kind} elevation={0} sx={{
+            flex: 1, minWidth: 260, border: `1px solid ${LINE}`, borderRadius: '12px', p: 2,
+          }}>
+            <Typography sx={{ fontSize: '0.6875rem', fontWeight: 700, color: MUTED, textTransform: 'uppercase', letterSpacing: '0.5px', mb: 1 }}>
+              {title}
+            </Typography>
+            {(categories?.[listKey] || []).map((cat) => (
+              <Box key={cat.id} sx={{ display: 'flex', alignItems: 'center', gap: 1, py: 0.75, borderBottom: `1px solid ${LINE}` }}>
+                <Chip size="small" label={cat.code} sx={{
+                  fontSize: '0.625rem', fontWeight: 700, borderRadius: '99px', height: 18,
+                  backgroundColor: '#f1f1f1', color: MUTED,
+                }} />
+                {editing?.id === cat.id ? (
+                  <>
+                    <TextField
+                      size="small"
+                      value={editing.name}
+                      onChange={(e) => setEditing({ ...editing, name: e.target.value })}
+                      inputProps={{ 'aria-label': `Rename ${cat.name}` }}
+                      sx={{ flexGrow: 1, '& .MuiInputBase-input': { fontSize: '0.78125rem', py: 0.5 } }}
+                    />
+                    <Button size="small" onClick={handleRename} sx={{ ...pillButtonSx, fontSize: '0.65625rem', py: 0.25 }}>
+                      Save 保存
+                    </Button>
+                    <Button size="small" onClick={() => setEditing(null)} sx={{ textTransform: 'none', fontSize: '0.65625rem', color: MUTED, minWidth: 0 }}>
+                      ✕
+                    </Button>
+                  </>
+                ) : (
+                  <>
+                    <Typography sx={{ fontSize: '0.78125rem', fontWeight: 600, flexGrow: 1, color: cat.is_active === false ? '#b5b5b5' : 'inherit' }}>
+                      {cat.name}
+                    </Typography>
+                    <Button
+                      size="small"
+                      onClick={() => setEditing({ id: cat.id, name: cat.name })}
+                      sx={{ textTransform: 'none', fontSize: '0.65625rem', fontWeight: 700, color: ORANGE, minWidth: 0 }}
+                    >
+                      ✎ Rename 重命名
+                    </Button>
+                  </>
+                )}
+              </Box>
+            ))}
+            <Box sx={{ display: 'flex', gap: 1, mt: 1.25 }}>
+              <TextField
+                size="small"
+                placeholder="New name 新名称"
+                value={newNames[kind] || ''}
+                onChange={(e) => setNewNames((prev) => ({ ...prev, [kind]: e.target.value }))}
+                inputProps={{ 'aria-label': `New ${title}` }}
+                sx={{ flexGrow: 1, '& .MuiInputBase-input': { fontSize: '0.78125rem', py: 0.5 } }}
+              />
+              <Button
+                size="small"
+                onClick={() => handleAddCategory(kind)}
+                disabled={!(newNames[kind] || '').trim()}
+                sx={{ ...pillButtonSx, fontSize: '0.65625rem', py: 0.25 }}
+              >
+                ＋ Add 添加
+              </Button>
+            </Box>
+          </Paper>
+        ))}
+      </Box>
+    </Box>
+  );
+}

--- a/ProjectCode/client/src/components/finance/FinanceSettingsTab.test.js
+++ b/ProjectCode/client/src/components/finance/FinanceSettingsTab.test.js
@@ -1,0 +1,181 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import FinanceSettingsTab from './FinanceSettingsTab';
+import { useAuth } from '../../context';
+import {
+  getFinanceSettings, updateFinanceSettings, getFinanceCategories,
+  createFinanceCategory, updateFinanceCategory,
+} from '../../api/finance';
+
+jest.mock('../../context', () => ({
+  useAuth: jest.fn(),
+}));
+jest.mock('../../api/finance', () => ({
+  getFinanceSettings: jest.fn(),
+  updateFinanceSettings: jest.fn(),
+  getFinanceCategories: jest.fn(),
+  createFinanceCategory: jest.fn(),
+  updateFinanceCategory: jest.fn(),
+}));
+
+const settings = { auto_ack_enabled: false, org_start: '2016-06-01', fye_month: 12 };
+
+const categories = {
+  events: [
+    { id: 1, kind: 'event', code: 1001, name: 'General', is_active: true },
+    { id: 2, kind: 'event', code: 1002, name: 'Bear Mt. Run', is_active: true },
+  ],
+  income_types: [
+    { id: 5, kind: 'income_type', code: 1, name: 'Donation 捐款', is_active: true },
+  ],
+  expenses: [
+    { id: 9, kind: 'expense', code: 201, name: 'Supplies 物资', is_active: false },
+  ],
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  useAuth.mockReturnValue({ currentUser: { uid: 'admin-uid' } });
+  getFinanceSettings.mockResolvedValue(settings);
+  getFinanceCategories.mockResolvedValue(categories);
+  updateFinanceSettings.mockResolvedValue({});
+  createFinanceCategory.mockResolvedValue({});
+  updateFinanceCategory.mockResolvedValue({});
+});
+
+test('renders the auto-ack switch, 509 parameters and the three category lists', async () => {
+  render(<FinanceSettingsTab />);
+  expect(await screen.findByText('Auto-send acknowledgments weekly 每周自动致谢')).toBeInTheDocument();
+  expect(screen.getByLabelText('Auto-send acknowledgments weekly 每周自动致谢')).not.toBeChecked();
+  expect(screen.getByLabelText('Org start 组织成立日')).toHaveValue('2016-06-01');
+  expect(screen.getByText('Events 活动')).toBeInTheDocument();
+  expect(screen.getByText('Income types 收入属性')).toBeInTheDocument();
+  expect(screen.getByText('Expense categories 支出类别')).toBeInTheDocument();
+  expect(screen.getByText('General')).toBeInTheDocument();
+  expect(screen.getByText('Donation 捐款')).toBeInTheDocument();
+  expect(screen.getByText('Supplies 物资')).toBeInTheDocument();
+  expect(screen.getByText('1001')).toBeInTheDocument(); // code chip
+});
+
+test('toggling the auto-ack switch saves the setting', async () => {
+  render(<FinanceSettingsTab />);
+  const toggle = await screen.findByLabelText('Auto-send acknowledgments weekly 每周自动致谢');
+  fireEvent.click(toggle);
+  await waitFor(() => expect(updateFinanceSettings).toHaveBeenCalledWith(
+    { auto_ack_enabled: true }, 'admin-uid'
+  ));
+  await waitFor(() => expect(toggle).toBeChecked());
+});
+
+test('changing the org start date saves on blur', async () => {
+  render(<FinanceSettingsTab />);
+  const field = await screen.findByLabelText('Org start 组织成立日');
+  fireEvent.change(field, { target: { value: '2016-01-15' } });
+  fireEvent.blur(field);
+  await waitFor(() => expect(updateFinanceSettings).toHaveBeenCalledWith(
+    { org_start: '2016-01-15' }, 'admin-uid'
+  ));
+});
+
+test('an unchanged org start date does not save on blur', async () => {
+  render(<FinanceSettingsTab />);
+  const field = await screen.findByLabelText('Org start 组织成立日');
+  fireEvent.blur(field);
+  await waitFor(() => expect(updateFinanceSettings).not.toHaveBeenCalled());
+});
+
+test('changing the fiscal year end month saves the setting', async () => {
+  render(<FinanceSettingsTab />);
+  await screen.findByText('Events 活动');
+  fireEvent.mouseDown(screen.getByLabelText('Fiscal year end month 财年截止月').closest('[role="combobox"]'));
+  fireEvent.click(await screen.findByRole('option', { name: 'June' }));
+  await waitFor(() => expect(updateFinanceSettings).toHaveBeenCalledWith(
+    { fye_month: 6 }, 'admin-uid'
+  ));
+});
+
+test('adds a category of the right kind', async () => {
+  render(<FinanceSettingsTab />);
+  await screen.findByText('Events 活动');
+
+  const input = screen.getByLabelText('New Events 活动');
+  fireEvent.change(input, { target: { value: 'Track Meet 田径赛' } });
+  const addButtons = screen.getAllByText('＋ Add 添加');
+  fireEvent.click(addButtons[0]);
+
+  await waitFor(() => expect(createFinanceCategory).toHaveBeenCalledWith(
+    { kind: 'event', name: 'Track Meet 田径赛' }, 'admin-uid'
+  ));
+  // Categories reload and the input clears
+  await waitFor(() => expect(getFinanceCategories).toHaveBeenCalledTimes(2));
+  expect(screen.getByLabelText('New Events 活动')).toHaveValue('');
+});
+
+test('add buttons stay disabled while the name is blank', async () => {
+  render(<FinanceSettingsTab />);
+  await screen.findByText('Events 活动');
+  screen.getAllByText('＋ Add 添加').forEach((b) => {
+    expect(b.closest('button')).toBeDisabled();
+  });
+});
+
+test('renames a category inline', async () => {
+  render(<FinanceSettingsTab />);
+  await screen.findByText('General');
+
+  fireEvent.click(screen.getAllByText('✎ Rename 重命名')[0]);
+  const field = screen.getByLabelText('Rename General');
+  fireEvent.change(field, { target: { value: 'General Support' } });
+  fireEvent.click(screen.getByText('Save 保存'));
+
+  await waitFor(() => expect(updateFinanceCategory).toHaveBeenCalledWith(
+    1, { name: 'General Support' }, 'admin-uid'
+  ));
+  await waitFor(() => expect(getFinanceCategories).toHaveBeenCalledTimes(2));
+});
+
+test('cancelling a rename leaves the category untouched', async () => {
+  render(<FinanceSettingsTab />);
+  await screen.findByText('General');
+  fireEvent.click(screen.getAllByText('✎ Rename 重命名')[0]);
+  fireEvent.click(screen.getByText('✕'));
+  await waitFor(() => expect(screen.queryByLabelText('Rename General')).not.toBeInTheDocument());
+  expect(updateFinanceCategory).not.toHaveBeenCalled();
+});
+
+test('shows an error when settings fail to save', async () => {
+  updateFinanceSettings.mockRejectedValue(new Error('500'));
+  render(<FinanceSettingsTab />);
+  fireEvent.click(await screen.findByLabelText('Auto-send acknowledgments weekly 每周自动致谢'));
+  expect(await screen.findByText(/保存设置失败/)).toBeInTheDocument();
+});
+
+test('shows an error when adding a category fails', async () => {
+  createFinanceCategory.mockRejectedValue(new Error('409'));
+  render(<FinanceSettingsTab />);
+  await screen.findByText('Events 活动');
+  fireEvent.change(screen.getByLabelText('New Events 活动'), { target: { value: 'Dup' } });
+  fireEvent.click(screen.getAllByText('＋ Add 添加')[0]);
+  expect(await screen.findByText(/添加类别失败/)).toBeInTheDocument();
+});
+
+test('shows an error when renaming fails', async () => {
+  updateFinanceCategory.mockRejectedValue(new Error('500'));
+  render(<FinanceSettingsTab />);
+  await screen.findByText('General');
+  fireEvent.click(screen.getAllByText('✎ Rename 重命名')[0]);
+  fireEvent.change(screen.getByLabelText('Rename General'), { target: { value: 'X' } });
+  fireEvent.click(screen.getByText('Save 保存'));
+  expect(await screen.findByText(/重命名失败/)).toBeInTheDocument();
+});
+
+test('shows an error when loading fails', async () => {
+  getFinanceSettings.mockRejectedValue(new Error('500'));
+  render(<FinanceSettingsTab />);
+  expect(await screen.findByText(/加载设置失败/)).toBeInTheDocument();
+});
+
+test('fetches nothing without a logged-in user', () => {
+  useAuth.mockReturnValue({ currentUser: null });
+  render(<FinanceSettingsTab />);
+  expect(getFinanceSettings).not.toHaveBeenCalled();
+});

--- a/ProjectCode/client/src/components/finance/IncomeGrid.js
+++ b/ProjectCode/client/src/components/finance/IncomeGrid.js
@@ -1,0 +1,564 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  Alert, Box, Button, Checkbox, Chip, CircularProgress, Dialog, DialogActions,
+  DialogContent, DialogTitle, Menu, MenuItem, Paper, Select, Table, TableBody,
+  TableCell, TableContainer, TableHead, TableRow, TextField, Typography,
+} from '@mui/material';
+import { useAuth } from '../../context';
+import {
+  getIncome, getFinanceCategories, classifyIncome, addManualIncome,
+} from '../../api/finance';
+
+// Design tokens (homepage design language + finance chip colors)
+const ORANGE = '#FFA500';
+const ORANGE_DARK = '#F29400';
+const ORANGE_BG = '#FFF6E8';
+const LINE = '#EEE7DC';
+const INK = '#212121';
+const MUTED = '#757575';
+const GREEN = '#2e7d32';
+const GREEN_BG = '#eaf5ea';
+const TEAL = '#00796b';
+const TEAL_BG = '#e0f2f1';
+const BLUE = '#1a63d0';
+const BLUE_BG = '#e8f0fe';
+const PURPLE = '#7b3ff2';
+const PURPLE_BG = '#f3e8ff';
+
+export const INCOME_TYPES = [
+  { key: 'donation', label: 'Donation 捐款', color: GREEN, bg: GREEN_BG },
+  { key: 'event_revenue', label: 'Event Revenue 活动收入', color: TEAL, bg: TEAL_BG },
+  { key: 'pass_through', label: 'Pass-through 代收', color: BLUE, bg: BLUE_BG },
+  { key: 'mistake', label: 'Mistake 误操作', color: MUTED, bg: '#f1f1f1' },
+];
+
+const FILTERS = [
+  { key: 'all', label: 'All 全部' },
+  { key: 'unclassified', label: 'Unclassified 未分类' },
+  { key: 'donation', label: 'Donation 捐款' },
+  { key: 'event_revenue', label: 'Event Revenue 活动收入' },
+  { key: 'pass_through', label: 'Pass-through 代收' },
+];
+
+const pillButtonSx = {
+  textTransform: 'none',
+  fontWeight: 700,
+  borderRadius: '99px',
+  px: 2,
+  boxShadow: 'none',
+  color: 'white',
+  backgroundColor: ORANGE,
+  '&:hover': { backgroundColor: ORANGE_DARK, boxShadow: 'none' },
+};
+
+const formatAmount = (amount) =>
+  `$${parseFloat(amount || 0).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+
+const formatDate = (dateStr) => {
+  if (!dateStr) return '';
+  const d = new Date(`${String(dateStr).slice(0, 10)}T00:00:00`);
+  if (Number.isNaN(d.getTime())) return dateStr;
+  const opts = { month: 'short', day: 'numeric' };
+  if (d.getFullYear() !== new Date().getFullYear()) opts.year = 'numeric';
+  return d.toLocaleDateString('en-US', opts);
+};
+
+// 'Zelle (Li Chen)' -> 'Zelle'; 'Manual entry' -> 'Manual entry'
+export const methodFromSource = (source) =>
+  (source || '').replace(/\s*\(.*$/, '').trim();
+
+function CellChip({ label, color, bg, dashed, onClick, ariaLabel }) {
+  return (
+    <Chip
+      size="small"
+      label={label}
+      onClick={onClick}
+      aria-label={ariaLabel}
+      sx={{
+        fontSize: '0.65625rem',
+        fontWeight: 700,
+        borderRadius: '99px',
+        cursor: 'pointer',
+        height: 22,
+        backgroundColor: dashed ? 'white' : bg,
+        color: dashed ? ORANGE : color,
+        border: dashed ? `1.5px dashed ${ORANGE}` : '1px dashed transparent',
+        '&:hover': { borderColor: ORANGE, backgroundColor: dashed ? ORANGE_BG : bg },
+      }}
+    />
+  );
+}
+
+export default function IncomeGrid({ refreshKey = 0, onChanged }) {
+  const { currentUser } = useAuth();
+  const firebaseUid = currentUser?.uid;
+
+  const [rows, setRows] = useState([]);
+  const [events, setEvents] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [filter, setFilter] = useState('all');
+  const [selected, setSelected] = useState([]);
+  const [typeMenu, setTypeMenu] = useState(null); // { anchorEl, row }
+  const [eventMenu, setEventMenu] = useState(null); // { anchorEl, row }
+  const [bulkType, setBulkType] = useState('donation');
+  const [bulkEvent, setBulkEvent] = useState('');
+  const [applying, setApplying] = useState(false);
+
+  // Manual income dialog
+  const [manualOpen, setManualOpen] = useState(false);
+  const [manual, setManual] = useState(null);
+  const [savingManual, setSavingManual] = useState(false);
+
+  const fetchData = useCallback(async () => {
+    if (!firebaseUid) return;
+    setLoading(true);
+    setError('');
+    try {
+      const [income, categories] = await Promise.all([
+        getIncome(firebaseUid),
+        getFinanceCategories(firebaseUid),
+      ]);
+      setRows(income);
+      setEvents((categories.events || []).filter((e) => e.is_active !== false));
+    } catch (err) {
+      console.error('Error loading income:', err);
+      setError('Failed to load income rows. / 加载收入记录失败。');
+    } finally {
+      setLoading(false);
+    }
+  }, [firebaseUid]);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData, refreshKey]);
+
+  const eventName = (code) =>
+    events.find((e) => e.code === code)?.name || `#${code}`;
+
+  const typeMeta = (key) => INCOME_TYPES.find((t) => t.key === key);
+
+  const filteredRows = rows.filter((r) => {
+    if (filter === 'unclassified') return !r.income_type;
+    if (filter === 'all') return true;
+    return r.income_type === filter;
+  });
+
+  const toggleSelected = (id) => {
+    setSelected((prev) =>
+      prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]);
+  };
+
+  const allSelected = filteredRows.length > 0 &&
+    filteredRows.every((r) => selected.includes(r.donation_id));
+
+  const toggleAll = () => {
+    setSelected(allSelected ? [] : filteredRows.map((r) => r.donation_id));
+  };
+
+  const runClassify = async (payload) => {
+    setError('');
+    try {
+      await classifyIncome(payload, firebaseUid);
+      await fetchData();
+      if (onChanged) onChanged();
+    } catch (err) {
+      console.error('Error classifying income:', err);
+      setError('Failed to classify. / 分类失败。');
+    }
+  };
+
+  const handlePickType = async (row, incomeType) => {
+    setTypeMenu(null);
+    await runClassify({ donation_ids: [row.donation_id], income_type: incomeType });
+  };
+
+  const handlePickEvent = async (row, eventCode) => {
+    setEventMenu(null);
+    await runClassify({
+      donation_ids: [row.donation_id],
+      income_type: row.income_type || 'donation',
+      event_code: eventCode,
+    });
+  };
+
+  const handleBulkApply = async () => {
+    setApplying(true);
+    const payload = { donation_ids: selected, income_type: bulkType };
+    if (bulkEvent !== '') payload.event_code = bulkEvent;
+    await runClassify(payload);
+    setSelected([]);
+    setApplying(false);
+  };
+
+  const openManual = () => {
+    setManual({
+      name: '', amount: '', donation_date: new Date().toISOString().split('T')[0],
+      method: '', memo: '', income_type: 'donation', event_code: '',
+    });
+    setManualOpen(true);
+  };
+
+  const handleSaveManual = async () => {
+    setSavingManual(true);
+    setError('');
+    try {
+      const payload = {
+        name: manual.name,
+        amount: parseFloat(manual.amount),
+        donation_date: manual.donation_date || undefined,
+        method: manual.method || undefined,
+        memo: manual.memo || undefined,
+        income_type: manual.income_type,
+      };
+      if (manual.event_code !== '') payload.event_code = manual.event_code;
+      await addManualIncome(payload, firebaseUid);
+      setManualOpen(false);
+      await fetchData();
+      if (onChanged) onChanged();
+    } catch (err) {
+      console.error('Error adding manual income:', err);
+      setError('Failed to add the manual row. / 手动记账失败。');
+    } finally {
+      setSavingManual(false);
+    }
+  };
+
+  if (loading && rows.length === 0) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', py: 6 }}>
+        <CircularProgress sx={{ color: ORANGE }} />
+      </Box>
+    );
+  }
+
+  return (
+    <Box>
+      {error && (
+        <Alert severity="error" onClose={() => setError('')} sx={{ mb: 1.5 }}>
+          {error}
+        </Alert>
+      )}
+
+      {/* Filter chips + manual entry */}
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap', mb: 1.5 }}>
+        {FILTERS.map((f) => (
+          <Chip
+            key={f.key}
+            label={f.label}
+            onClick={() => setFilter(f.key)}
+            sx={{
+              fontSize: '0.75rem',
+              fontWeight: 700,
+              borderRadius: '99px',
+              cursor: 'pointer',
+              border: `1.5px solid ${filter === f.key ? ORANGE : LINE}`,
+              backgroundColor: filter === f.key ? ORANGE : 'white',
+              color: filter === f.key ? 'white' : MUTED,
+              '&:hover': { backgroundColor: filter === f.key ? ORANGE_DARK : ORANGE_BG },
+            }}
+          />
+        ))}
+        <Box sx={{ flexGrow: 1 }} />
+        <Button size="small" onClick={openManual} sx={{
+          textTransform: 'none', fontWeight: 700, fontSize: '0.75rem',
+          border: `1.5px dashed ${ORANGE}`, color: ORANGE, borderRadius: '99px', px: 2,
+        }}>
+          ＋ Manual row 手动记一笔
+        </Button>
+      </Box>
+
+      {/* Income grid */}
+      <TableContainer component={Paper} elevation={0} sx={{
+        border: `1px solid ${ORANGE}`,
+        borderRadius: '0 10px 10px 10px',
+        boxShadow: '0 2px 8px rgba(0,0,0,0.06)',
+      }}>
+        <Table size="small">
+          <TableHead>
+            <TableRow sx={{ backgroundColor: '#FDFBF7' }}>
+              <TableCell padding="checkbox" sx={{ borderBottom: `1px solid ${LINE}` }}>
+                <Checkbox
+                  size="small"
+                  checked={allSelected}
+                  onChange={toggleAll}
+                  inputProps={{ 'aria-label': 'Select all rows 全选' }}
+                  sx={{ color: ORANGE, '&.Mui-checked': { color: ORANGE } }}
+                />
+              </TableCell>
+              {['Date', 'From 来自', 'Amount', 'Method', 'Memo', 'Type 属性 ▾', 'Event 活动 ▾', 'Ack 致谢'].map((h) => (
+                <TableCell key={h} sx={{
+                  fontSize: '0.625rem', fontWeight: 700, color: MUTED,
+                  textTransform: 'uppercase', letterSpacing: '0.4px',
+                  borderBottom: `1px solid ${LINE}`,
+                  textAlign: h === 'Amount' ? 'right' : 'left',
+                }}>
+                  {h}
+                </TableCell>
+              ))}
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {filteredRows.length === 0 && (
+              <TableRow>
+                <TableCell colSpan={9} sx={{ textAlign: 'center', py: 4, color: MUTED }}>
+                  No income rows. / 暂无收入记录。
+                </TableCell>
+              </TableRow>
+            )}
+            {filteredRows.map((row) => {
+              const meta = typeMeta(row.income_type);
+              const unclassified = !row.income_type;
+              return (
+                <TableRow key={row.donation_id} hover sx={{
+                  backgroundColor: unclassified ? '#FFFDF8' : 'inherit',
+                }}>
+                  <TableCell padding="checkbox">
+                    <Checkbox
+                      size="small"
+                      checked={selected.includes(row.donation_id)}
+                      onChange={() => toggleSelected(row.donation_id)}
+                      inputProps={{ 'aria-label': `Select row ${row.donation_id}` }}
+                      sx={{ color: ORANGE, '&.Mui-checked': { color: ORANGE } }}
+                    />
+                  </TableCell>
+                  <TableCell sx={{ whiteSpace: 'nowrap', fontSize: '0.78125rem' }}>
+                    {formatDate(row.donation_date)}
+                  </TableCell>
+                  <TableCell sx={{ fontSize: '0.78125rem', fontWeight: unclassified ? 700 : 500 }}>
+                    {row.name}
+                  </TableCell>
+                  <TableCell sx={{ fontWeight: 700, color: ORANGE, whiteSpace: 'nowrap', textAlign: 'right', fontSize: '0.78125rem' }}>
+                    {formatAmount(row.amount)}
+                  </TableCell>
+                  <TableCell sx={{ fontSize: '0.78125rem', whiteSpace: 'nowrap' }}>
+                    {methodFromSource(row.source)}
+                  </TableCell>
+                  <TableCell sx={{ fontSize: '0.75rem', color: MUTED, maxWidth: 260 }}>
+                    <Typography sx={{ fontSize: '0.75rem', color: MUTED }} noWrap>
+                      {row.message || ''}
+                    </Typography>
+                  </TableCell>
+                  <TableCell>
+                    {meta ? (
+                      <CellChip
+                        label={`${meta.label} ▾`}
+                        color={meta.color}
+                        bg={meta.bg}
+                        ariaLabel={`Type for ${row.name}`}
+                        onClick={(e) => setTypeMenu({ anchorEl: e.currentTarget, row })}
+                      />
+                    ) : (
+                      <CellChip
+                        label="＋ classify 分类"
+                        dashed
+                        ariaLabel={`Type for ${row.name}`}
+                        onClick={(e) => setTypeMenu({ anchorEl: e.currentTarget, row })}
+                      />
+                    )}
+                  </TableCell>
+                  <TableCell>
+                    {row.event_code ? (
+                      <CellChip
+                        label={`${eventName(row.event_code)} ▾`}
+                        color={PURPLE}
+                        bg={PURPLE_BG}
+                        ariaLabel={`Event for ${row.name}`}
+                        onClick={(e) => setEventMenu({ anchorEl: e.currentTarget, row })}
+                      />
+                    ) : (
+                      <CellChip
+                        label="＋ event"
+                        dashed
+                        ariaLabel={`Event for ${row.name}`}
+                        onClick={(e) => setEventMenu({ anchorEl: e.currentTarget, row })}
+                      />
+                    )}
+                  </TableCell>
+                  <TableCell sx={{ whiteSpace: 'nowrap' }}>
+                    {row.income_type && row.income_type !== 'donation' ? (
+                      <Typography component="span" sx={{ fontSize: '0.75rem', color: MUTED }}>—</Typography>
+                    ) : row.thank_you_sent_at ? (
+                      <Typography component="span" sx={{ fontSize: '0.71875rem', color: GREEN, fontWeight: 700 }}>
+                        ✓ {formatDate(row.thank_you_sent_at)}
+                      </Typography>
+                    ) : null}
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+      </TableContainer>
+
+      {/* Bulk classify bar */}
+      {selected.length > 0 && (
+        <Box sx={{
+          display: 'flex', alignItems: 'center', gap: 1.25, flexWrap: 'wrap',
+          backgroundColor: INK, color: 'white', borderRadius: '12px',
+          px: 2, py: 1.25, mt: 1.5, fontSize: '0.78125rem',
+        }}>
+          <Typography sx={{ fontSize: '0.78125rem', fontWeight: 700 }}>
+            ☑ {selected.length} rows selected 已选 {selected.length} 行 →
+          </Typography>
+          <Typography sx={{ fontSize: '0.78125rem' }}>set Type 属性:</Typography>
+          <Select
+            size="small"
+            value={bulkType}
+            onChange={(e) => setBulkType(e.target.value)}
+            inputProps={{ 'aria-label': 'Bulk type 批量属性' }}
+            sx={{ backgroundColor: 'white', borderRadius: '8px', fontSize: '0.75rem', fontWeight: 700, '& .MuiSelect-select': { py: 0.5 } }}
+          >
+            {INCOME_TYPES.map((t) => (
+              <MenuItem key={t.key} value={t.key} sx={{ fontSize: '0.8125rem' }}>{t.label}</MenuItem>
+            ))}
+          </Select>
+          <Typography sx={{ fontSize: '0.78125rem' }}>set Event:</Typography>
+          <Select
+            size="small"
+            value={bulkEvent}
+            onChange={(e) => setBulkEvent(e.target.value)}
+            displayEmpty
+            inputProps={{ 'aria-label': 'Bulk event 批量活动' }}
+            sx={{ backgroundColor: 'white', borderRadius: '8px', fontSize: '0.75rem', fontWeight: 700, '& .MuiSelect-select': { py: 0.5 } }}
+          >
+            <MenuItem value="" sx={{ fontSize: '0.8125rem' }}>— keep 保持 —</MenuItem>
+            {events.map((ev) => (
+              <MenuItem key={ev.code} value={ev.code} sx={{ fontSize: '0.8125rem' }}>{ev.name}</MenuItem>
+            ))}
+          </Select>
+          <Button size="small" onClick={handleBulkApply} disabled={applying} sx={pillButtonSx}>
+            {applying ? <CircularProgress size={14} sx={{ color: 'white' }} /> : 'Apply 应用'}
+          </Button>
+          <Button size="small" onClick={() => setSelected([])} sx={{ textTransform: 'none', color: 'rgba(255,255,255,0.7)', fontSize: '0.71875rem' }}>
+            Clear 清除
+          </Button>
+        </Box>
+      )}
+
+      {/* Type chip menu */}
+      <Menu
+        anchorEl={typeMenu?.anchorEl}
+        open={Boolean(typeMenu)}
+        onClose={() => setTypeMenu(null)}
+      >
+        {INCOME_TYPES.map((t) => (
+          <MenuItem
+            key={t.key}
+            onClick={() => handlePickType(typeMenu.row, t.key)}
+            sx={{ fontSize: '0.8125rem', fontWeight: 600, color: t.color }}
+          >
+            {t.label}
+          </MenuItem>
+        ))}
+      </Menu>
+
+      {/* Event chip menu */}
+      <Menu
+        anchorEl={eventMenu?.anchorEl}
+        open={Boolean(eventMenu)}
+        onClose={() => setEventMenu(null)}
+      >
+        {events.map((ev) => (
+          <MenuItem
+            key={ev.code}
+            onClick={() => handlePickEvent(eventMenu.row, ev.code)}
+            sx={{ fontSize: '0.8125rem', fontWeight: 600, color: PURPLE }}
+          >
+            {ev.name}
+          </MenuItem>
+        ))}
+      </Menu>
+
+      {/* Manual income dialog */}
+      <Dialog open={manualOpen} onClose={() => setManualOpen(false)} maxWidth="sm" fullWidth>
+        <DialogTitle>＋ Manual row 手动记一笔</DialogTitle>
+        <DialogContent>
+          {manual && (
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 1 }}>
+              <Box sx={{ display: 'flex', gap: 1.5 }}>
+                <TextField
+                  label="From 来自"
+                  size="small"
+                  fullWidth
+                  value={manual.name}
+                  onChange={(e) => setManual({ ...manual, name: e.target.value })}
+                />
+                <TextField
+                  label="Amount 金额 $"
+                  size="small"
+                  type="number"
+                  sx={{ width: 180 }}
+                  value={manual.amount}
+                  onChange={(e) => setManual({ ...manual, amount: e.target.value })}
+                />
+              </Box>
+              <Box sx={{ display: 'flex', gap: 1.5 }}>
+                <TextField
+                  label="Date 日期"
+                  type="date"
+                  size="small"
+                  fullWidth
+                  value={manual.donation_date}
+                  onChange={(e) => setManual({ ...manual, donation_date: e.target.value })}
+                  InputLabelProps={{ shrink: true }}
+                />
+                <TextField
+                  label="Method 方式"
+                  size="small"
+                  fullWidth
+                  placeholder="Cash / Check ..."
+                  value={manual.method}
+                  onChange={(e) => setManual({ ...manual, method: e.target.value })}
+                />
+              </Box>
+              <TextField
+                label="Memo 备注"
+                size="small"
+                fullWidth
+                value={manual.memo}
+                onChange={(e) => setManual({ ...manual, memo: e.target.value })}
+              />
+              <Box sx={{ display: 'flex', gap: 1.5 }}>
+                <Select
+                  size="small"
+                  fullWidth
+                  value={manual.income_type}
+                  onChange={(e) => setManual({ ...manual, income_type: e.target.value })}
+                  inputProps={{ 'aria-label': 'Type 属性' }}
+                >
+                  {INCOME_TYPES.map((t) => (
+                    <MenuItem key={t.key} value={t.key} sx={{ fontSize: '0.8125rem' }}>{t.label}</MenuItem>
+                  ))}
+                </Select>
+                <Select
+                  size="small"
+                  fullWidth
+                  value={manual.event_code}
+                  onChange={(e) => setManual({ ...manual, event_code: e.target.value })}
+                  displayEmpty
+                  inputProps={{ 'aria-label': 'Event 活动' }}
+                >
+                  <MenuItem value="" sx={{ fontSize: '0.8125rem' }}>General 常规</MenuItem>
+                  {events.map((ev) => (
+                    <MenuItem key={ev.code} value={ev.code} sx={{ fontSize: '0.8125rem' }}>{ev.name}</MenuItem>
+                  ))}
+                </Select>
+              </Box>
+            </Box>
+          )}
+        </DialogContent>
+        <DialogActions sx={{ px: 3, py: 2 }}>
+          <Button onClick={() => setManualOpen(false)} disabled={savingManual}>Cancel 取消</Button>
+          <Button
+            onClick={handleSaveManual}
+            disabled={savingManual || !manual?.name || !(parseFloat(manual?.amount) > 0)}
+            sx={pillButtonSx}
+          >
+            {savingManual ? <CircularProgress size={16} sx={{ color: 'white' }} /> : 'Save 保存'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  );
+}

--- a/ProjectCode/client/src/components/finance/IncomeGrid.test.js
+++ b/ProjectCode/client/src/components/finance/IncomeGrid.test.js
@@ -1,0 +1,317 @@
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import IncomeGrid, { methodFromSource } from './IncomeGrid';
+import { useAuth } from '../../context';
+import {
+  getIncome, getFinanceCategories, classifyIncome, addManualIncome,
+} from '../../api/finance';
+
+jest.mock('../../context', () => ({
+  useAuth: jest.fn(),
+}));
+jest.mock('../../api/finance', () => ({
+  getIncome: jest.fn(),
+  getFinanceCategories: jest.fn(),
+  classifyIncome: jest.fn(),
+  addManualIncome: jest.fn(),
+}));
+
+const currentYear = new Date().getFullYear();
+
+const incomeRows = [
+  {
+    donation_id: 1,
+    name: 'connie zhou',
+    amount: '20.00',
+    donation_date: `${currentYear}-07-08`,
+    source: 'Venmo (connie zhou)',
+    message: 'carpool bear mountain - 岑岑',
+    income_type: null,
+    event_code: null,
+    thank_you_sent_at: null,
+  },
+  {
+    donation_id: 2,
+    name: 'Kevin Gu',
+    amount: '15.00',
+    donation_date: `${currentYear}-07-06`,
+    source: 'Venmo (Kevin Gu)',
+    message: '🍉 梅老板加油',
+    income_type: 'donation',
+    event_code: 1001,
+    thank_you_sent_at: `${currentYear}-07-11T09:00:00`,
+  },
+  {
+    donation_id: 3,
+    name: 'Ryan Young',
+    amount: '20.00',
+    donation_date: `${currentYear}-07-08`,
+    source: 'Zelle (Ryan Young)',
+    message: '拼车费用',
+    income_type: 'pass_through',
+    event_code: 1002,
+    thank_you_sent_at: null,
+  },
+];
+
+const categories = {
+  events: [
+    { id: 1, kind: 'event', code: 1001, name: 'General', is_active: true },
+    { id: 2, kind: 'event', code: 1002, name: 'Bear Mt. Run', is_active: true },
+    { id: 3, kind: 'event', code: 1003, name: 'Old Gala', is_active: false },
+  ],
+  income_types: [],
+  expenses: [],
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  useAuth.mockReturnValue({ currentUser: { uid: 'admin-uid' } });
+  getIncome.mockResolvedValue(incomeRows);
+  getFinanceCategories.mockResolvedValue(categories);
+  classifyIncome.mockResolvedValue({ updated: 1 });
+  addManualIncome.mockResolvedValue({});
+});
+
+test('derives the method by stripping the parenthetical from the source', () => {
+  expect(methodFromSource('Zelle (Li Chen)')).toBe('Zelle');
+  expect(methodFromSource('Venmo (connie zhou)')).toBe('Venmo');
+  expect(methodFromSource('Manual')).toBe('Manual');
+  expect(methodFromSource(null)).toBe('');
+});
+
+test('renders rows with amounts, methods, memos and classification chips', async () => {
+  render(<IncomeGrid />);
+  expect(await screen.findByText('connie zhou')).toBeInTheDocument();
+  expect(screen.getAllByText('$20.00')).toHaveLength(2);
+  expect(screen.getByText('$15.00')).toBeInTheDocument();
+  expect(screen.getAllByText('Venmo').length).toBe(2);
+  expect(screen.getByText('Zelle')).toBeInTheDocument();
+  expect(screen.getByText('carpool bear mountain - 岑岑')).toBeInTheDocument();
+  // Chips: classified rows show type + event, unclassified shows the dashed prompts
+  expect(screen.getByText('Donation 捐款 ▾')).toBeInTheDocument();
+  expect(screen.getByText('Pass-through 代收 ▾')).toBeInTheDocument();
+  expect(screen.getByText('General ▾')).toBeInTheDocument();
+  expect(screen.getByText('Bear Mt. Run ▾')).toBeInTheDocument();
+  expect(screen.getByText('＋ classify 分类')).toBeInTheDocument();
+  expect(screen.getByText('＋ event')).toBeInTheDocument();
+});
+
+test('ack column shows the sent date for donations and a dash for non-donations', async () => {
+  render(<IncomeGrid />);
+  await screen.findByText('Kevin Gu');
+  expect(screen.getByText('✓ Jul 11')).toBeInTheDocument();
+  expect(screen.getByText('—')).toBeInTheDocument(); // pass-through row
+});
+
+test('filter chips narrow the grid', async () => {
+  render(<IncomeGrid />);
+  await screen.findByText('connie zhou');
+
+  fireEvent.click(screen.getByText('Unclassified 未分类'));
+  expect(screen.getByText('connie zhou')).toBeInTheDocument();
+  expect(screen.queryByText('Kevin Gu')).not.toBeInTheDocument();
+
+  fireEvent.click(screen.getByText('Donation 捐款'));
+  expect(screen.getByText('Kevin Gu')).toBeInTheDocument();
+  expect(screen.queryByText('connie zhou')).not.toBeInTheDocument();
+
+  fireEvent.click(screen.getByText('Pass-through 代收'));
+  expect(screen.getByText('Ryan Young')).toBeInTheDocument();
+  expect(screen.queryByText('Kevin Gu')).not.toBeInTheDocument();
+
+  fireEvent.click(screen.getByText('All 全部'));
+  expect(screen.getByText('connie zhou')).toBeInTheDocument();
+});
+
+test('classifies a single row from the type chip menu', async () => {
+  const onChanged = jest.fn();
+  render(<IncomeGrid onChanged={onChanged} />);
+  await screen.findByText('connie zhou');
+
+  fireEvent.click(screen.getByText('＋ classify 分类'));
+  const menu = await screen.findByRole('menu');
+  fireEvent.click(within(menu).getByText('Event Revenue 活动收入'));
+
+  await waitFor(() => expect(classifyIncome).toHaveBeenCalledWith(
+    { donation_ids: [1], income_type: 'event_revenue' }, 'admin-uid'
+  ));
+  await waitFor(() => expect(onChanged).toHaveBeenCalled());
+  expect(getIncome).toHaveBeenCalledTimes(2); // refetched after classify
+});
+
+test('changes the event of a classified row, keeping its income type', async () => {
+  render(<IncomeGrid />);
+  await screen.findByText('Ryan Young');
+
+  fireEvent.click(screen.getByText('Bear Mt. Run ▾'));
+  const menu = await screen.findByRole('menu');
+  fireEvent.click(within(menu).getByText('General'));
+
+  await waitFor(() => expect(classifyIncome).toHaveBeenCalledWith(
+    { donation_ids: [3], income_type: 'pass_through', event_code: 1001 }, 'admin-uid'
+  ));
+});
+
+test('setting the event of an unclassified row defaults it to a donation', async () => {
+  render(<IncomeGrid />);
+  await screen.findByText('connie zhou');
+
+  fireEvent.click(screen.getByText('＋ event'));
+  const menu = await screen.findByRole('menu');
+  fireEvent.click(within(menu).getByText('Bear Mt. Run'));
+
+  await waitFor(() => expect(classifyIncome).toHaveBeenCalledWith(
+    { donation_ids: [1], income_type: 'donation', event_code: 1002 }, 'admin-uid'
+  ));
+});
+
+test('inactive events are hidden from the event menu', async () => {
+  render(<IncomeGrid />);
+  await screen.findByText('connie zhou');
+  fireEvent.click(screen.getByText('＋ event'));
+  const menu = await screen.findByRole('menu');
+  expect(within(menu).queryByText('Old Gala')).not.toBeInTheDocument();
+});
+
+test('bulk classify bar applies a type and event to the checked rows', async () => {
+  render(<IncomeGrid />);
+  await screen.findByText('connie zhou');
+
+  fireEvent.click(screen.getByLabelText('Select row 1'));
+  fireEvent.click(screen.getByLabelText('Select row 3'));
+  expect(screen.getByText(/2 rows selected 已选 2 行/)).toBeInTheDocument();
+
+  fireEvent.mouseDown(screen.getByLabelText('Bulk type 批量属性').closest('[role="combobox"]') || screen.getAllByRole('combobox')[0]);
+  fireEvent.click(await screen.findByRole('option', { name: 'Pass-through 代收' }));
+
+  fireEvent.mouseDown(screen.getByLabelText('Bulk event 批量活动').closest('[role="combobox"]') || screen.getAllByRole('combobox')[1]);
+  fireEvent.click(await screen.findByRole('option', { name: 'Bear Mt. Run' }));
+
+  fireEvent.click(screen.getByText('Apply 应用'));
+  await waitFor(() => expect(classifyIncome).toHaveBeenCalledWith(
+    { donation_ids: [1, 3], income_type: 'pass_through', event_code: 1002 }, 'admin-uid'
+  ));
+  // Selection clears afterwards
+  await waitFor(() => expect(screen.queryByText(/rows selected/)).not.toBeInTheDocument());
+});
+
+test('bulk apply without an event omits event_code', async () => {
+  render(<IncomeGrid />);
+  await screen.findByText('connie zhou');
+  fireEvent.click(screen.getByLabelText('Select row 1'));
+  fireEvent.click(screen.getByText('Apply 应用'));
+  await waitFor(() => expect(classifyIncome).toHaveBeenCalledWith(
+    { donation_ids: [1], income_type: 'donation' }, 'admin-uid'
+  ));
+});
+
+test('the header checkbox selects and clears every visible row', async () => {
+  render(<IncomeGrid />);
+  await screen.findByText('connie zhou');
+  fireEvent.click(screen.getByLabelText('Select all rows 全选'));
+  expect(screen.getByText(/3 rows selected 已选 3 行/)).toBeInTheDocument();
+  fireEvent.click(screen.getByLabelText('Select all rows 全选'));
+  await waitFor(() => expect(screen.queryByText(/rows selected/)).not.toBeInTheDocument());
+});
+
+test('the Clear button empties the selection', async () => {
+  render(<IncomeGrid />);
+  await screen.findByText('connie zhou');
+  fireEvent.click(screen.getByLabelText('Select row 1'));
+  fireEvent.click(screen.getByText('Clear 清除'));
+  await waitFor(() => expect(screen.queryByText(/rows selected/)).not.toBeInTheDocument());
+});
+
+test('adds a manual income row through the dialog', async () => {
+  const onChanged = jest.fn();
+  render(<IncomeGrid onChanged={onChanged} />);
+  await screen.findByText('connie zhou');
+
+  fireEvent.click(screen.getByText('＋ Manual row 手动记一笔'));
+  expect(await screen.findByLabelText('From 来自')).toBeInTheDocument();
+
+  fireEvent.change(screen.getByLabelText('From 来自'), { target: { value: 'Cash box' } });
+  fireEvent.change(screen.getByLabelText('Amount 金额 $'), { target: { value: '40' } });
+  fireEvent.change(screen.getByLabelText('Date 日期'), { target: { value: '2026-07-01' } });
+  fireEvent.change(screen.getByLabelText('Method 方式'), { target: { value: 'Cash' } });
+  fireEvent.change(screen.getByLabelText('Memo 备注'), { target: { value: 'bake sale' } });
+
+  fireEvent.mouseDown(screen.getByLabelText('Type 属性').closest('[role="combobox"]'));
+  fireEvent.click(await screen.findByRole('option', { name: 'Event Revenue 活动收入' }));
+  fireEvent.mouseDown(screen.getByLabelText('Event 活动').closest('[role="combobox"]'));
+  fireEvent.click(await screen.findByRole('option', { name: 'Bear Mt. Run' }));
+
+  fireEvent.click(screen.getByText('Save 保存'));
+  await waitFor(() => expect(addManualIncome).toHaveBeenCalledWith({
+    name: 'Cash box',
+    amount: 40,
+    donation_date: '2026-07-01',
+    method: 'Cash',
+    memo: 'bake sale',
+    income_type: 'event_revenue',
+    event_code: 1002,
+  }, 'admin-uid'));
+  await waitFor(() => expect(screen.queryByLabelText('From 来自')).not.toBeInTheDocument());
+  expect(onChanged).toHaveBeenCalled();
+});
+
+test('manual dialog save stays disabled without a name and positive amount', async () => {
+  render(<IncomeGrid />);
+  await screen.findByText('connie zhou');
+  fireEvent.click(screen.getByText('＋ Manual row 手动记一笔'));
+  const save = await screen.findByText('Save 保存');
+  expect(save.closest('button')).toBeDisabled();
+  fireEvent.change(screen.getByLabelText('From 来自'), { target: { value: 'X' } });
+  expect(save.closest('button')).toBeDisabled();
+  fireEvent.change(screen.getByLabelText('Amount 金额 $'), { target: { value: '5' } });
+  expect(save.closest('button')).not.toBeDisabled();
+  fireEvent.click(screen.getByText('Cancel 取消'));
+  await waitFor(() => expect(screen.queryByLabelText('From 来自')).not.toBeInTheDocument());
+});
+
+test('shows an error when the manual row cannot be saved', async () => {
+  addManualIncome.mockRejectedValue(new Error('400'));
+  render(<IncomeGrid />);
+  await screen.findByText('connie zhou');
+  fireEvent.click(screen.getByText('＋ Manual row 手动记一笔'));
+  fireEvent.change(await screen.findByLabelText('From 来自'), { target: { value: 'X' } });
+  fireEvent.change(screen.getByLabelText('Amount 金额 $'), { target: { value: '5' } });
+  fireEvent.click(screen.getByText('Save 保存'));
+  expect(await screen.findByText(/手动记账失败/)).toBeInTheDocument();
+});
+
+test('shows an error when loading fails', async () => {
+  getIncome.mockRejectedValue(new Error('500'));
+  render(<IncomeGrid />);
+  expect(await screen.findByText(/Failed to load income rows/)).toBeInTheDocument();
+});
+
+test('shows an error when classification fails', async () => {
+  classifyIncome.mockRejectedValue(new Error('403'));
+  render(<IncomeGrid />);
+  await screen.findByText('connie zhou');
+  fireEvent.click(screen.getByText('＋ classify 分类'));
+  const menu = await screen.findByRole('menu');
+  fireEvent.click(within(menu).getByText('Donation 捐款'));
+  expect(await screen.findByText(/分类失败/)).toBeInTheDocument();
+});
+
+test('shows an empty state when the filter matches nothing', async () => {
+  getIncome.mockResolvedValue([]);
+  render(<IncomeGrid />);
+  expect(await screen.findByText(/暂无收入记录/)).toBeInTheDocument();
+});
+
+test('fetches nothing without a logged-in user', () => {
+  useAuth.mockReturnValue({ currentUser: null });
+  render(<IncomeGrid />);
+  expect(getIncome).not.toHaveBeenCalled();
+});
+
+test('refetches when refreshKey changes', async () => {
+  const { rerender } = render(<IncomeGrid refreshKey={0} />);
+  await screen.findByText('connie zhou');
+  expect(getIncome).toHaveBeenCalledTimes(1);
+  rerender(<IncomeGrid refreshKey={1} />);
+  await waitFor(() => expect(getIncome).toHaveBeenCalledTimes(2));
+});

--- a/ProjectCode/client/src/components/finance/ReportsTab.js
+++ b/ProjectCode/client/src/components/finance/ReportsTab.js
@@ -1,0 +1,438 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  Alert, Box, Button, Chip, CircularProgress, MenuItem, Paper, Select, Table,
+  TableBody, TableCell, TableContainer, TableHead, TableRow, Typography,
+} from '@mui/material';
+import FileDownloadOutlinedIcon from '@mui/icons-material/FileDownloadOutlined';
+import { useAuth } from '../../context';
+import {
+  getReportByEvent, getReportYoy, getReportPublicSupport, downloadByEventCsv,
+} from '../../api/finance';
+
+// Design tokens (homepage design language + finance chip colors)
+const ORANGE = '#FFA500';
+const ORANGE_DARK = '#F29400';
+const ORANGE_BG = '#FFF6E8';
+const LINE = '#EEE7DC';
+const INK = '#212121';
+const MUTED = '#757575';
+const GREEN = '#2e7d32';
+const GREEN_BG = '#eaf5ea';
+const RED = '#c62828';
+
+const SUBTABS = [
+  { key: 'byEvent', label: 'By Event 按活动' },
+  { key: 'yoy', label: 'YoY 同比' },
+  { key: 'publicSupport', label: 'Public support 509(a)' },
+];
+
+const fmtMoney = (value) => {
+  const n = Number(value || 0);
+  if (n === 0) return '—';
+  const abs = Math.abs(n).toLocaleString('en-US', { maximumFractionDigits: 2 });
+  return n < 0 ? `-$${abs}` : `$${abs}`;
+};
+
+const fmtExpense = (value) => {
+  const n = Number(value || 0);
+  if (n === 0) return '—';
+  return `-$${Math.abs(n).toLocaleString('en-US', { maximumFractionDigits: 2 })}`;
+};
+
+const fmtPct = (ratio) =>
+  `${(Number(ratio || 0) * 100).toFixed(1)}%`;
+
+const triggerDownload = (blob, filename) => {
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+};
+
+const headCellSx = {
+  fontSize: '0.625rem', fontWeight: 700, color: MUTED, textTransform: 'uppercase',
+  letterSpacing: '0.4px', borderBottom: `1px solid ${LINE}`, whiteSpace: 'nowrap',
+};
+
+function PassChip({ passes }) {
+  return (
+    <Chip
+      size="small"
+      label={passes ? 'PASS 通过' : 'FAIL 未通过'}
+      sx={{
+        fontSize: '0.65625rem', fontWeight: 700, borderRadius: '99px', height: 20,
+        backgroundColor: passes ? GREEN_BG : '#fdecea',
+        color: passes ? GREEN : RED,
+      }}
+    />
+  );
+}
+
+export default function ReportsTab() {
+  const { currentUser } = useAuth();
+  const firebaseUid = currentUser?.uid;
+
+  const [subtab, setSubtab] = useState('byEvent');
+  const [error, setError] = useState('');
+  const [year, setYear] = useState('');
+  const [byEvent, setByEvent] = useState(null);
+  const [yoy, setYoy] = useState(null);
+  const [publicSupport, setPublicSupport] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [exporting, setExporting] = useState(false);
+
+  const fetchAll = useCallback(async () => {
+    if (!firebaseUid) return;
+    setLoading(true);
+    setError('');
+    try {
+      const [yoyData, supportData] = await Promise.all([
+        getReportYoy(firebaseUid),
+        getReportPublicSupport(firebaseUid),
+      ]);
+      setYoy(yoyData);
+      setPublicSupport(supportData);
+    } catch (err) {
+      console.error('Error loading reports:', err);
+      setError('Failed to load reports. / 加载报表失败。');
+    } finally {
+      setLoading(false);
+    }
+  }, [firebaseUid]);
+
+  useEffect(() => {
+    fetchAll();
+  }, [fetchAll]);
+
+  useEffect(() => {
+    if (!firebaseUid) return;
+    let cancelled = false;
+    getReportByEvent(year || undefined, firebaseUid)
+      .then((data) => { if (!cancelled) setByEvent(data); })
+      .catch((err) => {
+        console.error('Error loading by-event report:', err);
+        if (!cancelled) setError('Failed to load the by-event report. / 加载活动报表失败。');
+      });
+    return () => { cancelled = true; };
+  }, [firebaseUid, year]);
+
+  const handleExport = async () => {
+    setExporting(true);
+    setError('');
+    try {
+      const { blob, filename } = await downloadByEventCsv(year || undefined, firebaseUid);
+      triggerDownload(blob, filename);
+    } catch (err) {
+      console.error('Error exporting CSV:', err);
+      setError('Failed to export the CSV. / 导出 CSV 失败。');
+    } finally {
+      setExporting(false);
+    }
+  };
+
+  if (loading && !yoy && !publicSupport) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', py: 6 }}>
+        <CircularProgress sx={{ color: ORANGE }} />
+      </Box>
+    );
+  }
+
+  const years = yoy?.years || [];
+
+  return (
+    <Box>
+      {error && (
+        <Alert severity="error" onClose={() => setError('')} sx={{ mb: 1.5 }}>
+          {error}
+        </Alert>
+      )}
+
+      {/* Sub-report chips */}
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap', mb: 1.5 }}>
+        {SUBTABS.map((t) => (
+          <Chip
+            key={t.key}
+            label={t.label}
+            onClick={() => setSubtab(t.key)}
+            sx={{
+              fontSize: '0.75rem',
+              fontWeight: 700,
+              borderRadius: '99px',
+              cursor: 'pointer',
+              border: `1.5px solid ${subtab === t.key ? ORANGE : LINE}`,
+              backgroundColor: subtab === t.key ? ORANGE : 'white',
+              color: subtab === t.key ? 'white' : MUTED,
+              '&:hover': { backgroundColor: subtab === t.key ? ORANGE_DARK : ORANGE_BG },
+            }}
+          />
+        ))}
+        <Box sx={{ flexGrow: 1 }} />
+        {subtab === 'byEvent' && (
+          <>
+            <Select
+              size="small"
+              value={year}
+              onChange={(e) => setYear(e.target.value)}
+              displayEmpty
+              inputProps={{ 'aria-label': 'Report year 年份' }}
+              sx={{ borderRadius: '8px', fontSize: '0.75rem', fontWeight: 700, minWidth: 130, '& .MuiSelect-select': { py: 0.5 } }}
+            >
+              <MenuItem value="" sx={{ fontSize: '0.8125rem' }}>All years 全部年份</MenuItem>
+              {years.map((y) => (
+                <MenuItem key={y} value={y} sx={{ fontSize: '0.8125rem' }}>{y}</MenuItem>
+              ))}
+            </Select>
+            <Button
+              size="small"
+              startIcon={exporting
+                ? <CircularProgress size={14} sx={{ color: ORANGE }} />
+                : <FileDownloadOutlinedIcon sx={{ fontSize: 16 }} />}
+              onClick={handleExport}
+              disabled={exporting}
+              sx={{
+                textTransform: 'none', fontWeight: 700, borderRadius: '99px', px: 2,
+                border: `1.5px solid ${ORANGE}`, color: ORANGE, boxShadow: 'none',
+                '&:hover': { backgroundColor: ORANGE, color: 'white' },
+              }}
+            >
+              Export CSV 导出
+            </Button>
+          </>
+        )}
+      </Box>
+
+      {/* By Event matrix */}
+      {subtab === 'byEvent' && byEvent && (
+        <TableContainer component={Paper} elevation={0} sx={{
+          border: `1px solid ${LINE}`, borderRadius: '12px', boxShadow: '0 2px 4px rgba(0,0,0,0.05)',
+        }}>
+          <Table size="small">
+            <TableHead>
+              <TableRow sx={{ backgroundColor: '#FDFBF7' }}>
+                <TableCell sx={headCellSx}>
+                  {byEvent.year ? `FY${byEvent.year} · ` : ''}Income 收入
+                </TableCell>
+                <TableCell sx={headCellSx}>Donation 捐款</TableCell>
+                <TableCell sx={headCellSx}>Event Revenue 活动收入</TableCell>
+                <TableCell sx={headCellSx}>Pass-through 代收</TableCell>
+                <TableCell sx={headCellSx}>TOTAL 合计</TableCell>
+                <TableCell sx={headCellSx}>Expenses 支出</TableCell>
+                <TableCell sx={headCellSx}>NET 净额</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {(byEvent.events || []).map((ev) => (
+                <TableRow key={ev.event_code} hover>
+                  <TableCell sx={{ fontSize: '0.78125rem', fontWeight: 700, backgroundColor: '#FDFBF7' }}>
+                    {ev.event_name}
+                  </TableCell>
+                  <TableCell sx={{ fontSize: '0.78125rem' }}>{fmtMoney(ev.donation)}</TableCell>
+                  <TableCell sx={{ fontSize: '0.78125rem' }}>{fmtMoney(ev.event_revenue)}</TableCell>
+                  <TableCell sx={{ fontSize: '0.78125rem' }}>{fmtMoney(ev.pass_through)}</TableCell>
+                  <TableCell sx={{ fontSize: '0.78125rem', fontWeight: 700 }}>{fmtMoney(ev.income_total)}</TableCell>
+                  <TableCell sx={{ fontSize: '0.78125rem', fontWeight: 700, color: RED }}>{fmtExpense(ev.expense_total)}</TableCell>
+                  <TableCell sx={{ fontSize: '0.78125rem', fontWeight: 700, color: Number(ev.net) < 0 ? RED : INK }}>{fmtMoney(ev.net)}</TableCell>
+                </TableRow>
+              ))}
+              {byEvent.totals && (
+                <TableRow>
+                  {[
+                    'TOTAL 合计',
+                    fmtMoney(byEvent.totals.donation),
+                    fmtMoney(byEvent.totals.event_revenue),
+                    fmtMoney(byEvent.totals.pass_through),
+                    fmtMoney(byEvent.totals.income_total),
+                    fmtExpense(byEvent.totals.expense_total),
+                    fmtMoney(byEvent.totals.net),
+                  ].map((cell, i) => (
+                    <TableCell key={i} sx={{
+                      fontSize: '0.78125rem', fontWeight: 700,
+                      backgroundColor: ORANGE_BG, color: ORANGE_DARK,
+                    }}>
+                      {cell}
+                    </TableCell>
+                  ))}
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      )}
+
+      {/* Year over year */}
+      {subtab === 'yoy' && yoy && (
+        <TableContainer component={Paper} elevation={0} sx={{
+          border: `1px solid ${LINE}`, borderRadius: '12px', boxShadow: '0 2px 4px rgba(0,0,0,0.05)',
+        }}>
+          <Table size="small">
+            <TableHead>
+              <TableRow sx={{ backgroundColor: '#FDFBF7' }}>
+                <TableCell sx={headCellSx}>Event 活动</TableCell>
+                {years.map((y) => (
+                  <TableCell key={y} sx={headCellSx}>
+                    {y} · income / expense / net
+                  </TableCell>
+                ))}
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {(yoy.events || []).map((ev) => (
+                <TableRow key={ev.event_code} hover>
+                  <TableCell sx={{ fontSize: '0.78125rem', fontWeight: 700, backgroundColor: '#FDFBF7' }}>
+                    {ev.event_name}
+                  </TableCell>
+                  {years.map((y) => {
+                    const cell = ev.years?.[y];
+                    return (
+                      <TableCell key={y} sx={{ fontSize: '0.78125rem', whiteSpace: 'nowrap' }}>
+                        {cell ? (
+                          <>
+                            {fmtMoney(cell.income)}
+                            {' / '}
+                            <Box component="span" sx={{ color: RED }}>{fmtExpense(cell.expense)}</Box>
+                            {' / '}
+                            <Box component="span" sx={{ fontWeight: 700, color: Number(cell.net) < 0 ? RED : INK }}>
+                              {fmtMoney(cell.net)}
+                            </Box>
+                          </>
+                        ) : '—'}
+                      </TableCell>
+                    );
+                  })}
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      )}
+
+      {/* Public support 509(a) */}
+      {subtab === 'publicSupport' && publicSupport && (
+        <Box>
+          <Box sx={{ display: 'flex', gap: 1.5, flexWrap: 'wrap', mb: 1.5 }}>
+            <Paper elevation={0} sx={{ flex: 1, minWidth: 220, border: `1px solid ${LINE}`, borderRadius: '12px', p: 2 }}>
+              <Typography sx={{ fontSize: '0.6875rem', fontWeight: 700, color: MUTED, textTransform: 'uppercase' }}>
+                Support window 支持期 FY{(publicSupport.window_fys || []).join(' – FY')}
+              </Typography>
+              <Typography sx={{ fontSize: '0.78125rem', color: MUTED, mt: 1 }}>
+                Contributions 捐款: <b>{fmtMoney(publicSupport.support?.contributions)}</b>
+              </Typography>
+              <Typography sx={{ fontSize: '0.78125rem', color: MUTED }}>
+                Gross receipts 营业收入: <b>{fmtMoney(publicSupport.support?.gross_receipts)}</b>
+              </Typography>
+              <Typography sx={{ fontSize: '0.78125rem', color: MUTED }}>
+                Total support 总支持: <b>{fmtMoney(publicSupport.support?.total_support)}</b>
+              </Typography>
+            </Paper>
+
+            <Paper elevation={0} sx={{ flex: 1, minWidth: 220, border: `1px solid ${LINE}`, borderRadius: '12px', p: 2 }}>
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                <Typography sx={{ fontSize: '0.6875rem', fontWeight: 700, color: MUTED, textTransform: 'uppercase' }}>
+                  Test 1 · 509(a)(1)
+                </Typography>
+                <PassChip passes={publicSupport.test1_509a1?.passes} />
+              </Box>
+              <Typography sx={{ fontSize: '1.25rem', fontWeight: 700, color: publicSupport.test1_509a1?.passes ? GREEN : RED, mt: 0.5 }}>
+                {fmtPct(publicSupport.test1_509a1?.ratio)}
+              </Typography>
+              <Typography sx={{ fontSize: '0.71875rem', color: MUTED }}>
+                Public support 公共支持 {fmtMoney(publicSupport.test1_509a1?.public_support)} ·
+                2% cap 上限 {fmtMoney(publicSupport.test1_509a1?.cap_2pct)} ·
+                excluded 超限剔除 {fmtMoney(publicSupport.test1_509a1?.excluded_by_cap)}
+              </Typography>
+            </Paper>
+
+            <Paper elevation={0} sx={{ flex: 1, minWidth: 220, border: `1px solid ${LINE}`, borderRadius: '12px', p: 2 }}>
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                <Typography sx={{ fontSize: '0.6875rem', fontWeight: 700, color: MUTED, textTransform: 'uppercase' }}>
+                  Test 2 · 509(a)(2)
+                </Typography>
+                <PassChip passes={publicSupport.test2_509a2?.passes} />
+              </Box>
+              <Typography sx={{ fontSize: '1.25rem', fontWeight: 700, color: publicSupport.test2_509a2?.passes ? GREEN : RED, mt: 0.5 }}>
+                {fmtPct(publicSupport.test2_509a2?.ratio)}
+              </Typography>
+              <Typography sx={{ fontSize: '0.71875rem', color: MUTED }}>
+                Public support 公共支持 {fmtMoney(publicSupport.test2_509a2?.public_support)} ·
+                DQP excluded 关联人剔除 {fmtMoney(publicSupport.test2_509a2?.dqp_excluded)}
+              </Typography>
+            </Paper>
+          </Box>
+
+          <Paper elevation={0} sx={{ border: `1px solid ${LINE}`, borderRadius: '12px', p: 2, mb: 1.5 }}>
+            <Typography sx={{ fontSize: '0.78125rem', color: MUTED }}>
+              Headroom 安全余量 — max single gift 单笔最大捐款: 509(a)(1) <b>{fmtMoney(publicSupport.headroom?.max_gift_a1)}</b>
+              {' · '}509(a)(2) <b>{fmtMoney(publicSupport.headroom?.max_gift_a2)}</b>
+            </Typography>
+          </Paper>
+
+          {(publicSupport.test2_509a2?.dqp_rows || []).length > 0 && (
+            <TableContainer component={Paper} elevation={0} sx={{
+              border: `1px solid ${LINE}`, borderRadius: '12px', mb: 1.5,
+            }}>
+              <Table size="small">
+                <TableHead>
+                  <TableRow sx={{ backgroundColor: '#FDFBF7' }}>
+                    <TableCell sx={headCellSx}>Disqualified person 关联人</TableCell>
+                    <TableCell sx={headCellSx}>Amount 金额</TableCell>
+                    <TableCell sx={headCellSx}>Reason 原因</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {publicSupport.test2_509a2.dqp_rows.map((row) => (
+                    <TableRow key={row.name}>
+                      <TableCell sx={{ fontSize: '0.78125rem', fontWeight: 600 }}>{row.name}</TableCell>
+                      <TableCell sx={{ fontSize: '0.78125rem' }}>{fmtMoney(row.amount)}</TableCell>
+                      <TableCell sx={{ fontSize: '0.75rem', color: MUTED }}>{row.reason}</TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </TableContainer>
+          )}
+
+          {(publicSupport.watch_list || []).length > 0 && (
+            <TableContainer component={Paper} elevation={0} sx={{
+              border: `1px solid ${LINE}`, borderRadius: '12px', mb: 1.5,
+            }}>
+              <Table size="small">
+                <TableHead>
+                  <TableRow sx={{ backgroundColor: '#FDFBF7' }}>
+                    <TableCell sx={headCellSx}>Watch list 关注名单 — top donors 大额捐赠人</TableCell>
+                    <TableCell sx={headCellSx}>Total 累计</TableCell>
+                    <TableCell sx={headCellSx}>Insider 内部人</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {publicSupport.watch_list.map((row) => (
+                    <TableRow key={row.name}>
+                      <TableCell sx={{ fontSize: '0.78125rem', fontWeight: 600 }}>{row.name}</TableCell>
+                      <TableCell sx={{ fontSize: '0.78125rem' }}>{fmtMoney(row.total)}</TableCell>
+                      <TableCell sx={{ fontSize: '0.78125rem' }}>
+                        {row.insider ? (
+                          <Chip size="small" label="insider 内部人" sx={{
+                            fontSize: '0.625rem', fontWeight: 700, borderRadius: '99px', height: 18,
+                            backgroundColor: '#fdecea', color: RED,
+                          }} />
+                        ) : '—'}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </TableContainer>
+          )}
+
+          <Typography sx={{ fontSize: '0.6875rem', color: '#9a9a9a' }}>
+            {publicSupport.disclaimer}
+          </Typography>
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/ProjectCode/client/src/components/finance/ReportsTab.test.js
+++ b/ProjectCode/client/src/components/finance/ReportsTab.test.js
@@ -1,0 +1,192 @@
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import ReportsTab from './ReportsTab';
+import { useAuth } from '../../context';
+import {
+  getReportByEvent, getReportYoy, getReportPublicSupport, downloadByEventCsv,
+} from '../../api/finance';
+
+jest.mock('../../context', () => ({
+  useAuth: jest.fn(),
+}));
+jest.mock('../../api/finance', () => ({
+  getReportByEvent: jest.fn(),
+  getReportYoy: jest.fn(),
+  getReportPublicSupport: jest.fn(),
+  downloadByEventCsv: jest.fn(),
+}));
+
+const byEventData = {
+  year: null,
+  events: [
+    { event_code: 1001, event_name: 'General', donation: 5320, event_revenue: 0, pass_through: 0, income_total: 5320, expense_total: 1214, net: 4106 },
+    { event_code: 1002, event_name: 'Bear Mt. Run 熊山', donation: 500, event_revenue: 0, pass_through: 1080, income_total: 1580, expense_total: 1466, net: 114 },
+  ],
+  totals: { donation: 5820, event_revenue: 0, pass_through: 1080, income_total: 6900, expense_total: 2680, net: 4220 },
+};
+
+const yoyData = {
+  years: ['2025', '2026'],
+  events: [
+    {
+      event_code: 1001,
+      event_name: 'General',
+      years: {
+        2025: { income: 100, expense: 50, net: 50 },
+        2026: { income: 200, expense: 80, net: 120 },
+      },
+    },
+    { event_code: 1002, event_name: 'Bear Mt. Run 熊山', years: {} },
+  ],
+};
+
+const publicSupportData = {
+  disclaimer: 'Estimates only — confirm with a CPA before filing. 仅供参考。',
+  org_start: '2016-06-01',
+  fye_month: 12,
+  window_fys: [2021, 2025],
+  support: { contributions: 10000, gross_receipts: 2000, total_support: 12000 },
+  test1_509a1: {
+    total_support: 12000, cap_2pct: 240, public_support: 9000,
+    excluded_by_cap: 1000, ratio: 0.75, passes: true,
+  },
+  test2_509a2: {
+    dqp_excluded: 500, public_support: 11500, ratio: 0.9583, passes: false,
+    dqp_rows: [{ name: 'Brandon Li', amount: 500, reason: 'Officer 委员' }],
+  },
+  headroom: { max_gift_a1: 3000, max_gift_a2: 2500 },
+  watch_list: [
+    { name: 'Yue Ma', total: 800, insider: false },
+    { name: 'Brandon Li', total: 500, insider: true },
+  ],
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  useAuth.mockReturnValue({ currentUser: { uid: 'admin-uid' } });
+  getReportByEvent.mockResolvedValue(byEventData);
+  getReportYoy.mockResolvedValue(yoyData);
+  getReportPublicSupport.mockResolvedValue(publicSupportData);
+  downloadByEventCsv.mockResolvedValue({ blob: new Blob(['csv']), filename: 'by-event.csv' });
+  global.URL.createObjectURL = jest.fn(() => 'blob:mock');
+  global.URL.revokeObjectURL = jest.fn();
+});
+
+test('renders the by-event matrix with a totals row', async () => {
+  render(<ReportsTab />);
+  expect(await screen.findByText('General')).toBeInTheDocument();
+  expect(screen.getByText('Bear Mt. Run 熊山')).toBeInTheDocument();
+  expect(screen.getAllByText('$5,320').length).toBe(2); // donation + income total columns
+  expect(screen.getByText('-$1,214')).toBeInTheDocument(); // expenses shown negative
+  expect(screen.getByText('$4,106')).toBeInTheDocument(); // net
+  expect(screen.getAllByText('TOTAL 合计').length).toBe(2); // header + totals row
+  expect(screen.getByText('$4,220')).toBeInTheDocument(); // total net
+  expect(getReportByEvent).toHaveBeenCalledWith(undefined, 'admin-uid');
+});
+
+test('zero amounts render as an em dash', async () => {
+  render(<ReportsTab />);
+  await screen.findByText('General');
+  // event_revenue is 0 for both rows and the totals row
+  expect(screen.getAllByText('—').length).toBeGreaterThanOrEqual(3);
+});
+
+test('changing the year refetches the by-event report', async () => {
+  render(<ReportsTab />);
+  await screen.findByText('General');
+
+  fireEvent.mouseDown(screen.getByLabelText('Report year 年份').closest('[role="combobox"]'));
+  fireEvent.click(await screen.findByRole('option', { name: '2026' }));
+
+  await waitFor(() => expect(getReportByEvent).toHaveBeenCalledWith('2026', 'admin-uid'));
+});
+
+test('exports the by-event CSV and triggers a download', async () => {
+  render(<ReportsTab />);
+  await screen.findByText('General');
+  fireEvent.click(screen.getByText('Export CSV 导出'));
+  await waitFor(() => expect(downloadByEventCsv).toHaveBeenCalledWith(undefined, 'admin-uid'));
+  await waitFor(() => expect(global.URL.createObjectURL).toHaveBeenCalled());
+});
+
+test('shows an error when the CSV export fails', async () => {
+  downloadByEventCsv.mockRejectedValue(new Error('500'));
+  render(<ReportsTab />);
+  await screen.findByText('General');
+  fireEvent.click(screen.getByText('Export CSV 导出'));
+  expect(await screen.findByText(/导出 CSV 失败/)).toBeInTheDocument();
+});
+
+test('YoY sub-tab shows income / expense / net per year', async () => {
+  render(<ReportsTab />);
+  await screen.findByText('General');
+  fireEvent.click(screen.getByText('YoY 同比'));
+
+  expect(screen.getByText('2025 · income / expense / net')).toBeInTheDocument();
+  expect(screen.getByText('2026 · income / expense / net')).toBeInTheDocument();
+  const rows = screen.getAllByRole('row');
+  const generalRow = rows.find((r) => within(r).queryByText('General'));
+  expect(generalRow).toHaveTextContent('$100 / -$50 / $50');
+  expect(generalRow).toHaveTextContent('$200 / -$80 / $120');
+  // Event with no data in either year shows dashes
+  const bearRow = rows.find((r) => within(r).queryByText('Bear Mt. Run 熊山'));
+  expect(within(bearRow).getAllByText('—')).toHaveLength(2);
+});
+
+test('public support sub-tab shows both tests with pass/fail chips', async () => {
+  render(<ReportsTab />);
+  await screen.findByText('General');
+  fireEvent.click(screen.getByText('Public support 509(a)'));
+
+  expect(screen.getByText('Test 1 · 509(a)(1)')).toBeInTheDocument();
+  expect(screen.getByText('Test 2 · 509(a)(2)')).toBeInTheDocument();
+  expect(screen.getByText('PASS 通过')).toBeInTheDocument();
+  expect(screen.getByText('FAIL 未通过')).toBeInTheDocument();
+  expect(screen.getByText('75.0%')).toBeInTheDocument();
+  expect(screen.getByText('95.8%')).toBeInTheDocument();
+  // Window + support block
+  expect(screen.getByText(/Support window 支持期 FY2021 – FY2025/)).toBeInTheDocument();
+  // Headroom
+  expect(screen.getByText(/max single gift 单笔最大捐款/)).toBeInTheDocument();
+  expect(screen.getByText('$3,000')).toBeInTheDocument();
+  // DQP table
+  expect(screen.getByText('Disqualified person 关联人')).toBeInTheDocument();
+  expect(screen.getByText('Officer 委员')).toBeInTheDocument();
+  // Watch list with insider chip
+  expect(screen.getByText('Yue Ma')).toBeInTheDocument();
+  expect(screen.getByText('insider 内部人')).toBeInTheDocument();
+  // Disclaimer
+  expect(screen.getByText(/confirm with a CPA/)).toBeInTheDocument();
+});
+
+test('hides the DQP and watch list tables when empty', async () => {
+  getReportPublicSupport.mockResolvedValue({
+    ...publicSupportData,
+    test2_509a2: { ...publicSupportData.test2_509a2, dqp_rows: [] },
+    watch_list: [],
+  });
+  render(<ReportsTab />);
+  await screen.findByText('General');
+  fireEvent.click(screen.getByText('Public support 509(a)'));
+  expect(screen.queryByText('Disqualified person 关联人')).not.toBeInTheDocument();
+  expect(screen.queryByText(/Watch list 关注名单/)).not.toBeInTheDocument();
+});
+
+test('shows an error when the reports fail to load', async () => {
+  getReportYoy.mockRejectedValue(new Error('500'));
+  getReportPublicSupport.mockRejectedValue(new Error('500'));
+  render(<ReportsTab />);
+  expect(await screen.findByText(/加载报表失败/)).toBeInTheDocument();
+});
+
+test('shows an error when the by-event report fails', async () => {
+  getReportByEvent.mockRejectedValue(new Error('500'));
+  render(<ReportsTab />);
+  expect(await screen.findByText(/加载活动报表失败/)).toBeInTheDocument();
+});
+
+test('fetches nothing without a logged-in user', () => {
+  useAuth.mockReturnValue({ currentUser: null });
+  render(<ReportsTab />);
+  expect(getReportYoy).not.toHaveBeenCalled();
+  expect(getReportByEvent).not.toHaveBeenCalled();
+});

--- a/ProjectCode/client/src/pages/FinancePage.js
+++ b/ProjectCode/client/src/pages/FinancePage.js
@@ -1,0 +1,242 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  Alert, Box, Button, CircularProgress, Container, Paper, Typography,
+} from '@mui/material';
+import { useAuth, useAdmin } from '../context';
+import IncomeGrid from '../components/finance/IncomeGrid';
+import ExpensesGrid from '../components/finance/ExpensesGrid';
+import ReportsTab from '../components/finance/ReportsTab';
+import DirectoryTab from '../components/finance/DirectoryTab';
+import FinanceSettingsTab from '../components/finance/FinanceSettingsTab';
+import { getAckQueue, sendAcks, importBankCsv } from '../api/finance';
+import { runGmailSync } from '../api/donors';
+
+// Design tokens (homepage design language)
+const ORANGE = '#FFA500';
+const ORANGE_DARK = '#F29400';
+const ORANGE_BG = '#FFF6E8';
+const LINE = '#EEE7DC';
+const MUTED = '#757575';
+const GREEN = '#2e7d32';
+
+const TABS = [
+  { key: 'income', label: '💵 Income 收入' },
+  { key: 'expenses', label: '💸 Expenses 支出' },
+  { key: 'reports', label: '🧾 Reports 报表' },
+  { key: 'directory', label: '👥 Directory 通讯录' },
+  { key: 'settings', label: '⚙️ Settings' },
+];
+
+const ghostButtonSx = {
+  textTransform: 'none',
+  fontWeight: 700,
+  fontSize: '0.71875rem',
+  borderRadius: '99px',
+  px: 2,
+  boxShadow: 'none',
+  border: `1.5px solid ${ORANGE}`,
+  color: ORANGE,
+  backgroundColor: 'white',
+  '&:hover': { backgroundColor: ORANGE, color: 'white', boxShadow: 'none' },
+};
+
+export default function FinancePage() {
+  const { currentUser } = useAuth();
+  const { adminModeEnabled } = useAdmin();
+  const firebaseUid = currentUser?.uid;
+
+  const [tab, setTab] = useState('income');
+  const [ackQueue, setAckQueue] = useState([]);
+  const [refreshKey, setRefreshKey] = useState(0);
+  const [notice, setNotice] = useState(null); // { severity, text }
+  const [scanning, setScanning] = useState(false);
+  const [importing, setImporting] = useState(false);
+  const [sending, setSending] = useState(false);
+  const fileInputRef = useRef(null);
+
+  const fetchAckQueue = useCallback(async () => {
+    if (!firebaseUid || !adminModeEnabled) return;
+    try {
+      setAckQueue(await getAckQueue(firebaseUid));
+    } catch (err) {
+      console.error('Error loading ack queue:', err);
+    }
+  }, [firebaseUid, adminModeEnabled]);
+
+  useEffect(() => {
+    fetchAckQueue();
+  }, [fetchAckQueue, refreshKey]);
+
+  const handleScanGmail = async () => {
+    setScanning(true);
+    setNotice(null);
+    try {
+      await runGmailSync(firebaseUid);
+      setNotice({ severity: 'success', text: 'Gmail scan finished. / 邮件扫描完成。' });
+      setRefreshKey((k) => k + 1);
+    } catch (err) {
+      console.error('Error scanning Gmail:', err);
+      setNotice({ severity: 'error', text: 'Gmail scan failed. Check server Gmail credentials. / 邮件扫描失败。' });
+    } finally {
+      setScanning(false);
+    }
+  };
+
+  const handleFileSelected = async (event) => {
+    const file = event.target.files?.[0];
+    event.target.value = '';
+    if (!file) return;
+    setImporting(true);
+    setNotice(null);
+    try {
+      const text = await new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => resolve(reader.result);
+        reader.onerror = () => reject(reader.error || new Error('Failed to read file'));
+        reader.readAsText(file);
+      });
+      const result = await importBankCsv(text, firebaseUid);
+      setNotice({
+        severity: 'success',
+        text: `Imported 已导入: ${result.expenses_added} expenses 支出 · ${result.income_added} income 收入 · `
+          + `${result.duplicates} duplicates skipped 重复跳过 · ${result.skipped_gmail_synced} already synced 已同步。`,
+      });
+      setRefreshKey((k) => k + 1);
+    } catch (err) {
+      console.error('Error importing CSV:', err);
+      setNotice({ severity: 'error', text: 'CSV import failed. / 账单导入失败。' });
+    } finally {
+      setImporting(false);
+    }
+  };
+
+  const handleSendAcks = async () => {
+    setSending(true);
+    setNotice(null);
+    try {
+      const result = await sendAcks(undefined, firebaseUid);
+      setNotice({
+        severity: 'success',
+        text: `Acknowledgments 致谢: ${result.sent} sent 已发送 · ${result.skipped} skipped (no email) 跳过（无邮箱）。`,
+      });
+      setRefreshKey((k) => k + 1);
+    } catch (err) {
+      console.error('Error sending acks:', err);
+      setNotice({ severity: 'error', text: 'Failed to send acknowledgments. / 发送致谢失败。' });
+    } finally {
+      setSending(false);
+    }
+  };
+
+  if (!adminModeEnabled) {
+    return (
+      <Container maxWidth="md" sx={{ mt: 6 }}>
+        <Paper elevation={0} sx={{
+          border: `1px dashed ${ORANGE}`, backgroundColor: ORANGE_BG,
+          borderRadius: '12px', p: 4, textAlign: 'center',
+        }}>
+          <Typography sx={{ fontSize: '1.0625rem', fontWeight: 700, mb: 1 }}>
+            🔒 Admin mode required 需要管理员模式
+          </Typography>
+          <Typography sx={{ fontSize: '0.8125rem', color: MUTED }}>
+            The finance workbench is for committee members. Enable admin mode from your account menu to continue.
+            财务工作台仅限委员会成员使用，请在账户菜单中开启管理员模式。
+          </Typography>
+        </Paper>
+      </Container>
+    );
+  }
+
+  return (
+    <Container maxWidth="xl" sx={{ mt: 4 }}>
+      <Typography sx={{ fontSize: '1.25rem', fontWeight: 700, mb: 0.5 }}>
+        📚 Finance 财务工作台
+      </Typography>
+      <Typography sx={{ fontSize: '0.78125rem', color: MUTED, mb: 2 }}>
+        Books grid — classify income & expenses, send acknowledgments, run the reports.
+        电子账本：分类收支、群发致谢、生成报表。
+      </Typography>
+
+      {notice && (
+        <Alert severity={notice.severity} onClose={() => setNotice(null)} sx={{ mb: 1.5 }}>
+          {notice.text}
+        </Alert>
+      )}
+
+      {/* Sheet tabs + toolbar */}
+      <Box sx={{ display: 'flex', alignItems: 'flex-end', gap: 1, flexWrap: 'wrap', mb: 0 }}>
+        <Box sx={{ display: 'flex', gap: '2px' }}>
+          {TABS.map((t) => {
+            const on = tab === t.key;
+            return (
+              <Box
+                key={t.key}
+                onClick={() => setTab(t.key)}
+                role="tab"
+                aria-selected={on}
+                sx={{
+                  backgroundColor: on ? 'white' : '#EFEBE2',
+                  border: `1px solid ${on ? ORANGE : LINE}`,
+                  borderBottom: 'none',
+                  borderRadius: '8px 8px 0 0',
+                  px: 2.25,
+                  py: 1,
+                  fontSize: '0.78125rem',
+                  fontWeight: 700,
+                  color: on ? ORANGE_DARK : MUTED,
+                  cursor: 'pointer',
+                  userSelect: 'none',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                {t.label}
+              </Box>
+            );
+          })}
+        </Box>
+        <Box sx={{ flexGrow: 1 }} />
+        <Box sx={{ display: 'flex', gap: 1, pb: 0.75, flexWrap: 'wrap' }}>
+          <Button size="small" onClick={handleScanGmail} disabled={scanning} sx={ghostButtonSx}>
+            {scanning ? <CircularProgress size={14} sx={{ color: ORANGE }} /> : '↻ Scan Gmail 扫描邮件'}
+          </Button>
+          <Button size="small" onClick={() => fileInputRef.current?.click()} disabled={importing} sx={ghostButtonSx}>
+            {importing ? <CircularProgress size={14} sx={{ color: ORANGE }} /> : '⬆ Import Chase CSV 导入账单'}
+          </Button>
+          <input
+            type="file"
+            accept=".csv,text/csv"
+            hidden
+            ref={fileInputRef}
+            onChange={handleFileSelected}
+            data-testid="chase-csv-input"
+          />
+          <Button
+            size="small"
+            onClick={handleSendAcks}
+            disabled={sending || ackQueue.length === 0}
+            sx={{
+              textTransform: 'none', fontWeight: 700, fontSize: '0.71875rem',
+              borderRadius: '99px', px: 2, boxShadow: 'none',
+              color: 'white', backgroundColor: GREEN,
+              '&:hover': { backgroundColor: '#1e5c22', boxShadow: 'none' },
+              '&.Mui-disabled': { backgroundColor: '#c8dcc9', color: 'white' },
+            }}
+          >
+            {sending
+              ? <CircularProgress size={14} sx={{ color: 'white' }} />
+              : `✉ Send ${ackQueue.length} acks 群发致谢`}
+          </Button>
+        </Box>
+      </Box>
+
+      {/* Active worksheet */}
+      <Box sx={{ pt: 0 }}>
+        {tab === 'income' && <IncomeGrid refreshKey={refreshKey} onChanged={fetchAckQueue} />}
+        {tab === 'expenses' && <ExpensesGrid refreshKey={refreshKey} />}
+        {tab === 'reports' && <ReportsTab />}
+        {tab === 'directory' && <DirectoryTab />}
+        {tab === 'settings' && <FinanceSettingsTab />}
+      </Box>
+    </Container>
+  );
+}

--- a/ProjectCode/client/src/pages/FinancePage.test.js
+++ b/ProjectCode/client/src/pages/FinancePage.test.js
@@ -1,0 +1,189 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import FinancePage from './FinancePage';
+import { useAuth, useAdmin } from '../context';
+import { getAckQueue, sendAcks, importBankCsv } from '../api/finance';
+import { runGmailSync } from '../api/donors';
+
+jest.mock('../context', () => ({
+  useAuth: jest.fn(),
+  useAdmin: jest.fn(),
+}));
+jest.mock('../api/finance', () => ({
+  getAckQueue: jest.fn(),
+  sendAcks: jest.fn(),
+  importBankCsv: jest.fn(),
+}));
+jest.mock('../api/donors', () => ({
+  runGmailSync: jest.fn(),
+}));
+
+jest.mock('../components/finance/IncomeGrid', () => (props) => {
+  const React = require('react');
+  return React.createElement(
+    'div',
+    { 'data-testid': 'income-grid' },
+    `income-refresh:${props.refreshKey}`,
+    React.createElement('button', { onClick: props.onChanged }, 'income-changed')
+  );
+});
+jest.mock('../components/finance/ExpensesGrid', () => (props) => {
+  const React = require('react');
+  return React.createElement('div', { 'data-testid': 'expenses-grid' }, `expenses-refresh:${props.refreshKey}`);
+});
+jest.mock('../components/finance/ReportsTab', () => () => {
+  const React = require('react');
+  return React.createElement('div', { 'data-testid': 'reports-tab' });
+});
+jest.mock('../components/finance/DirectoryTab', () => () => {
+  const React = require('react');
+  return React.createElement('div', { 'data-testid': 'directory-tab' });
+});
+jest.mock('../components/finance/FinanceSettingsTab', () => () => {
+  const React = require('react');
+  return React.createElement('div', { 'data-testid': 'settings-tab' });
+});
+
+const queue = [
+  { donation_id: 1, name: 'Yue Ma', amount: '500.00', donation_date: '2026-06-04', event_code: 1001, email: 'yue@x.com' },
+  { donation_id: 2, name: 'Kevin Gu', amount: '15.00', donation_date: '2026-07-06', event_code: 1001, email: null },
+];
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  useAuth.mockReturnValue({ currentUser: { uid: 'admin-uid' } });
+  useAdmin.mockReturnValue({ adminModeEnabled: true });
+  getAckQueue.mockResolvedValue(queue);
+  sendAcks.mockResolvedValue({ results: [], sent: 1, skipped: 1 });
+  importBankCsv.mockResolvedValue({
+    expenses_added: 3, income_added: 1, duplicates: 2, skipped_gmail_synced: 4, errors: [],
+  });
+  runGmailSync.mockResolvedValue({ emails_found: 2, inserted: 1 });
+});
+
+test('shows the admin gate when admin mode is off and fetches nothing', () => {
+  useAdmin.mockReturnValue({ adminModeEnabled: false });
+  render(<FinancePage />);
+  expect(screen.getByText(/Admin mode required 需要管理员模式/)).toBeInTheDocument();
+  expect(screen.queryByTestId('income-grid')).not.toBeInTheDocument();
+  expect(getAckQueue).not.toHaveBeenCalled();
+});
+
+test('renders the sheet tabs with the income grid active by default', async () => {
+  render(<FinancePage />);
+  expect(screen.getByText('📚 Finance 财务工作台')).toBeInTheDocument();
+  expect(screen.getByText('💵 Income 收入')).toBeInTheDocument();
+  expect(screen.getByText('💸 Expenses 支出')).toBeInTheDocument();
+  expect(screen.getByText('🧾 Reports 报表')).toBeInTheDocument();
+  expect(screen.getByText('👥 Directory 通讯录')).toBeInTheDocument();
+  expect(screen.getByText('⚙️ Settings')).toBeInTheDocument();
+  expect(screen.getByTestId('income-grid')).toBeInTheDocument();
+  expect(await screen.findByText('✉ Send 2 acks 群发致谢')).toBeInTheDocument();
+});
+
+test('switches worksheets when a tab is clicked', async () => {
+  render(<FinancePage />);
+  fireEvent.click(screen.getByText('💸 Expenses 支出'));
+  expect(screen.getByTestId('expenses-grid')).toBeInTheDocument();
+  expect(screen.queryByTestId('income-grid')).not.toBeInTheDocument();
+  fireEvent.click(screen.getByText('🧾 Reports 报表'));
+  expect(screen.getByTestId('reports-tab')).toBeInTheDocument();
+  fireEvent.click(screen.getByText('👥 Directory 通讯录'));
+  expect(screen.getByTestId('directory-tab')).toBeInTheDocument();
+  fireEvent.click(screen.getByText('⚙️ Settings'));
+  expect(screen.getByTestId('settings-tab')).toBeInTheDocument();
+  fireEvent.click(screen.getByText('💵 Income 收入'));
+  expect(screen.getByTestId('income-grid')).toBeInTheDocument();
+});
+
+test('Scan Gmail syncs, notifies and refreshes the grids', async () => {
+  render(<FinancePage />);
+  expect(screen.getByText('income-refresh:0')).toBeInTheDocument();
+  fireEvent.click(screen.getByText('↻ Scan Gmail 扫描邮件'));
+  await waitFor(() => expect(runGmailSync).toHaveBeenCalledWith('admin-uid'));
+  expect(await screen.findByText(/Gmail scan finished/)).toBeInTheDocument();
+  expect(screen.getByText('income-refresh:1')).toBeInTheDocument();
+});
+
+test('shows an error when the Gmail scan fails', async () => {
+  runGmailSync.mockRejectedValue(new Error('503'));
+  render(<FinancePage />);
+  fireEvent.click(screen.getByText('↻ Scan Gmail 扫描邮件'));
+  expect(await screen.findByText(/Gmail scan failed/)).toBeInTheDocument();
+  expect(screen.getByText('income-refresh:0')).toBeInTheDocument();
+});
+
+test('imports a Chase CSV through the hidden file input', async () => {
+  render(<FinancePage />);
+  // The visible button just proxies to the hidden input
+  fireEvent.click(screen.getByText('⬆ Import Chase CSV 导入账单'));
+  const input = screen.getByTestId('chase-csv-input');
+  const file = new File(['Details,Posting Date,Description,Amount\nDEBIT,07/01/2026,NYRR,-120.00'], 'chase.csv', { type: 'text/csv' });
+  fireEvent.change(input, { target: { files: [file] } });
+
+  await waitFor(() => expect(importBankCsv).toHaveBeenCalledWith(
+    expect.stringContaining('NYRR'), 'admin-uid'
+  ));
+  expect(await screen.findByText(/3 expenses 支出 · 1 income 收入 · 2 duplicates skipped 重复跳过 · 4 already synced 已同步/)).toBeInTheDocument();
+  expect(screen.getByText('income-refresh:1')).toBeInTheDocument();
+});
+
+test('shows an error when the CSV import fails', async () => {
+  importBankCsv.mockRejectedValue(new Error('bad csv'));
+  render(<FinancePage />);
+  const input = screen.getByTestId('chase-csv-input');
+  fireEvent.change(input, { target: { files: [new File(['x'], 'chase.csv', { type: 'text/csv' })] } });
+  expect(await screen.findByText(/CSV import failed/)).toBeInTheDocument();
+});
+
+test('ignores an empty file selection', async () => {
+  render(<FinancePage />);
+  const input = screen.getByTestId('chase-csv-input');
+  fireEvent.change(input, { target: { files: [] } });
+  await waitFor(() => expect(importBankCsv).not.toHaveBeenCalled());
+});
+
+test('sends the whole ack queue and reports the outcome', async () => {
+  render(<FinancePage />);
+  const button = await screen.findByText('✉ Send 2 acks 群发致谢');
+  fireEvent.click(button);
+  await waitFor(() => expect(sendAcks).toHaveBeenCalledWith(undefined, 'admin-uid'));
+  expect(await screen.findByText(/1 sent 已发送 · 1 skipped/)).toBeInTheDocument();
+  // Queue is re-fetched after sending
+  expect(getAckQueue.mock.calls.length).toBeGreaterThanOrEqual(2);
+});
+
+test('shows an error when sending acks fails', async () => {
+  sendAcks.mockRejectedValue(new Error('smtp down'));
+  render(<FinancePage />);
+  fireEvent.click(await screen.findByText('✉ Send 2 acks 群发致谢'));
+  expect(await screen.findByText(/Failed to send acknowledgments/)).toBeInTheDocument();
+});
+
+test('disables the ack button when the queue is empty', async () => {
+  getAckQueue.mockResolvedValue([]);
+  render(<FinancePage />);
+  const button = await screen.findByText('✉ Send 0 acks 群发致谢');
+  expect(button.closest('button')).toBeDisabled();
+});
+
+test('survives an ack-queue load failure', async () => {
+  getAckQueue.mockRejectedValue(new Error('500'));
+  render(<FinancePage />);
+  expect(await screen.findByText('✉ Send 0 acks 群发致谢')).toBeInTheDocument();
+});
+
+test('refreshes the ack queue when the income grid reports a change', async () => {
+  render(<FinancePage />);
+  await screen.findByText('✉ Send 2 acks 群发致谢');
+  const callsBefore = getAckQueue.mock.calls.length;
+  fireEvent.click(screen.getByText('income-changed'));
+  await waitFor(() => expect(getAckQueue.mock.calls.length).toBe(callsBefore + 1));
+});
+
+test('notices can be dismissed', async () => {
+  render(<FinancePage />);
+  fireEvent.click(screen.getByText('↻ Scan Gmail 扫描邮件'));
+  const alert = await screen.findByText(/Gmail scan finished/);
+  fireEvent.click(screen.getByTitle('Close'));
+  await waitFor(() => expect(alert).not.toBeInTheDocument());
+});

--- a/ProjectCode/server/.coveragerc
+++ b/ProjectCode/server/.coveragerc
@@ -10,6 +10,7 @@ omit =
     create_tables.py
     migrate_credits.py
     migrate_donation_ledger.py
+    migrate_finance_module.py
     migrate_events.py
     sync_member_results.py
     sync_zelle_donations.py

--- a/ProjectCode/server/database.py
+++ b/ProjectCode/server/database.py
@@ -77,6 +77,13 @@ class Donor(Base):
     thank_you_sent_at = Column(DateTime, nullable=True)
     email_excerpt = Column(Text, nullable=True)  # Original notification email summary
 
+    # Two-layer bookkeeping (mirrors the club's Google Sheet):
+    # income_type: NULL = unclassified, else 'donation' | 'event_revenue'
+    #   | 'pass_through' | 'mistake'. Only 'donation' rows appear publicly.
+    # event_code: finance_categories code (1xxx), e.g. 1001 General.
+    income_type = Column(String(20), nullable=True)
+    event_code = Column(Integer, nullable=True)
+
     # Indexes for better query performance
     __table_args__ = (
         Index('idx_donor_type', 'donor_type'),
@@ -87,6 +94,61 @@ class Donor(Base):
         Index('idx_donor_member_id', 'member_id'),
         Index('idx_donor_status', 'status'),
     )
+
+# Finance category codes, mirroring the club's Google Sheet coding:
+# kind='event' (1xxx: General, Anniversary, Bear Mt. ...), kind='income_type'
+# (2xxx: Donation, Gala Tickets, ...), kind='expense' (5xxx: Food & Drink, ...)
+class FinanceCategory(Base):
+    __tablename__ = "finance_categories"
+
+    id = Column(Integer, primary_key=True, index=True, autoincrement=True)
+    kind = Column(String(20), nullable=False)  # event | income_type | expense
+    code = Column(Integer, nullable=False)     # 1001, 2001, 5001 ...
+    name = Column(String(100), nullable=False)
+    is_active = Column(Boolean, default=True)
+    created_at = Column(DateTime, default=func.now())
+
+    __table_args__ = (
+        UniqueConstraint('kind', 'code', name='uq_finance_category_kind_code'),
+    )
+
+
+# Money-out ledger, imported from Chase CSV statements (cash basis)
+class Expense(Base):
+    __tablename__ = "expenses"
+
+    id = Column(Integer, primary_key=True, index=True, autoincrement=True)
+    expense_date = Column(Date, nullable=False)
+    vendor = Column(String(255), nullable=False)
+    amount = Column(DECIMAL(10, 2), nullable=False)  # positive number
+    method = Column(String(50))                      # Debit Card / ACH / Check / Zelle / ...
+    bank_description = Column(Text)                  # raw statement line
+    event_code = Column(Integer, nullable=True)      # finance_categories 1xxx
+    expense_category_code = Column(Integer, nullable=True)  # finance_categories 5xxx
+    import_id = Column(String(255), unique=True)     # dedupe key (BANK|date|amount|desc)
+    created_at = Column(DateTime, default=func.now())
+    updated_at = Column(DateTime, default=func.now(), onupdate=func.now())
+
+    __table_args__ = (
+        Index('idx_expense_date', 'expense_date'),
+        Index('idx_expense_event', 'event_code'),
+    )
+
+
+# Donor name -> email memory so acknowledgments can batch-send
+# (payment notification emails never include the donor's address)
+class DonorDirectoryEntry(Base):
+    __tablename__ = "donor_directory"
+
+    id = Column(Integer, primary_key=True, index=True, autoincrement=True)
+    name = Column(String(255), nullable=False, unique=True)  # normalized donor name
+    email = Column(String(255), nullable=False)
+    # Officer/founder/family — excluded as disqualified persons in the
+    # 509(a)(2) public support test
+    is_insider = Column(Boolean, default=False)
+    created_at = Column(DateTime, default=func.now())
+    updated_at = Column(DateTime, default=func.now(), onupdate=func.now())
+
 
 # Thank-you letter templates for the donation ledger, tiered by amount:
 # the template with the highest min_amount <= donation amount is used.

--- a/ProjectCode/server/main.py
+++ b/ProjectCode/server/main.py
@@ -22,6 +22,7 @@ from scheduler import start_scheduler, shutdown_scheduler
 from routes import (
     results,
     donors,
+    finance,
     members,
     activities,
     events,
@@ -193,6 +194,7 @@ def read_root():
 # Register all route modules
 app.include_router(results.router)
 app.include_router(donors.router)
+app.include_router(finance.router)
 app.include_router(members.router)
 app.include_router(activities.router)
 app.include_router(events.router)

--- a/ProjectCode/server/migrate_finance_module.py
+++ b/ProjectCode/server/migrate_finance_module.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""
+One-time migration for the finance module (Books Grid).
+
+1. Adds two-layer bookkeeping columns to donors:
+       income_type VARCHAR(20) NULL   (donation | event_revenue | pass_through | mistake)
+       event_code  INTEGER NULL       (finance_categories 1xxx)
+2. Creates the new tables (finance_categories, expenses, donor_directory)
+   and seeds the category codes used in the club's Google Sheet.
+3. Backfills income_type from the old two-state model:
+       confirmed -> donation
+       dismissed -> pass_through / event_revenue by memo keywords, else mistake
+       pending   -> NULL (unclassified)
+
+Safe to re-run. Works on SQLite (dev) and MySQL (prod):
+    cd /var/www/newbeerunning/backend && python migrate_finance_module.py
+"""
+
+from sqlalchemy import inspect, text
+
+from database import SessionLocal, FinanceCategory, create_tables, engine
+
+DONOR_COLUMNS = [
+    ("income_type", "VARCHAR(20) NULL"),
+    ("event_code", "INTEGER NULL"),
+]
+
+CATEGORY_SEED = [
+    # events (layer 1)
+    ("event", 1001, "General"),
+    ("event", 1002, "NewBee New Year Gala"),
+    ("event", 1003, "NewBee Anniversary"),
+    ("event", 1004, "Bear Mt. Run"),
+    ("event", 1005, "BK Half Course Preview"),
+    ("event", 1006, "Team Championship"),
+    ("event", 1007, "Queens 10K"),
+    # income types (layer 2, money in)
+    ("income_type", 2001, "Donation"),
+    ("income_type", 2002, "Gala Tickets"),
+    ("income_type", 2003, "Merchandise Sales"),
+    ("income_type", 2004, "Pass-through Agent"),
+    # expense categories (layer 2, money out)
+    ("expense", 5001, "Event Food & Drink"),
+    ("expense", 5002, "Event Supplies"),
+    ("expense", 5003, "Transportation"),
+    ("expense", 5004, "Others (General)"),
+    ("expense", 5005, "Space Rental"),
+    ("expense", 5006, "Office Supplies&Sub"),
+]
+
+PASS_THROUGH_KEYWORDS = ["拼车", "carpool", "车费", "🚗"]
+EVENT_REVENUE_KEYWORDS = ["队服", "衣服", "t-shirt", "tshirt", "t shirt", "tee",
+                          "shirt", "jersey", "门票", "ticket"]
+
+
+def migrate():
+    # 1. donors columns
+    inspector = inspect(engine)
+    existing = {col["name"] for col in inspector.get_columns("donors")}
+    with engine.begin() as conn:
+        for name, ddl in DONOR_COLUMNS:
+            if name in existing:
+                print(f"Column donors.{name} already exists, skipping.")
+                continue
+            conn.execute(text(f"ALTER TABLE donors ADD COLUMN {name} {ddl}"))
+            print(f"Added column donors.{name}.")
+
+    # 2. new tables + category seed
+    create_tables()
+    db = SessionLocal()
+    try:
+        for kind, code, name in CATEGORY_SEED:
+            exists = db.query(FinanceCategory).filter(
+                FinanceCategory.kind == kind, FinanceCategory.code == code
+            ).first()
+            if not exists:
+                db.add(FinanceCategory(kind=kind, code=code, name=name))
+                print(f"Seeded {kind} {code} - {name}")
+        db.commit()
+
+        # 3. backfill income_type from the old status model
+        rows = db.execute(text(
+            "SELECT donation_id, status, message, notes FROM donors "
+            "WHERE income_type IS NULL"
+        )).fetchall()
+        counts = {"donation": 0, "pass_through": 0, "event_revenue": 0, "mistake": 0}
+        for donation_id, status, message, notes in rows:
+            memo = f"{message or ''} {notes or ''}".lower()
+            income_type = None
+            if status == "confirmed":
+                income_type = "donation"
+            elif status == "dismissed":
+                if any(k in memo for k in PASS_THROUGH_KEYWORDS):
+                    income_type = "pass_through"
+                elif any(k in memo for k in EVENT_REVENUE_KEYWORDS):
+                    income_type = "event_revenue"
+                else:
+                    income_type = "mistake"
+            if income_type:
+                counts[income_type] += 1
+                db.execute(text(
+                    "UPDATE donors SET income_type = :t, "
+                    "event_code = COALESCE(event_code, 1001) "
+                    "WHERE donation_id = :id"
+                ), {"t": income_type, "id": donation_id})
+        db.commit()
+        print(f"Backfilled income_type: {counts}")
+    finally:
+        db.close()
+
+    print("Finance module migration complete.")
+
+
+if __name__ == "__main__":
+    migrate()

--- a/ProjectCode/server/models.py
+++ b/ProjectCode/server/models.py
@@ -84,6 +84,9 @@ class DonorLedgerEntry(DonorResponse):
     status: str = "confirmed"  # pending | confirmed | dismissed
     thank_you_sent_at: Optional[datetime] = None
     email_excerpt: Optional[str] = None
+    # Two-layer bookkeeping (finance module)
+    income_type: Optional[str] = None  # donation | event_revenue | pass_through | mistake
+    event_code: Optional[int] = None
     # The ledger shows every row, including legacy/imported ones where these
     # can be NULL (rows inserted outside SQLAlchemy get no column defaults)
     donation_event: Optional[str] = None
@@ -161,6 +164,106 @@ class ThankYouTemplateResponse(ThankYouTemplateBase):
     class Config:
         from_attributes = True
     
+# ---------------------------------------------------------------------------
+# Finance module (Books Grid)
+# ---------------------------------------------------------------------------
+
+INCOME_TYPES = ("donation", "event_revenue", "pass_through", "mistake")
+
+
+class FinanceCategoryCreate(BaseModel):
+    kind: str = Field(..., pattern="^(event|income_type|expense)$")
+    name: str = Field(..., max_length=100)
+    code: Optional[int] = None  # auto-assigned (next in kind's range) if omitted
+
+
+class FinanceCategoryUpdate(BaseModel):
+    name: Optional[str] = Field(None, max_length=100)
+    is_active: Optional[bool] = None
+
+
+class FinanceCategoryOut(BaseModel):
+    id: int
+    kind: str
+    code: int
+    name: str
+    is_active: bool
+
+    class Config:
+        from_attributes = True
+
+
+class ClassifyIncomeRequest(BaseModel):
+    donation_ids: List[int]
+    income_type: str = Field(..., pattern="^(donation|event_revenue|pass_through|mistake)$")
+    event_code: Optional[int] = None
+
+
+class ManualIncomeRequest(BaseModel):
+    name: str = Field(..., max_length=255)
+    amount: Decimal = Field(..., gt=0, decimal_places=2)
+    donation_date: Optional[dt.date] = None
+    method: Optional[str] = Field(None, max_length=50)
+    memo: Optional[str] = None
+    income_type: str = Field(..., pattern="^(donation|event_revenue|pass_through|mistake)$")
+    event_code: Optional[int] = None
+
+
+class ExpenseOut(BaseModel):
+    id: int
+    expense_date: dt.date
+    vendor: str
+    amount: Decimal
+    method: Optional[str] = None
+    bank_description: Optional[str] = None
+    event_code: Optional[int] = None
+    expense_category_code: Optional[int] = None
+
+    class Config:
+        from_attributes = True
+
+
+class ClassifyExpenseRequest(BaseModel):
+    expense_ids: List[int]
+    event_code: Optional[int] = None
+    expense_category_code: Optional[int] = None
+
+
+class BankImportRequest(BaseModel):
+    csv_text: str
+
+
+class DirectoryUpsertRequest(BaseModel):
+    name: str = Field(..., max_length=255)
+    email: EmailStr
+    is_insider: Optional[bool] = None
+
+
+class DirectoryEntryOut(BaseModel):
+    id: int
+    name: str
+    email: str
+    is_insider: bool = False
+
+    class Config:
+        from_attributes = True
+
+
+class SendAcksRequest(BaseModel):
+    donation_ids: Optional[List[int]] = None  # default: whole queue
+
+
+class YearEndSendRequest(BaseModel):
+    year: int
+    names: Optional[List[str]] = None  # default: all donors with previews
+
+
+class FinanceSettingsUpdate(BaseModel):
+    auto_ack_enabled: Optional[bool] = None
+    org_start: Optional[str] = None   # YYYY-MM-DD, 990 exemption effective date
+    fye_month: Optional[int] = Field(None, ge=1, le=12)
+
+
 class DonationSummary(BaseModel):
     donor_type: str
     donor_count: int

--- a/ProjectCode/server/routes/donors.py
+++ b/ProjectCode/server/routes/donors.py
@@ -232,6 +232,10 @@ def approve_donation(
     if request.hide_name is not None:
         donor.hide_name = request.hide_name
     donor.status = "confirmed"
+    # Keep the finance books in sync: approved = a real donation
+    donor.income_type = "donation"
+    if donor.event_code is None:
+        donor.event_code = 1001  # General
 
     db.commit()
     db.refresh(donor)
@@ -254,6 +258,7 @@ def revert_donation(
         )
 
     donor.status = "pending"
+    donor.income_type = None  # back to unclassified in the finance books
     db.commit()
     db.refresh(donor)
     return donor
@@ -274,6 +279,9 @@ def dismiss_donation(
         )
 
     donor.status = "dismissed"
+    # Keep the finance books in sync; committee can refine the type later
+    if donor.income_type in (None, "donation"):
+        donor.income_type = "mistake"
     db.commit()
     db.refresh(donor)
     return donor
@@ -483,22 +491,39 @@ def send_thank_you(
             detail="Only confirmed donations can receive a thank-you email"
         )
 
+    send_acknowledgment(db, donor, request.email,
+                        subject=request.subject, message=request.message,
+                        attach_receipt=request.attach_receipt)
+    db.commit()
+    db.refresh(donor)
+    return donor
+
+
+def send_acknowledgment(db: Session, donor, email: str, subject=None,
+                        message=None, attach_receipt: bool = True):
+    """Compose (matched tier template), send with optional receipt PDF,
+    stamp thank_you_sent_at, and append the full acknowledgment to the
+    notes audit trail. Caller commits. Raises HTTPException on failure.
+
+    Shared by the single-send dialog, the finance batch queue, and the
+    weekly auto-send job.
+    """
     from email_service import EmailService
-    subject, body_html, body_text = _compose_thank_you(db, donor)[:3]
+    final_subject, body_html, body_text = _compose_thank_you(db, donor)[:3]
     # Committee reviewed/edited the letter in the dialog — send their text
-    if request.subject and request.subject.strip():
-        subject = request.subject.strip()
-    if request.message and request.message.strip():
-        body_text = request.message
-        body_html = _text_to_html(request.message)
+    if subject and subject.strip():
+        final_subject = subject.strip()
+    if message and message.strip():
+        body_text = message
+        body_html = _text_to_html(message)
 
     attachments = None
     receipt_filename = None
-    if request.attach_receipt:
+    if attach_receipt:
         receipt_filename = _receipt_filename(donor)
         attachments = [(receipt_filename, _build_receipt_pdf(donor), "pdf")]
 
-    if not EmailService.send_email(request.email, subject, body_html, body_text,
+    if not EmailService.send_email(email, final_subject, body_html, body_text,
                                    attachments=attachments):
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,
@@ -511,15 +536,12 @@ def send_thank_you(
     # shows exactly what was sent, to whom, and when
     ack_record = (
         f"—— Thank-you email 感谢邮件 ——\n"
-        f"Sent to {request.email} on {sent_at.strftime('%b %d, %Y %H:%M')} UTC\n"
-        f"Subject: {subject}\n"
+        f"Sent to {email} on {sent_at.strftime('%b %d, %Y %H:%M')} UTC\n"
+        f"Subject: {final_subject}\n"
         + (f"Attachment 附件: {receipt_filename}\n" if receipt_filename else "")
         + f"\n{body_text}"
     )
     donor.notes = f"{donor.notes}\n\n{ack_record}" if donor.notes else ack_record
-    db.commit()
-    db.refresh(donor)
-    return donor
 
 
 # ---------------------------------------------------------------------------

--- a/ProjectCode/server/routes/finance.py
+++ b/ProjectCode/server/routes/finance.py
@@ -1,0 +1,784 @@
+"""Finance module (Books Grid): two-layer income classification, expense
+ledger with Chase CSV import, donor directory, batch acknowledgments,
+cash-basis reports, and year-end donor statements.
+
+Ports the workflows of the club's Google Sheet ("DONATION & EXPENSE
+WORKFLOW" script) onto the website, keeping its category codes:
+events 1xxx · income types 2xxx · expense categories 5xxx.
+"""
+import csv
+import io
+import json
+import re
+from datetime import date, datetime
+from decimal import Decimal, InvalidOperation
+
+from fastapi import APIRouter, Depends, HTTPException, Response, status
+from sqlalchemy.orm import Session
+from typing import List, Optional
+
+from database import (
+    get_db, Donor, Expense, FinanceCategory, DonorDirectoryEntry, Member,
+    SiteSetting,
+)
+from models import (
+    FinanceCategoryCreate, FinanceCategoryUpdate, FinanceCategoryOut,
+    ClassifyIncomeRequest, ManualIncomeRequest, DonorLedgerEntry,
+    ExpenseOut, ClassifyExpenseRequest, BankImportRequest,
+    DirectoryUpsertRequest, DirectoryEntryOut, SendAcksRequest,
+    YearEndSendRequest, FinanceSettingsUpdate,
+)
+from utils.auth import get_current_committee_or_admin
+
+router = APIRouter(prefix="/api/finance", tags=["finance"])
+
+KIND_RANGES = {"event": 1000, "income_type": 2000, "expense": 5000}
+
+
+def _normalize_name(name: str) -> str:
+    return re.sub(r"\s+", " ", (name or "").strip()).lower()
+
+
+def _get_setting(db: Session, key: str):
+    row = db.query(SiteSetting).filter(SiteSetting.key == key).first()
+    return row.value if row else None
+
+
+def _put_setting(db: Session, key: str, value: str, label: str = "Finance"):
+    row = db.query(SiteSetting).filter(SiteSetting.key == key).first()
+    if row:
+        row.value = value
+    else:
+        db.add(SiteSetting(key=key, value=value, label_en=label,
+                           label_cn="财务", category="finance", is_active=True))
+
+
+# ---------------------------------------------------------------------------
+# Categories (events 1xxx / income types 2xxx / expense categories 5xxx)
+# ---------------------------------------------------------------------------
+
+@router.get("/categories")
+def list_categories(db: Session = Depends(get_db), current_admin: Member = Depends(get_current_committee_or_admin)):
+    rows = db.query(FinanceCategory).filter(FinanceCategory.is_active == True).order_by(  # noqa: E712
+        FinanceCategory.code).all()
+    out = {"events": [], "income_types": [], "expenses": []}
+    for row in rows:
+        entry = FinanceCategoryOut.model_validate(row).model_dump()
+        if row.kind == "event":
+            out["events"].append(entry)
+        elif row.kind == "income_type":
+            out["income_types"].append(entry)
+        else:
+            out["expenses"].append(entry)
+    return out
+
+
+@router.post("/categories", response_model=FinanceCategoryOut)
+def create_category(request: FinanceCategoryCreate, db: Session = Depends(get_db),
+                    current_admin: Member = Depends(get_current_committee_or_admin)):
+    code = request.code
+    if code is None:
+        top = db.query(FinanceCategory).filter(
+            FinanceCategory.kind == request.kind
+        ).order_by(FinanceCategory.code.desc()).first()
+        code = (top.code + 1) if top else KIND_RANGES[request.kind] + 1
+    if db.query(FinanceCategory).filter(FinanceCategory.kind == request.kind,
+                                        FinanceCategory.code == code).first():
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST,
+                            detail=f"Code {code} already exists for {request.kind}")
+    row = FinanceCategory(kind=request.kind, code=code, name=request.name)
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+@router.put("/categories/{category_id}", response_model=FinanceCategoryOut)
+def update_category(category_id: int, request: FinanceCategoryUpdate,
+                    db: Session = Depends(get_db),
+                    current_admin: Member = Depends(get_current_committee_or_admin)):
+    row = db.query(FinanceCategory).filter(FinanceCategory.id == category_id).first()
+    if not row:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND,
+                            detail=f"Category {category_id} not found")
+    for field, value in request.model_dump(exclude_unset=True).items():
+        setattr(row, field, value)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+# ---------------------------------------------------------------------------
+# Income (donations table with two-layer classification)
+# ---------------------------------------------------------------------------
+
+@router.get("/income", response_model=List[DonorLedgerEntry])
+def list_income(db: Session = Depends(get_db), current_admin: Member = Depends(get_current_committee_or_admin)):
+    """Every money-in row, unclassified first, newest first within groups."""
+    rows = db.query(Donor).order_by(
+        Donor.donation_date.desc(), Donor.created_at.desc()).all()
+    rows.sort(key=lambda d: d.income_type is not None)
+    return rows
+
+
+@router.post("/income/classify")
+def classify_income(request: ClassifyIncomeRequest, db: Session = Depends(get_db),
+                    current_admin: Member = Depends(get_current_committee_or_admin)):
+    """Bulk two-layer classification. Only 'donation' rows publish to the
+    public sponsor wall (status stays in sync for the legacy endpoints)."""
+    rows = db.query(Donor).filter(Donor.donation_id.in_(request.donation_ids)).all()
+    if len(rows) != len(set(request.donation_ids)):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND,
+                            detail="One or more donations not found")
+    for donor in rows:
+        donor.income_type = request.income_type
+        if request.event_code is not None:
+            donor.event_code = request.event_code
+        elif donor.event_code is None:
+            donor.event_code = 1001  # General
+        donor.status = "confirmed" if request.income_type == "donation" else "dismissed"
+    db.commit()
+    return {"updated": len(rows)}
+
+
+@router.post("/income/manual", response_model=DonorLedgerEntry)
+def add_manual_income(request: ManualIncomeRequest, db: Session = Depends(get_db),
+                      current_admin: Member = Depends(get_current_committee_or_admin)):
+    """Record income that never hit Gmail or the bank import (e.g. cash)."""
+    donor = Donor(
+        donor_id=f"MAN_{int(datetime.utcnow().timestamp() * 1000)}",
+        name=request.name,
+        donor_type="individual",
+        amount=request.amount,
+        donation_date=request.donation_date or date.today(),
+        source=request.method or "Manual",
+        message=request.memo,
+        notes="Manual entry 手动记账",
+        donation_event="General Support",
+        receipt_confirmed=False,
+        quantity=1,
+        income_type=request.income_type,
+        event_code=request.event_code or 1001,
+        status="confirmed" if request.income_type == "donation" else "dismissed",
+    )
+    db.add(donor)
+    db.commit()
+    db.refresh(donor)
+    return donor
+
+
+# ---------------------------------------------------------------------------
+# Expenses + Chase CSV bank import
+# ---------------------------------------------------------------------------
+
+@router.get("/expenses", response_model=List[ExpenseOut])
+def list_expenses(db: Session = Depends(get_db), current_admin: Member = Depends(get_current_committee_or_admin)):
+    rows = db.query(Expense).order_by(Expense.expense_date.desc(), Expense.id.desc()).all()
+    rows.sort(key=lambda e: e.expense_category_code is not None)
+    return rows
+
+
+@router.post("/expenses/classify")
+def classify_expenses(request: ClassifyExpenseRequest, db: Session = Depends(get_db),
+                      current_admin: Member = Depends(get_current_committee_or_admin)):
+    rows = db.query(Expense).filter(Expense.id.in_(request.expense_ids)).all()
+    if len(rows) != len(set(request.expense_ids)):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND,
+                            detail="One or more expenses not found")
+    for expense in rows:
+        if request.event_code is not None:
+            expense.event_code = request.event_code
+        if request.expense_category_code is not None:
+            expense.expense_category_code = request.expense_category_code
+    db.commit()
+    return {"updated": len(rows)}
+
+
+@router.delete("/expenses/{expense_id}")
+def delete_expense(expense_id: int, db: Session = Depends(get_db),
+                   current_admin: Member = Depends(get_current_committee_or_admin)):
+    row = db.query(Expense).filter(Expense.id == expense_id).first()
+    if not row:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND,
+                            detail=f"Expense {expense_id} not found")
+    db.delete(row)
+    db.commit()
+    return {"message": f"Expense {expense_id} deleted"}
+
+
+def _method_from_description(description: str) -> str:
+    lowered = (description or "").lower()
+    if "zelle" in lowered:
+        return "Zelle"
+    if "venmo" in lowered:
+        return "Venmo"
+    if "check" in lowered:
+        return "Check"
+    if "ach" in lowered or "orig co" in lowered:
+        return "ACH"
+    if "atm" in lowered:
+        return "ATM"
+    return "Debit Card"
+
+
+def _parse_amount(raw) -> Optional[Decimal]:
+    try:
+        return Decimal(str(raw).replace(",", "").replace("$", "").strip())
+    except (InvalidOperation, AttributeError):
+        return None
+
+
+@router.post("/bank-import")
+def import_bank_csv(request: BankImportRequest, db: Session = Depends(get_db),
+                    current_admin: Member = Depends(get_current_committee_or_admin)):
+    """Import a Chase statement CSV (Details, Posting Date, Description,
+    Amount, Type ...). Outflows land in Expenses; inflows become income
+    rows to classify — except Zelle/Venmo credits, which already arrive
+    via the Gmail sync. Rows dedupe by a BANK| key so re-imports are safe.
+    """
+    reader = csv.reader(io.StringIO(request.csv_text))
+    all_rows = [row for row in reader if any(str(c).strip() for c in row)]
+
+    header_idx, col = None, {}
+    for i, row in enumerate(all_rows[:10]):
+        lowered = [str(c).lower().strip() for c in row]
+        if "details" in lowered and "description" in lowered:
+            header_idx = i
+            col = {
+                "details": lowered.index("details"),
+                "date": lowered.index("posting date") if "posting date" in lowered else None,
+                "desc": lowered.index("description"),
+                "amount": lowered.index("amount") if "amount" in lowered else None,
+            }
+            break
+    if header_idx is None or col.get("date") is None or col.get("amount") is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail='Could not find the Chase header row (needs "Details", '
+                   '"Posting Date", "Description" and "Amount" columns)'
+        )
+
+    stats = {"expenses_added": 0, "income_added": 0, "duplicates": 0,
+             "skipped_gmail_synced": 0, "errors": 0}
+
+    existing_expense_ids = {e.import_id for e in db.query(Expense.import_id).all()}
+
+    for row in all_rows[header_idx + 1:]:
+        try:
+            description = str(row[col["desc"]]).strip()
+            amount = _parse_amount(row[col["amount"]])
+            raw_date = str(row[col["date"]]).strip()
+            if amount is None or not raw_date:
+                continue
+            posted = None
+            for fmt in ("%m/%d/%Y", "%m/%d/%y", "%Y-%m-%d"):
+                try:
+                    posted = datetime.strptime(raw_date, fmt).date()
+                    break
+                except ValueError:
+                    continue
+            if posted is None:
+                continue
+
+            import_id = f"BANK|{posted.isoformat()}|{amount}|{description[:40]}"
+
+            if amount < 0:  # money out -> expense
+                if import_id in existing_expense_ids:
+                    stats["duplicates"] += 1
+                    continue
+                vendor = re.sub(
+                    r"^(POS PURCHASE|DEBIT CARD PURCHASE|RECURRING PAYMENT|"
+                    r"ONLINE PAYMENT|CHECKCARD)\s*", "",
+                    description, flags=re.IGNORECASE).strip()[:255] or description[:255]
+                db.add(Expense(
+                    expense_date=posted,
+                    vendor=vendor,
+                    amount=-amount,
+                    method=_method_from_description(description),
+                    bank_description=description,
+                    import_id=import_id,
+                ))
+                existing_expense_ids.add(import_id)
+                stats["expenses_added"] += 1
+            else:  # money in
+                lowered = description.lower()
+                if "zelle" in lowered or "venmo" in lowered:
+                    # These arrive with donor names via the Gmail sync
+                    stats["skipped_gmail_synced"] += 1
+                    continue
+                if db.query(Donor).filter(Donor.notes.contains(import_id)).first():
+                    stats["duplicates"] += 1
+                    continue
+                db.add(Donor(
+                    donor_id=f"BNK_{int(datetime.utcnow().timestamp() * 1000)}_{stats['income_added']}",
+                    name=description[:255],
+                    donor_type="individual",
+                    amount=amount,
+                    donation_date=posted,
+                    source=_method_from_description(description),
+                    notes=f"Bank import {import_id}",
+                    donation_event="General Support",
+                    receipt_confirmed=True,
+                    quantity=1,
+                    status="pending",
+                ))
+                stats["income_added"] += 1
+        except Exception:
+            stats["errors"] += 1
+
+    db.commit()
+    return stats
+
+
+# ---------------------------------------------------------------------------
+# Donor directory (name -> email memory)
+# ---------------------------------------------------------------------------
+
+@router.get("/directory", response_model=List[DirectoryEntryOut])
+def list_directory(db: Session = Depends(get_db), current_admin: Member = Depends(get_current_committee_or_admin)):
+    return db.query(DonorDirectoryEntry).order_by(DonorDirectoryEntry.name).all()
+
+
+@router.put("/directory", response_model=DirectoryEntryOut)
+def upsert_directory(request: DirectoryUpsertRequest, db: Session = Depends(get_db),
+                     current_admin: Member = Depends(get_current_committee_or_admin)):
+    normalized = _normalize_name(request.name)
+    row = db.query(DonorDirectoryEntry).filter(
+        DonorDirectoryEntry.name == normalized).first()
+    if row:
+        row.email = request.email
+        if request.is_insider is not None:
+            row.is_insider = request.is_insider
+    else:
+        row = DonorDirectoryEntry(name=normalized, email=request.email,
+                                  is_insider=bool(request.is_insider))
+        db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+@router.delete("/directory/{entry_id}")
+def delete_directory_entry(entry_id: int, db: Session = Depends(get_db),
+                           current_admin: Member = Depends(get_current_committee_or_admin)):
+    row = db.query(DonorDirectoryEntry).filter(DonorDirectoryEntry.id == entry_id).first()
+    if not row:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND,
+                            detail=f"Directory entry {entry_id} not found")
+    db.delete(row)
+    db.commit()
+    return {"message": f"Directory entry {entry_id} deleted"}
+
+
+def _directory_lookup(db: Session):
+    return {e.name: e.email for e in db.query(DonorDirectoryEntry).all()}
+
+
+# ---------------------------------------------------------------------------
+# Batch acknowledgments
+# ---------------------------------------------------------------------------
+
+@router.get("/ack-queue")
+def ack_queue(db: Session = Depends(get_db), current_admin: Member = Depends(get_current_committee_or_admin)):
+    """Confirmed donations without a thank-you yet, with directory emails."""
+    directory = _directory_lookup(db)
+    rows = db.query(Donor).filter(
+        Donor.income_type == "donation",
+        Donor.thank_you_sent_at.is_(None),
+    ).order_by(Donor.donation_date.desc()).all()
+    return [{
+        "donation_id": d.donation_id,
+        "name": d.name,
+        "amount": str(d.amount),
+        "donation_date": d.donation_date.isoformat() if d.donation_date else None,
+        "event_code": d.event_code,
+        "email": directory.get(_normalize_name(d.name)),
+    } for d in rows]
+
+
+def _send_ack_batch(db: Session, donation_ids: Optional[List[int]] = None):
+    """Send tiered acknowledgments (receipt attached) to every queue row
+    with a directory email. Returns per-row results; commits as it goes so
+    a failure mid-batch never loses earlier sends."""
+    from routes.donors import send_acknowledgment
+    directory = _directory_lookup(db)
+    query = db.query(Donor).filter(
+        Donor.income_type == "donation",
+        Donor.thank_you_sent_at.is_(None),
+    )
+    if donation_ids:
+        query = query.filter(Donor.donation_id.in_(donation_ids))
+    results = []
+    for donor in query.all():
+        email = directory.get(_normalize_name(donor.name))
+        if not email:
+            results.append({"donation_id": donor.donation_id, "name": donor.name,
+                            "sent": False, "reason": "no email in directory 缺邮箱"})
+            continue
+        try:
+            send_acknowledgment(db, donor, email, attach_receipt=True)
+            db.commit()
+            results.append({"donation_id": donor.donation_id, "name": donor.name,
+                            "sent": True, "email": email})
+        except HTTPException as exc:
+            db.rollback()
+            results.append({"donation_id": donor.donation_id, "name": donor.name,
+                            "sent": False, "reason": exc.detail})
+    return results
+
+
+@router.post("/send-acks")
+def send_acks(request: SendAcksRequest, db: Session = Depends(get_db),
+              current_admin: Member = Depends(get_current_committee_or_admin)):
+    results = _send_ack_batch(db, request.donation_ids)
+    return {"results": results,
+            "sent": sum(1 for r in results if r["sent"]),
+            "skipped": sum(1 for r in results if not r["sent"])}
+
+
+def run_auto_ack_batch():
+    """Weekly scheduler hook: batch-send acknowledgments when the
+    finance_auto_ack switch is on. Returns results (or None when off)."""
+    from database import SessionLocal
+    db = SessionLocal()
+    try:
+        if _get_setting(db, "finance_auto_ack") != "true":
+            return None
+        return _send_ack_batch(db)
+    finally:
+        db.close()
+
+
+# ---------------------------------------------------------------------------
+# Reports (cash basis)
+# ---------------------------------------------------------------------------
+
+def _year_of(d) -> Optional[int]:
+    return d.year if d else None
+
+
+@router.get("/reports/by-event")
+def report_by_event(year: Optional[int] = None, db: Session = Depends(get_db),
+                    current_admin: Member = Depends(get_current_committee_or_admin)):
+    """Income (by type) and expenses per event; cash basis."""
+    events = {c.code: c.name for c in db.query(FinanceCategory).filter(
+        FinanceCategory.kind == "event").all()}
+    matrix = {}
+
+    def bucket(code):
+        if code not in matrix:
+            matrix[code] = {"event_code": code,
+                            "event_name": events.get(code, f"#{code}" if code else "(unassigned 未分配)"),
+                            "donation": 0.0, "event_revenue": 0.0, "pass_through": 0.0,
+                            "income_total": 0.0, "expense_total": 0.0, "net": 0.0}
+        return matrix[code]
+
+    incomes = db.query(Donor).filter(Donor.income_type.in_(
+        ["donation", "event_revenue", "pass_through"]))
+    for d in incomes.all():
+        if year and _year_of(d.donation_date) != year:
+            continue
+        b = bucket(d.event_code)
+        amount = float(d.amount or 0)
+        b[d.income_type] += amount
+        b["income_total"] += amount
+
+    for e in db.query(Expense).all():
+        if year and _year_of(e.expense_date) != year:
+            continue
+        b = bucket(e.event_code)
+        b["expense_total"] += float(e.amount or 0)
+
+    for b in matrix.values():
+        # Pass-through money isn't the club's — exclude from net
+        b["net"] = round(b["income_total"] - b["pass_through"] - b["expense_total"], 2)
+        for key in ("donation", "event_revenue", "pass_through", "income_total", "expense_total"):
+            b[key] = round(b[key], 2)
+
+    rows = sorted(matrix.values(), key=lambda r: (r["event_code"] is None, r["event_code"] or 0))
+    totals = {k: round(sum(r[k] for r in rows), 2)
+              for k in ("donation", "event_revenue", "pass_through",
+                        "income_total", "expense_total", "net")}
+    return {"year": year, "events": rows, "totals": totals}
+
+
+@router.get("/reports/yoy")
+def report_yoy(db: Session = Depends(get_db), current_admin: Member = Depends(get_current_committee_or_admin)):
+    """Per-event income/expense/net by calendar year — the year-to-year,
+    event-to-event comparison."""
+    events = {c.code: c.name for c in db.query(FinanceCategory).filter(
+        FinanceCategory.kind == "event").all()}
+    data = {}
+
+    def cell(code, yr):
+        key = (code, yr)
+        if key not in data:
+            data[key] = {"income": 0.0, "expense": 0.0}
+        return data[key]
+
+    for d in db.query(Donor).filter(Donor.income_type.in_(
+            ["donation", "event_revenue"])).all():
+        yr = _year_of(d.donation_date)
+        if yr:
+            cell(d.event_code, yr)["income"] += float(d.amount or 0)
+    for e in db.query(Expense).all():
+        yr = _year_of(e.expense_date)
+        if yr:
+            cell(e.event_code, yr)["expense"] += float(e.amount or 0)
+
+    years = sorted({yr for (_, yr) in data})
+    rows = []
+    for code in sorted({c for (c, _) in data}, key=lambda c: (c is None, c or 0)):
+        row = {"event_code": code,
+               "event_name": events.get(code, f"#{code}" if code else "(unassigned 未分配)"),
+               "years": {}}
+        for yr in years:
+            c = data.get((code, yr), {"income": 0.0, "expense": 0.0})
+            row["years"][str(yr)] = {"income": round(c["income"], 2),
+                                     "expense": round(c["expense"], 2),
+                                     "net": round(c["income"] - c["expense"], 2)}
+        rows.append(row)
+    return {"years": [str(y) for y in years], "events": rows}
+
+
+@router.get("/reports/public-support")
+def report_public_support(db: Session = Depends(get_db),
+                          current_admin: Member = Depends(get_current_committee_or_admin)):
+    """509(a)(1) + 509(a)(2) public support tests over the first-5-fiscal-
+    year window. Management model — final numbers belong to the 990
+    preparer (same disclaimer as the club's Sheet)."""
+    org_start_raw = _get_setting(db, "finance_org_start") or "2025-01-01"
+    fye_month = int(_get_setting(db, "finance_fye_month") or 12)
+    org_start = datetime.strptime(org_start_raw, "%Y-%m-%d").date()
+
+    def fiscal_year(d: date) -> int:
+        # FY labeled by the calendar year the fiscal year ENDS in
+        return d.year if d.month <= fye_month else d.year + 1
+
+    first_fy = fiscal_year(org_start)
+    window = [first_fy + i for i in range(5)]
+
+    insiders = {e.name for e in db.query(DonorDirectoryEntry).filter(
+        DonorDirectoryEntry.is_insider == True).all()}  # noqa: E712
+
+    donors = {}
+    gross_receipts = 0.0
+    for d in db.query(Donor).filter(Donor.income_type.in_(
+            ["donation", "event_revenue"])).all():
+        if not d.donation_date:
+            continue
+        fy = fiscal_year(d.donation_date)
+        if fy not in window:
+            continue
+        amount = float(d.amount or 0)
+        if d.income_type == "event_revenue":
+            gross_receipts += amount
+            continue
+        key = _normalize_name(d.name)
+        entry = donors.setdefault(key, {"label": d.name, "total": 0.0,
+                                        "insider": key in insiders})
+        entry["total"] += amount
+
+    donor_list = list(donors.values())
+    total_contrib = sum(d["total"] for d in donor_list)
+    total_support = total_contrib + gross_receipts  # other income not tracked
+
+    # Test 1 — 509(a)(1): gross receipts excluded; per-donor 2% cap
+    ts1 = total_contrib
+    cap = 0.02 * ts1
+    ps1 = sum(min(d["total"], cap) for d in donor_list)
+    excess1 = sum(max(d["total"] - cap, 0) for d in donor_list)
+    ratio1 = (ps1 / ts1) if ts1 else 0
+
+    # Test 2 — 509(a)(2): disqualified persons excluded; gross receipts count
+    ps2, dqp_excluded, dqp_rows = 0.0, 0.0, []
+    for d in donor_list:
+        substantial = d["total"] > 5000 and d["total"] > 0.02 * total_contrib
+        if d["insider"] or substantial:
+            dqp_excluded += d["total"]
+            dqp_rows.append({"name": d["label"], "amount": round(d["total"], 2),
+                             "reason": "Insider (officer/founder/family)" if d["insider"]
+                             else "Substantial contributor (>$5,000 & >2%)"})
+        else:
+            ps2 += d["total"]
+    ps2 += gross_receipts
+    ratio2 = (ps2 / total_support) if total_support else 0
+
+    # Headroom — largest single new outside gift keeping ratios >= 1/3
+    gmax2 = max(3 * ps2 - total_support, 0)
+    gmax1 = max(ps1 / (1 / 3 - 0.02) - ts1, 0) if ts1 else 0
+
+    watch = sorted(donor_list, key=lambda d: -d["total"])[:15]
+    return {
+        "disclaimer": "Management model — final numbers belong to the 990 preparer. "
+                      "管理层模型，正式数字以报税会计师为准。",
+        "org_start": org_start_raw, "fye_month": fye_month,
+        "window_fys": window,
+        "support": {"contributions": round(total_contrib, 2),
+                    "gross_receipts": round(gross_receipts, 2),
+                    "total_support": round(total_support, 2)},
+        "test1_509a1": {"total_support": round(ts1, 2), "cap_2pct": round(cap, 2),
+                        "public_support": round(ps1, 2),
+                        "excluded_by_cap": round(excess1, 2),
+                        "ratio": round(ratio1, 4), "passes": ratio1 >= 1 / 3},
+        "test2_509a2": {"dqp_excluded": round(dqp_excluded, 2),
+                        "public_support": round(ps2, 2),
+                        "ratio": round(ratio2, 4), "passes": ratio2 > 1 / 3,
+                        "dqp_rows": dqp_rows},
+        "headroom": {"max_gift_a1": round(gmax1, 2), "max_gift_a2": round(gmax2, 2)},
+        "watch_list": [{"name": d["label"], "total": round(d["total"], 2),
+                        "insider": d["insider"]} for d in watch],
+    }
+
+
+@router.get("/reports/by-event/export")
+def export_by_event(year: Optional[int] = None, db: Session = Depends(get_db),
+                    current_admin: Member = Depends(get_current_committee_or_admin)):
+    report = report_by_event(year=year, db=db, current_admin=current_admin)
+    buffer = io.StringIO()
+    writer = csv.writer(buffer)
+    writer.writerow(["Event", "Donation", "Event Revenue", "Pass-through",
+                     "Income Total", "Expenses", "Net"])
+    for row in report["events"]:
+        writer.writerow([row["event_name"], row["donation"], row["event_revenue"],
+                         row["pass_through"], row["income_total"],
+                         row["expense_total"], row["net"]])
+    t = report["totals"]
+    writer.writerow(["TOTAL", t["donation"], t["event_revenue"], t["pass_through"],
+                     t["income_total"], t["expense_total"], t["net"]])
+    filename = f"newbee-finance-by-event{'-' + str(year) if year else ''}.csv"
+    return Response(content=buffer.getvalue(), media_type="text/csv",
+                    headers={"Content-Disposition": f'attachment; filename="{filename}"'})
+
+
+# ---------------------------------------------------------------------------
+# Year-end donor statements
+# ---------------------------------------------------------------------------
+
+def _year_end_data(db: Session, year: int):
+    directory = _directory_lookup(db)
+    per_donor = {}
+    for d in db.query(Donor).filter(Donor.income_type == "donation").all():
+        if not d.donation_date or d.donation_date.year != year:
+            continue
+        key = _normalize_name(d.name)
+        entry = per_donor.setdefault(key, {"name": d.name, "email": directory.get(key),
+                                           "count": 0, "total": 0.0, "items": []})
+        entry["count"] += 1
+        entry["total"] += float(d.amount or 0)
+        entry["items"].append({
+            "date": d.donation_date.isoformat(),
+            "amount": float(d.amount or 0),
+            "method": re.sub(r"\s*\(.*\)\s*$", "", d.source or "").strip() or "—",
+        })
+    for entry in per_donor.values():
+        entry["total"] = round(entry["total"], 2)
+        entry["items"].sort(key=lambda i: i["date"])
+    return sorted(per_donor.values(), key=lambda e: -e["total"])
+
+
+@router.get("/year-end/preview")
+def year_end_preview(year: int, db: Session = Depends(get_db),
+                     current_admin: Member = Depends(get_current_committee_or_admin)):
+    sent_raw = _get_setting(db, f"finance_year_end_sent_{year}")
+    sent = json.loads(sent_raw) if sent_raw else {}
+    donors = _year_end_data(db, year)
+    for d in donors:
+        d["sent_at"] = sent.get(_normalize_name(d["name"]))
+    return {"year": year, "donors": donors,
+            "total": round(sum(d["total"] for d in donors), 2)}
+
+
+def _year_end_letter(name: str, year: int, items, total: float, count: int):
+    from routes.donors import RECEIPT_ORG, _text_to_html
+    org = RECEIPT_ORG
+    detail = "\n".join(
+        f"    {i['date']}  ${i['amount']:,.2f}  ({i['method']})" for i in items)
+    subject = f"{org['name']} — Annual Donation Summary, Tax Year {year}"
+    body_text = (
+        f"Dear {name},\n\n"
+        f"Thank you for supporting {org['name']} throughout {year}. Below is a "
+        "summary of your contributions for the tax year, provided for your records.\n\n"
+        f"ANNUAL DONATION SUMMARY — TAX YEAR {year}\n"
+        f"  Organization: {org['name']} (EIN: {org['ein']})\n"
+        f"  Number of donations: {count}\n\n"
+        f"  Itemized contributions:\n{detail}\n\n"
+        f"  TOTAL: ${total:,.2f}\n\n"
+        f"{org['name']} is a tax-exempt organization described in Section 501(c)(3) "
+        "of the Internal Revenue Code. Contributions are tax-deductible to the "
+        "extent allowed by law.\n\n"
+        "No goods or services were provided in exchange for these contributions.\n\n"
+        "Please retain this statement for your tax records. Thank you for being "
+        f"part of our running community — we look forward to seeing you on the "
+        f"road in {year + 1}!\n\n"
+        f"Sincerely,\n{org['name']}\n{org['contact_email']}"
+    )
+    return subject, _text_to_html(body_text), body_text
+
+
+@router.post("/year-end/send")
+def year_end_send(request: YearEndSendRequest, db: Session = Depends(get_db),
+                  current_admin: Member = Depends(get_current_committee_or_admin)):
+    from email_service import EmailService
+    key = f"finance_year_end_sent_{request.year}"
+    sent_raw = _get_setting(db, key)
+    sent = json.loads(sent_raw) if sent_raw else {}
+
+    wanted = {_normalize_name(n) for n in request.names} if request.names else None
+    results = []
+    for entry in _year_end_data(db, request.year):
+        normalized = _normalize_name(entry["name"])
+        if wanted is not None and normalized not in wanted:
+            continue
+        if normalized in sent:
+            results.append({"name": entry["name"], "sent": False,
+                            "reason": f"already sent {sent[normalized]}"})
+            continue
+        if not entry["email"]:
+            results.append({"name": entry["name"], "sent": False,
+                            "reason": "no email in directory 缺邮箱"})
+            continue
+        subject, body_html, body_text = _year_end_letter(
+            entry["name"], request.year, entry["items"], entry["total"], entry["count"])
+        if EmailService.send_email(entry["email"], subject, body_html, body_text):
+            sent[normalized] = datetime.utcnow().isoformat()
+            results.append({"name": entry["name"], "sent": True, "email": entry["email"]})
+        else:
+            results.append({"name": entry["name"], "sent": False,
+                            "reason": "email send failed"})
+
+    _put_setting(db, key, json.dumps(sent), label=f"Year-end sent {request.year}")
+    db.commit()
+    return {"results": results,
+            "sent": sum(1 for r in results if r["sent"]),
+            "skipped": sum(1 for r in results if not r["sent"])}
+
+
+# ---------------------------------------------------------------------------
+# Settings
+# ---------------------------------------------------------------------------
+
+@router.get("/settings")
+def get_finance_settings(db: Session = Depends(get_db),
+                         current_admin: Member = Depends(get_current_committee_or_admin)):
+    return {
+        "auto_ack_enabled": _get_setting(db, "finance_auto_ack") == "true",
+        "org_start": _get_setting(db, "finance_org_start") or "2025-01-01",
+        "fye_month": int(_get_setting(db, "finance_fye_month") or 12),
+    }
+
+
+@router.put("/settings")
+def update_finance_settings(request: FinanceSettingsUpdate, db: Session = Depends(get_db),
+                            current_admin: Member = Depends(get_current_committee_or_admin)):
+    if request.auto_ack_enabled is not None:
+        _put_setting(db, "finance_auto_ack",
+                     "true" if request.auto_ack_enabled else "false",
+                     label="Auto-send acknowledgments weekly")
+    if request.org_start is not None:
+        datetime.strptime(request.org_start, "%Y-%m-%d")  # validate
+        _put_setting(db, "finance_org_start", request.org_start)
+    if request.fye_month is not None:
+        _put_setting(db, "finance_fye_month", str(request.fye_month))
+    db.commit()
+    return get_finance_settings(db=db, current_admin=current_admin)

--- a/ProjectCode/server/scheduler.py
+++ b/ProjectCode/server/scheduler.py
@@ -401,6 +401,31 @@ def sync_zelle_donations_job():
         logger.error(f"Donation sync failed: {e}")
 
 
+def auto_ack_job():
+    """
+    Weekly job: batch-send donation acknowledgments when the committee has
+    switched on finance auto-send (finance_auto_ack site setting). Uses the
+    same tiered templates + receipts + donor directory as the manual queue.
+    """
+    logger.info("Starting weekly auto-acknowledgment job...")
+    try:
+        from routes.finance import run_auto_ack_batch
+    except Exception as e:
+        logger.error(f"Auto-ack: failed to import finance module: {e}")
+        return
+
+    try:
+        results = run_auto_ack_batch()
+        if results is None:
+            logger.info("Auto-ack: switch is off, nothing sent.")
+            return
+        sent = sum(1 for r in results if r["sent"])
+        skipped = len(results) - sent
+        logger.info(f"Auto-ack complete: {sent} sent, {skipped} skipped.")
+    except Exception as e:
+        logger.error(f"Auto-ack failed: {e}")
+
+
 def start_scheduler():
     """
     Start the APScheduler with configured jobs.
@@ -450,12 +475,23 @@ def start_scheduler():
         max_instances=1
     )
 
+    # Weekly auto-acknowledgment batch — Monday 5 AM UTC, after the Zelle
+    # sync has landed the week's donations. No-op unless the committee has
+    # enabled the finance_auto_ack switch.
+    scheduler.add_job(
+        auto_ack_job,
+        CronTrigger(day_of_week='mon', hour=5, minute=0),
+        id='auto_ack_donations',
+        replace_existing=True,
+        max_instances=1
+    )
+
     # Start the scheduler
     scheduler.start()
     logger.info(
         "Scheduler started - recurring events job (daily 2 AM), past events "
         "transition (weekly Mon 3 AM), NYRR results sync (weekly Mon 4 AM UTC), "
-        "Zelle donation sync (weekly Mon 4:30 AM UTC)"
+        "Zelle donation sync (weekly Mon 4:30 AM UTC), auto-ack (weekly Mon 5 AM UTC)"
     )
 
     # Run transition immediately on startup to catch any stale events

--- a/ProjectCode/server/sync_zelle_donations.py
+++ b/ProjectCode/server/sync_zelle_donations.py
@@ -535,6 +535,14 @@ def _process_provider_emails(mail, email_ids, parser, provider, session, stats,
             matched = auto_ignore_keyword(parsed["memo"])
             if matched:
                 record["status"] = "dismissed"
+                # Two-layer books: carpool money is pass-through, gear
+                # payments are event revenue
+                lowered = matched.lower()
+                if lowered in ('拼车', 'carpool', '车费', '🚗'):
+                    record["income_type"] = "pass_through"
+                else:
+                    record["income_type"] = "event_revenue"
+                record["event_code"] = 1001
                 record["notes"] += f" · Auto-ignored 自动忽略: memo matched '{matched}'"
 
             if dry_run:

--- a/ProjectCode/server/tests/test_finance.py
+++ b/ProjectCode/server/tests/test_finance.py
@@ -1,0 +1,519 @@
+"""Tests for the finance module (Books Grid): categories, two-layer income
+classification, expenses + Chase CSV import, donor directory, batch
+acknowledgments, reports, year-end statements, settings."""
+import json
+from datetime import date, datetime
+
+from database import Donor, DonorDirectoryEntry, Expense, FinanceCategory, SiteSetting
+from tests.conftest import auth
+
+
+def seed_categories(db_session):
+    for kind, code, name in [
+        ("event", 1001, "General"), ("event", 1003, "NewBee Anniversary"),
+        ("event", 1004, "Bear Mt. Run"),
+        ("income_type", 2001, "Donation"),
+        ("expense", 5001, "Event Food & Drink"), ("expense", 5002, "Event Supplies"),
+    ]:
+        db_session.add(FinanceCategory(kind=kind, code=code, name=name))
+    db_session.commit()
+
+
+def seed_income(db_session, donor_id="D1", **overrides):
+    defaults = dict(
+        donor_id=donor_id, name=f"Donor {donor_id}", donor_type="individual",
+        amount=100, donation_date=date(2026, 6, 1), status="confirmed",
+        income_type="donation", event_code=1001, source="Zelle (X)",
+        donation_event="General Support",
+    )
+    defaults.update(overrides)
+    donor = Donor(**defaults)
+    db_session.add(donor)
+    db_session.commit()
+    db_session.refresh(donor)
+    return donor
+
+
+def seed_expense(db_session, **overrides):
+    defaults = dict(expense_date=date(2026, 6, 2), vendor="COSTCO", amount=100,
+                    method="Debit Card", bank_description="COSTCO WHSE",
+                    event_code=1003, expense_category_code=5001,
+                    import_id=f"BANK|test|{overrides.get('vendor','COSTCO')}|{overrides.get('amount',100)}")
+    defaults.update(overrides)
+    expense = Expense(**defaults)
+    db_session.add(expense)
+    db_session.commit()
+    db_session.refresh(expense)
+    return expense
+
+
+# ---------------------------------------------------------------- categories
+
+def test_categories_require_auth(client):
+    assert client.get("/api/finance/categories").status_code == 401
+
+
+def test_categories_grouped_by_kind(client, db_session, committee_member):
+    seed_categories(db_session)
+    body = client.get("/api/finance/categories", headers=auth(committee_member)).json()
+    assert [c["code"] for c in body["events"]] == [1001, 1003, 1004]
+    assert body["income_types"][0]["name"] == "Donation"
+    assert len(body["expenses"]) == 2
+
+
+def test_create_category_auto_assigns_next_code(client, db_session, committee_member):
+    seed_categories(db_session)
+    resp = client.post("/api/finance/categories",
+                       json={"kind": "event", "name": "Queens 10K"},
+                       headers=auth(committee_member))
+    assert resp.status_code == 200
+    assert resp.json()["code"] == 1005  # after 1004
+
+
+def test_create_category_first_of_kind_starts_range(client, committee_member):
+    resp = client.post("/api/finance/categories",
+                       json={"kind": "expense", "name": "Space Rental"},
+                       headers=auth(committee_member))
+    assert resp.json()["code"] == 5001
+
+
+def test_create_category_duplicate_code_400(client, db_session, committee_member):
+    seed_categories(db_session)
+    resp = client.post("/api/finance/categories",
+                       json={"kind": "event", "name": "Dup", "code": 1001},
+                       headers=auth(committee_member))
+    assert resp.status_code == 400
+
+
+def test_update_category_and_404(client, db_session, committee_member):
+    seed_categories(db_session)
+    row = db_session.query(FinanceCategory).filter_by(code=1004).first()
+    resp = client.put(f"/api/finance/categories/{row.id}",
+                      json={"name": "Bear Mountain Run"},
+                      headers=auth(committee_member))
+    assert resp.json()["name"] == "Bear Mountain Run"
+    assert client.put("/api/finance/categories/999", json={"name": "x"},
+                      headers=auth(committee_member)).status_code == 404
+
+
+# ---------------------------------------------------------------- income
+
+def test_income_lists_unclassified_first(client, db_session, committee_member):
+    seed_income(db_session, "C1")
+    seed_income(db_session, "U1", income_type=None, status="pending",
+                donation_date=date(2026, 7, 1))
+    rows = client.get("/api/finance/income", headers=auth(committee_member)).json()
+    assert rows[0]["donor_id"] == "U1"
+    assert rows[0]["income_type"] is None
+    assert rows[1]["income_type"] == "donation"
+
+
+def test_classify_income_bulk_sets_type_event_and_status(client, db_session, committee_member):
+    a = seed_income(db_session, "A", income_type=None, status="pending")
+    b = seed_income(db_session, "B", income_type=None, status="pending")
+    resp = client.post("/api/finance/income/classify", json={
+        "donation_ids": [a.donation_id, b.donation_id],
+        "income_type": "pass_through", "event_code": 1004,
+    }, headers=auth(committee_member))
+    assert resp.json() == {"updated": 2}
+    db_session.expire_all()
+    for row in (a, b):
+        db_session.refresh(row)
+        assert row.income_type == "pass_through"
+        assert row.event_code == 1004
+        assert row.status == "dismissed"  # not public
+
+
+def test_classify_income_donation_publishes(client, db_session, committee_member):
+    a = seed_income(db_session, "A", income_type=None, status="pending")
+    client.post("/api/finance/income/classify", json={
+        "donation_ids": [a.donation_id], "income_type": "donation",
+    }, headers=auth(committee_member))
+    public = client.get("/api/donors/public").json()
+    assert [d["donor_id"] for d in public] == ["A"]
+    db_session.refresh(a)
+    assert a.event_code == 1001  # defaulted to General
+
+
+def test_classify_income_unknown_id_404(client, committee_member):
+    resp = client.post("/api/finance/income/classify", json={
+        "donation_ids": [999], "income_type": "mistake",
+    }, headers=auth(committee_member))
+    assert resp.status_code == 404
+
+
+def test_manual_income_row(client, committee_member):
+    resp = client.post("/api/finance/income/manual", json={
+        "name": "Cash Jar", "amount": "88.00", "donation_date": "2026-07-01",
+        "method": "Cash", "memo": "gala box", "income_type": "event_revenue",
+        "event_code": 1003,
+    }, headers=auth(committee_member))
+    body = resp.json()
+    assert body["income_type"] == "event_revenue"
+    assert body["status"] == "dismissed"
+    assert body["donor_id"].startswith("MAN_")
+
+
+def test_legacy_ledger_actions_sync_income_type(client, db_session, committee_member):
+    """The old ledger's approve/ignore/revert keep the finance books in sync."""
+    row = seed_income(db_session, "P1", income_type=None, status="pending")
+
+    client.post(f"/api/donors/donations/{row.donation_id}/approve", json={},
+                headers=auth(committee_member))
+    db_session.refresh(row)
+    assert row.income_type == "donation"
+    assert row.event_code == 1001
+
+    client.post(f"/api/donors/donations/{row.donation_id}/dismiss",
+                headers=auth(committee_member))
+    db_session.refresh(row)
+    assert row.income_type == "mistake"
+
+    client.post(f"/api/donors/donations/{row.donation_id}/revert",
+                headers=auth(committee_member))
+    db_session.refresh(row)
+    assert row.income_type is None  # back to unclassified
+
+
+def test_legacy_dismiss_preserves_finance_classification(client, db_session, committee_member):
+    row = seed_income(db_session, "P1", income_type="pass_through", status="confirmed")
+    client.post(f"/api/donors/donations/{row.donation_id}/dismiss",
+                headers=auth(committee_member))
+    db_session.refresh(row)
+    assert row.income_type == "pass_through"  # not clobbered to mistake
+
+
+# ---------------------------------------------------------------- bank import
+
+CHASE_CSV = """Details,Posting Date,Description,Amount,Type,Balance,Check or Slip #
+DEBIT,06/02/2026,COSTCO WHSE #0334,-412.88,DEBIT_CARD,,
+DEBIT,05/28/2026,POS PURCHASE PARTY CITY 1099,-86.20,DEBIT_CARD,,
+CREDIT,06/04/2026,Zelle payment from LI CHEN 12345,200.00,QUICKPAY_CREDIT,,
+CREDIT,06/05/2026,DEPOSIT CHECK 1042,300.00,DEPOSIT,,
+"""
+
+
+def test_bank_import_splits_flows(client, db_session, committee_member):
+    resp = client.post("/api/finance/bank-import", json={"csv_text": CHASE_CSV},
+                       headers=auth(committee_member))
+    stats = resp.json()
+    assert stats == {"expenses_added": 2, "income_added": 1, "duplicates": 0,
+                     "skipped_gmail_synced": 1, "errors": 0}
+
+    expenses = db_session.query(Expense).order_by(Expense.expense_date).all()
+    assert [e.vendor for e in expenses] == ["PARTY CITY 1099", "COSTCO WHSE #0334"]
+    assert float(expenses[1].amount) == 412.88
+    assert expenses[1].event_code is None  # unclassified
+
+    income = db_session.query(Donor).one()
+    assert income.status == "pending"
+    assert income.income_type is None
+    assert "BANK|2026-06-05" in income.notes
+    assert income.source == "Check"
+
+
+def test_bank_import_is_idempotent(client, committee_member):
+    client.post("/api/finance/bank-import", json={"csv_text": CHASE_CSV},
+                headers=auth(committee_member))
+    stats = client.post("/api/finance/bank-import", json={"csv_text": CHASE_CSV},
+                        headers=auth(committee_member)).json()
+    assert stats["expenses_added"] == 0
+    assert stats["income_added"] == 0
+    assert stats["duplicates"] == 3
+
+
+def test_bank_import_bad_header_400(client, committee_member):
+    resp = client.post("/api/finance/bank-import",
+                       json={"csv_text": "a,b,c\n1,2,3\n"},
+                       headers=auth(committee_member))
+    assert resp.status_code == 400
+
+
+def test_classify_and_delete_expense(client, db_session, committee_member):
+    expense = seed_expense(db_session, event_code=None, expense_category_code=None)
+    resp = client.post("/api/finance/expenses/classify", json={
+        "expense_ids": [expense.id], "event_code": 1003,
+        "expense_category_code": 5002,
+    }, headers=auth(committee_member))
+    assert resp.json() == {"updated": 1}
+    db_session.refresh(expense)
+    assert (expense.event_code, expense.expense_category_code) == (1003, 5002)
+
+    assert client.delete(f"/api/finance/expenses/{expense.id}",
+                         headers=auth(committee_member)).status_code == 200
+    assert client.delete("/api/finance/expenses/999",
+                         headers=auth(committee_member)).status_code == 404
+
+
+# ---------------------------------------------------------------- directory
+
+def test_directory_upsert_normalizes_and_updates(client, db_session, committee_member):
+    resp = client.put("/api/finance/directory",
+                      json={"name": "  Yue  Ma ", "email": "yue@example.com"},
+                      headers=auth(committee_member))
+    assert resp.json()["name"] == "yue ma"
+
+    resp = client.put("/api/finance/directory",
+                      json={"name": "YUE MA", "email": "new@example.com",
+                            "is_insider": True},
+                      headers=auth(committee_member))
+    assert resp.json()["email"] == "new@example.com"
+    assert resp.json()["is_insider"] is True
+    assert db_session.query(DonorDirectoryEntry).count() == 1
+
+    entries = client.get("/api/finance/directory", headers=auth(committee_member)).json()
+    assert len(entries) == 1
+    assert client.delete(f"/api/finance/directory/{entries[0]['id']}",
+                         headers=auth(committee_member)).status_code == 200
+    assert client.delete("/api/finance/directory/999",
+                         headers=auth(committee_member)).status_code == 404
+
+
+# ---------------------------------------------------------------- batch acks
+
+def _fake_email(monkeypatch, outcomes=True):
+    import email_service
+    sent = []
+
+    def fake_send(to_email, subject, body_html, body_text=None, attachments=None):
+        sent.append({"to": to_email, "subject": subject, "text": body_text,
+                     "attachments": attachments})
+        return outcomes
+
+    monkeypatch.setattr(email_service.EmailService, "send_email",
+                        staticmethod(fake_send))
+    return sent
+
+
+def test_ack_queue_lists_unthanked_with_directory_emails(client, db_session, committee_member):
+    seed_income(db_session, "A", name="Yue Ma")
+    seed_income(db_session, "B", name="No Email",
+                donation_date=date(2026, 5, 1))
+    seed_income(db_session, "C", name="Thanked",
+                thank_you_sent_at=datetime(2026, 7, 1))
+    seed_income(db_session, "R", name="Revenue", income_type="event_revenue")
+    db_session.add(DonorDirectoryEntry(name="yue ma", email="yue@example.com"))
+    db_session.commit()
+
+    queue = client.get("/api/finance/ack-queue", headers=auth(committee_member)).json()
+    assert [q["name"] for q in queue] == ["Yue Ma", "No Email"]
+    assert queue[0]["email"] == "yue@example.com"
+    assert queue[1]["email"] is None
+
+
+def test_send_acks_batch_sends_and_skips(client, db_session, committee_member, monkeypatch):
+    sent = _fake_email(monkeypatch)
+    a = seed_income(db_session, "A", name="Yue Ma", amount=500)
+    b = seed_income(db_session, "B", name="No Email")
+    db_session.add(DonorDirectoryEntry(name="yue ma", email="yue@example.com"))
+    db_session.commit()
+
+    resp = client.post("/api/finance/send-acks", json={},
+                       headers=auth(committee_member)).json()
+    assert resp["sent"] == 1 and resp["skipped"] == 1
+    assert sent[0]["to"] == "yue@example.com"
+    assert sent[0]["attachments"] is not None  # receipt attached
+
+    db_session.expire_all()
+    db_session.refresh(a)
+    db_session.refresh(b)
+    assert a.thank_you_sent_at is not None
+    assert "Thank-you email" in a.notes
+    assert b.thank_you_sent_at is None
+
+
+def test_send_acks_subset_by_ids(client, db_session, committee_member, monkeypatch):
+    _fake_email(monkeypatch)
+    a = seed_income(db_session, "A", name="Yue Ma")
+    seed_income(db_session, "B2", name="Yue Ma",
+                donation_date=date(2026, 5, 1))
+    db_session.add(DonorDirectoryEntry(name="yue ma", email="yue@example.com"))
+    db_session.commit()
+
+    resp = client.post("/api/finance/send-acks",
+                       json={"donation_ids": [a.donation_id]},
+                       headers=auth(committee_member)).json()
+    assert resp["sent"] == 1
+
+
+def test_auto_ack_batch_respects_switch(client, db_session, committee_member, monkeypatch):
+    from sqlalchemy.orm import sessionmaker
+    import database as database_mod
+    from routes.finance import run_auto_ack_batch
+    monkeypatch.setattr(database_mod, "SessionLocal",
+                        sessionmaker(bind=db_session.get_bind()))
+    _fake_email(monkeypatch)
+    seed_income(db_session, "A", name="Yue Ma")
+    db_session.add(DonorDirectoryEntry(name="yue ma", email="yue@example.com"))
+    db_session.commit()
+
+    assert run_auto_ack_batch() is None  # switch off
+
+    client.put("/api/finance/settings", json={"auto_ack_enabled": True},
+               headers=auth(committee_member))
+    results = run_auto_ack_batch()
+    assert results is not None
+    assert sum(1 for r in results if r["sent"]) == 1
+
+
+# ---------------------------------------------------------------- reports
+
+def test_report_by_event_matrix(client, db_session, committee_member):
+    seed_categories(db_session)
+    seed_income(db_session, "D1", amount=200, event_code=1003)
+    seed_income(db_session, "R1", amount=100, income_type="event_revenue",
+                status="dismissed", event_code=1003)
+    seed_income(db_session, "P1", amount=50, income_type="pass_through",
+                status="dismissed", event_code=1004)
+    seed_income(db_session, "M1", amount=999, income_type="mistake",
+                status="dismissed", event_code=1004)  # excluded entirely
+    seed_expense(db_session, amount=120, event_code=1003)
+
+    report = client.get("/api/finance/reports/by-event",
+                        headers=auth(committee_member)).json()
+    by_code = {r["event_code"]: r for r in report["events"]}
+    anniversary = by_code[1003]
+    assert anniversary["donation"] == 200.0
+    assert anniversary["event_revenue"] == 100.0
+    assert anniversary["income_total"] == 300.0
+    assert anniversary["expense_total"] == 120.0
+    assert anniversary["net"] == 180.0
+    # Pass-through is not the club's money: excluded from net
+    bear = by_code[1004]
+    assert bear["pass_through"] == 50.0
+    assert bear["net"] == 0.0
+    assert report["totals"]["income_total"] == 350.0
+
+
+def test_report_by_event_year_filter_and_export(client, db_session, committee_member):
+    seed_categories(db_session)
+    seed_income(db_session, "D1", amount=200, donation_date=date(2025, 6, 1))
+    seed_income(db_session, "D2", amount=300, donation_date=date(2026, 6, 1))
+    report = client.get("/api/finance/reports/by-event", params={"year": 2025},
+                        headers=auth(committee_member)).json()
+    assert report["totals"]["donation"] == 200.0
+
+    export = client.get("/api/finance/reports/by-event/export",
+                        headers=auth(committee_member))
+    assert export.headers["content-type"].startswith("text/csv")
+    assert "TOTAL" in export.text
+
+
+def test_report_yoy(client, db_session, committee_member):
+    seed_categories(db_session)
+    seed_income(db_session, "D1", amount=200, donation_date=date(2025, 6, 1),
+                event_code=1004)
+    seed_income(db_session, "D2", amount=300, donation_date=date(2026, 6, 1),
+                event_code=1004)
+    seed_expense(db_session, amount=100, expense_date=date(2026, 6, 2),
+                 event_code=1004)
+
+    report = client.get("/api/finance/reports/yoy", headers=auth(committee_member)).json()
+    assert report["years"] == ["2025", "2026"]
+    bear = next(r for r in report["events"] if r["event_code"] == 1004)
+    assert bear["years"]["2025"] == {"income": 200.0, "expense": 0.0, "net": 200.0}
+    assert bear["years"]["2026"] == {"income": 300.0, "expense": 100.0, "net": 200.0}
+
+
+def test_public_support_test(client, db_session, committee_member):
+    # Window: org start 2025 → FY2025-2029 (calendar years)
+    client.put("/api/finance/settings", json={"org_start": "2025-01-01", "fye_month": 12},
+               headers=auth(committee_member))
+    # Big donor exceeding 2% cap and the $5k substantial threshold
+    seed_income(db_session, "BIG", name="Big Donor", amount=6000,
+                donation_date=date(2026, 6, 1))
+    seed_income(db_session, "S1", name="Small One", amount=100,
+                donation_date=date(2026, 6, 2))
+    seed_income(db_session, "R1", name="Ticket Buyer", amount=400,
+                income_type="event_revenue", status="dismissed",
+                donation_date=date(2026, 6, 3))
+    # Insider excluded under (a)(2)
+    seed_income(db_session, "INS", name="Insider Ann", amount=500,
+                donation_date=date(2026, 6, 4))
+    db_session.add(DonorDirectoryEntry(name="insider ann", email="a@example.com",
+                                       is_insider=True))
+    db_session.commit()
+
+    report = client.get("/api/finance/reports/public-support",
+                        headers=auth(committee_member)).json()
+    assert report["window_fys"] == [2025, 2026, 2027, 2028, 2029]
+    support = report["support"]
+    assert support["contributions"] == 6600.0
+    assert support["gross_receipts"] == 400.0
+    assert support["total_support"] == 7000.0
+
+    t1 = report["test1_509a1"]
+    assert t1["cap_2pct"] == 132.0  # 2% of 6600
+    # Big donor capped at 132, small 100, insider capped at 132
+    assert t1["public_support"] == 364.0
+
+    t2 = report["test2_509a2"]
+    # Big donor is a substantial contributor; insider excluded; small + GR count
+    assert t2["dqp_excluded"] == 6500.0
+    assert t2["public_support"] == 500.0
+    reasons = {r["name"]: r["reason"] for r in t2["dqp_rows"]}
+    assert "Substantial contributor" in reasons["Big Donor"]
+    assert "Insider" in reasons["Insider Ann"]
+
+
+# ---------------------------------------------------------------- year-end
+
+def test_year_end_preview_groups_by_donor(client, db_session, committee_member):
+    seed_income(db_session, "A1", name="Yue Ma", amount=500,
+                donation_date=date(2026, 6, 4))
+    seed_income(db_session, "A2", name="Yue Ma", amount=30,
+                donation_date=date(2026, 2, 1), source="Venmo (Yue Ma)")
+    seed_income(db_session, "B1", name="Other", amount=10,
+                donation_date=date(2025, 6, 1))  # different year
+    db_session.add(DonorDirectoryEntry(name="yue ma", email="yue@example.com"))
+    db_session.commit()
+
+    preview = client.get("/api/finance/year-end/preview", params={"year": 2026},
+                         headers=auth(committee_member)).json()
+    assert preview["total"] == 530.0
+    donor = preview["donors"][0]
+    assert donor["name"] == "Yue Ma"
+    assert donor["count"] == 2
+    assert donor["email"] == "yue@example.com"
+    assert donor["items"][0]["date"] == "2026-02-01"
+    assert donor["sent_at"] is None
+
+
+def test_year_end_send_marks_and_skips_resend(client, db_session, committee_member, monkeypatch):
+    sent = _fake_email(monkeypatch)
+    seed_income(db_session, "A1", name="Yue Ma", amount=500,
+                donation_date=date(2026, 6, 4))
+    seed_income(db_session, "B1", name="No Email", amount=10,
+                donation_date=date(2026, 5, 1))
+    db_session.add(DonorDirectoryEntry(name="yue ma", email="yue@example.com"))
+    db_session.commit()
+
+    first = client.post("/api/finance/year-end/send", json={"year": 2026},
+                        headers=auth(committee_member)).json()
+    assert first["sent"] == 1 and first["skipped"] == 1
+    assert "ANNUAL DONATION SUMMARY — TAX YEAR 2026" in sent[0]["text"]
+    assert "$500.00" in sent[0]["text"]
+
+    second = client.post("/api/finance/year-end/send", json={"year": 2026},
+                         headers=auth(committee_member)).json()
+    assert second["sent"] == 0  # already-sent guard
+    assert any("already sent" in r.get("reason", "") for r in second["results"])
+
+    preview = client.get("/api/finance/year-end/preview", params={"year": 2026},
+                         headers=auth(committee_member)).json()
+    assert preview["donors"][0]["sent_at"] is not None
+
+
+# ---------------------------------------------------------------- settings
+
+def test_finance_settings_roundtrip(client, committee_member):
+    defaults = client.get("/api/finance/settings", headers=auth(committee_member)).json()
+    assert defaults == {"auto_ack_enabled": False, "org_start": "2025-01-01",
+                        "fye_month": 12}
+
+    updated = client.put("/api/finance/settings",
+                         json={"auto_ack_enabled": True, "org_start": "2025-04-01",
+                               "fye_month": 11},
+                         headers=auth(committee_member)).json()
+    assert updated == {"auto_ack_enabled": True, "org_start": "2025-04-01",
+                       "fye_month": 11}

--- a/ProjectCode/server/tests/test_scheduler.py
+++ b/ProjectCode/server/tests/test_scheduler.py
@@ -416,8 +416,8 @@ def test_start_scheduler_registers_jobs_and_runs_transition(monkeypatch):
 
     start_scheduler()
 
-    assert fake.add_job.call_count == 4
-    (recurring_call, transition_call, nyrr_call, zelle_call) = fake.add_job.call_args_list
+    assert fake.add_job.call_count == 5
+    (recurring_call, transition_call, nyrr_call, zelle_call, ack_call) = fake.add_job.call_args_list
 
     assert recurring_call.args[0] is scheduler_mod.generate_recurring_events
     assert recurring_call.kwargs['id'] == 'generate_recurring_events'
@@ -438,6 +438,11 @@ def test_start_scheduler_registers_jobs_and_runs_transition(monkeypatch):
     assert "hour='4'" in str(nyrr_call.args[1])
 
     assert zelle_call.args[0] is scheduler_mod.sync_zelle_donations_job
+    assert ack_call.args[0] is scheduler_mod.auto_ack_job
+    assert ack_call.kwargs['id'] == 'auto_ack_donations'
+    assert isinstance(ack_call.args[1], CronTrigger)
+    assert "day_of_week='mon'" in str(ack_call.args[1])
+    assert "hour='5'" in str(ack_call.args[1])
     assert zelle_call.kwargs['id'] == 'sync_zelle_donations'
     assert zelle_call.kwargs['max_instances'] == 1
     assert isinstance(zelle_call.args[1], CronTrigger)

--- a/ProjectCode/server/tests/test_zelle_sync.py
+++ b/ProjectCode/server/tests/test_zelle_sync.py
@@ -348,8 +348,10 @@ def test_sync_auto_ignores_carpool_payments(db_session, monkeypatch):
 
     donors = {d.name: d for d in db_session.query(Donor).all()}
     assert donors['Ryan Young'].status == 'dismissed'
+    assert donors['Ryan Young'].income_type == 'pass_through'
     assert "Auto-ignored 自动忽略: memo matched '拼车'" in donors['Ryan Young'].notes
     assert donors['Yue Ma'].status == 'confirmed'
+    assert donors['Yue Ma'].income_type is None
     assert 'Auto-ignored' not in donors['Yue Ma'].notes
 
 

--- a/design-mockups/donate-a-hero-card.html
+++ b/design-mockups/donate-a-hero-card.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="zh">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Donate Option A — Hero Donation Card · NewBee</title>
+<link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;600;700&family=Noto+Sans+SC:wght@400;500;700&display=swap" rel="stylesheet">
+<style>
+  :root{--orange:#FFA500;--orange-dark:#F29400;--orange-bg:#FFF6E8;--ink:#212121;--muted:#757575;--line:#EEE7DC;--green:#2e7d32;--zelle:#6d1ed4;--venmo:#008CFF}
+  *{margin:0;padding:0;box-sizing:border-box}
+  body{font-family:Roboto,'Noto Sans SC',sans-serif;background:#fff;color:var(--ink);max-width:1180px;margin:0 auto;padding:32px 24px 80px}
+  .optlabel{background:var(--orange-bg);border:1px dashed var(--orange);border-radius:10px;padding:10px 16px;font-size:12.5px;color:var(--muted);margin-bottom:20px}
+  .optlabel b{color:var(--orange-dark)}
+  .pagehead{display:flex;align-items:baseline;gap:10px;margin-bottom:16px}
+  .pagehead h2{font-size:20px;font-weight:700}
+  .pagehead span{font-size:14px;color:var(--muted)}
+
+  /* HERO DONATION CARD */
+  .hero{border:2px solid var(--orange);border-radius:16px;overflow:hidden;box-shadow:0 8px 32px rgba(255,165,0,.18);margin-bottom:26px}
+  .herotop{background:linear-gradient(135deg,#FFF6E8, #fff);padding:22px 28px 16px;text-align:center}
+  .herotop h3{font-size:22px;font-weight:700}
+  .herotop h3 span{color:var(--orange-dark)}
+  .herotop p{font-size:13px;color:var(--muted);margin-top:6px;line-height:1.6}
+  .amounts{display:flex;gap:8px;justify-content:center;margin-top:14px;flex-wrap:wrap}
+  .amt{border:1.5px solid var(--line);background:#fff;font-family:inherit;font-size:14px;font-weight:700;padding:8px 20px;border-radius:99px;cursor:pointer;color:var(--muted)}
+  .amt.active{background:var(--orange);border-color:var(--orange);color:#fff}
+  .amt:hover:not(.active){border-color:var(--orange);color:var(--orange)}
+  .amthint{font-size:11px;color:#b5b5b5;margin-top:8px}
+
+  .methods{display:grid;grid-template-columns:1fr 1fr;border-top:1px solid var(--line)}
+  @media(max-width:760px){.methods{grid-template-columns:1fr}}
+  .method{padding:24px 28px;display:flex;gap:20px;align-items:center}
+  .method+.method{border-left:1px solid var(--line)}
+  @media(max-width:760px){.method+.method{border-left:none;border-top:1px solid var(--line)}}
+  .qr{width:132px;height:132px;border:1px solid var(--line);border-radius:12px;padding:6px;background:#fff}
+  .minfo{flex:1}
+  .mbadge{display:inline-flex;align-items:center;gap:8px;font-size:16px;font-weight:700;margin-bottom:6px}
+  .dot{width:12px;height:12px;border-radius:4px}
+  .handle{display:flex;align-items:center;gap:8px;background:#F7F5F0;border:1px solid var(--line);border-radius:9px;padding:8px 12px;font-size:13.5px;font-weight:600;margin:8px 0}
+  .copy{margin-left:auto;border:none;background:var(--orange);color:#fff;font-family:inherit;font-size:11px;font-weight:700;padding:5px 13px;border-radius:99px;cursor:pointer;white-space:nowrap}
+  .copy:hover{background:var(--orange-dark)}
+  .copy.done{background:var(--green)}
+  .steps{font-size:11.5px;color:var(--muted);line-height:1.7}
+  .open{display:inline-block;margin-top:8px;border:1.5px solid var(--venmo);color:var(--venmo);font-size:12px;font-weight:700;padding:6px 16px;border-radius:99px;text-decoration:none}
+  .open:hover{background:var(--venmo);color:#fff}
+  .herofoot{background:#FDFBF7;border-top:1px solid var(--line);padding:10px 28px;font-size:11.5px;color:var(--muted);text-align:center}
+
+  .ghost{border:1px solid var(--line);border-radius:12px;padding:26px 30px;color:#bbb;font-size:13px;margin-top:10px}
+</style>
+</head>
+<body>
+
+<div class="optlabel"><b>Option A — Hero Donation Card 置顶捐款卡：</b>Sponsors 页最顶部放一张醒目的双通道捐款卡（替代埋在段落里的邮箱）。左 Zelle 右 Venmo：<b>大二维码 + 一键复制账号 + 手机深链</b>，上方金额快捷键只作参考提示（Zelle/Venmo 都在对方 App 里输金额）。无需点击任何东西即可看到全部捐款方式——最直接。</div>
+
+<div class="pagehead"><h2>Our Sponsors/Donors</h2><span>我们的赞助者/赞助商</span></div>
+
+<div class="hero">
+  <div class="herotop">
+    <h3>❤️ Support NewBee <span>支持新蜂跑团</span></h3>
+    <p>Every gift—large or small—funds our races, events, and community. 每一份捐赠都将用于赛事与社区活动。</p>
+    <div class="amounts">
+      <button class="amt">$20</button>
+      <button class="amt active">$50</button>
+      <button class="amt">$100</button>
+      <button class="amt">$300</button>
+      <button class="amt">Other 其他</button>
+    </div>
+    <div class="amthint">Suggested amounts — enter the amount in your payment app 参考金额，请在支付 App 内输入</div>
+  </div>
+  <div class="methods">
+    <div class="method">
+      <img class="qr" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQgAAAEIAQAAAACLjVdSAAABjklEQVR4nO1aXQ8CIQxbif//L9fso5zxxSdxOiHeAbfEWbeuoKC9aOuVgf0tfhePmxly5IECasq9Og4Pi5RBonHNdO/i6TpnAXg0IBYQnXu1l6dHLegBEhmDN77LN1nAgyJi47N+fJY/rGoudGMM2cvTdcTCKAHCp67H4+KD1wz0XuAc9WM10h+MRGHc/HIxCBt5uo5YoD57lBX6FA9azJfm4YHgTwejhEdW3gJroj5FKlMkKKVMfYCR8WHPFySbDowPSHtkungTfVTgdPF0HbOAQGCIEYQmSZzYy9MjFnA6RSgOeMIwa4yEWiNPz+QLSn9AVVc5NJQ/oKMOFp3uFgtD6y1Spl+bOwE18TzIPDhQWjUCJJPIT4RaeXrGgkoT1DGq+rz4uClJ8swDu/RKxg/c31o0L7OBQG1iEhEbyacmDqG/8BAgE+uL6dcFczASCtFJH0/XeQsUjzgmrt1Dv7f09L3xsRvqBKTYNQhkIB6MIbXfD2bdSnUeHsgh6kD5gmVgfcH//w4tv5fVxOIOk3qvEZI3EjkAAAAASUVORK5CYII=" alt="Zelle QR">
+      <div class="minfo">
+        <div class="mbadge"><span class="dot" style="background:var(--zelle)"></span>Zelle</div>
+        <div class="steps">Open your banking app → Zelle → send to: 打开银行 App 的 Zelle 转给：</div>
+        <div class="handle">newbeerunningclub@gmail.com <button class="copy" onclick="this.textContent='✓ Copied 已复制';this.classList.add('done')">Copy 复制</button></div>
+        <div class="steps">Memo 备注: <b>Donation + your name 捐款+姓名</b> — helps us thank you! 方便我们致谢</div>
+      </div>
+    </div>
+    <div class="method">
+      <img class="qr" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQgAAAEIAQAAAACLjVdSAAABnElEQVR4nO1Zwa7DMAjDUf//l/0EDml32mkMPZa1ako5IIuAzUB7s9Y7B/t5/F88LjNoRwPN732ldRweFkcGZoSDEsCAxzoPD3Ms9IqNyMM6EI/nghGJSKtIV7kHIiHOWflaHF/PD8YW20REIUlQukS6SjyMmQueFc9ffh6XH3zmheWT3SJdVR7wC/Au64kBpyHEOT6NIq3x4Dk2dGAcC38GJZvKPxCw4NBU5UeU1S6RrjoPMssqA5Pdcdkv0hoPbGZKNVo4I/OXQKdVpCX1FF5F7wpK9ZjowOPOy3X0XADCo+zCME/fQucjMTG1F19u9K9dIl21HsiMcAxEUSfWU6jNRiZYdt3bBg6sp/SNE1TzBpPULIdkjSKt0y/QVMxESZ8yb6R+MaUC1VkiORCKZlw9xT36wR58SOTu8jqtfuAxSbeTKo7MLqdj+ZgFTZWeO/JuXH+5XgenJmYaAmZDMhAPLaTEj/m6Os2487LuLZN3qIRI1rWM9NP5Qe2RU3Xp/z0amocHtIX+qFRjQbtIVzX/aB7p+nm8rBo8/gAWdroPcrwvtwAAAABJRU5ErkJggg==" alt="Venmo QR">
+      <div class="minfo">
+        <div class="mbadge"><span class="dot" style="background:var(--venmo)"></span>Venmo</div>
+        <div class="steps">Scan, or send to 扫码，或转给：</div>
+        <div class="handle">@NewBee-Running <button class="copy" onclick="this.textContent='✓ Copied 已复制';this.classList.add('done')">Copy 复制</button></div>
+        <a class="open" href="https://venmo.com/u/NewBee-Running">Open in Venmo 打开 Venmo →</a>
+      </div>
+    </div>
+  </div>
+  <div class="herofoot">Donations are reviewed by the committee and appear on this page; official 501(c)(3) receipts available (EIN 93-4936132). 捐款经确认后展示在本页，可开具税务收据。</div>
+</div>
+
+<div class="ghost">…intro paragraphs + Individual / Enterprise donor tabs continue below as today 原有介绍段落与赞助者卡片区在下方保持不变…</div>
+
+</body>
+</html>

--- a/design-mockups/donate-b-wizard.html
+++ b/design-mockups/donate-b-wizard.html
@@ -1,0 +1,121 @@
+<!DOCTYPE html>
+<html lang="zh">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Donate Option B — Step-by-step Wizard · NewBee</title>
+<link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;600;700&family=Noto+Sans+SC:wght@400;500;700&display=swap" rel="stylesheet">
+<style>
+  :root{--orange:#FFA500;--orange-dark:#F29400;--orange-bg:#FFF6E8;--ink:#212121;--muted:#757575;--line:#EEE7DC;--green:#2e7d32;--zelle:#6d1ed4;--venmo:#008CFF}
+  *{margin:0;padding:0;box-sizing:border-box}
+  body{font-family:Roboto,'Noto Sans SC',sans-serif;background:#F2EFE9;color:var(--ink);max-width:1180px;margin:0 auto;padding:32px 24px 80px}
+  .optlabel{background:var(--orange-bg);border:1px dashed var(--orange);border-radius:10px;padding:10px 16px;font-size:12.5px;color:var(--muted);margin-bottom:20px}
+  .optlabel b{color:var(--orange-dark)}
+  h2{font-size:15px;margin:26px 0 10px}
+  h2 small{font-size:12px;color:var(--muted);font-weight:400;margin-left:8px}
+
+  /* page CTA */
+  .pagestrip{background:#fff;border:1px solid var(--line);border-radius:14px;padding:20px 26px;display:flex;align-items:center;gap:18px;box-shadow:0 2px 4px rgba(0,0,0,.05)}
+  .pagestrip h3{font-size:18px}
+  .pagestrip p{font-size:12.5px;color:var(--muted);margin-top:3px}
+  .cta{margin-left:auto;border:none;background:var(--orange);color:#fff;font-family:inherit;font-size:15px;font-weight:700;padding:12px 32px;border-radius:99px;cursor:pointer;box-shadow:0 6px 18px rgba(255,165,0,.4)}
+  .cta:hover{background:var(--orange-dark)}
+
+  /* wizard dialog */
+  .dialog{background:#fff;border-radius:16px;max-width:520px;margin:14px auto;padding:24px 28px;box-shadow:0 16px 48px rgba(0,0,0,.18)}
+  .dsteps{display:flex;gap:6px;margin-bottom:18px}
+  .dstep{flex:1;height:4px;border-radius:99px;background:var(--line)}
+  .dstep.on{background:var(--orange)}
+  .dialog h3{font-size:17px;font-weight:700;margin-bottom:4px}
+  .dialog .sub{font-size:12px;color:var(--muted);margin-bottom:14px}
+  .amounts{display:grid;grid-template-columns:repeat(3,1fr);gap:10px;margin-bottom:12px}
+  .amt{border:1.5px solid var(--line);background:#fff;font-family:inherit;font-size:16px;font-weight:700;padding:14px 0;border-radius:12px;cursor:pointer;color:var(--ink);text-align:center}
+  .amt small{display:block;font-size:10.5px;color:var(--muted);font-weight:400;margin-top:2px}
+  .amt.active{border-color:var(--orange);background:var(--orange-bg);color:var(--orange-dark)}
+  input.other{width:100%;border:1.5px solid var(--line);border-radius:12px;padding:12px;font-family:inherit;font-size:14px}
+  .next{width:100%;border:none;background:var(--orange);color:#fff;font-family:inherit;font-size:14.5px;font-weight:700;padding:13px;border-radius:99px;cursor:pointer;margin-top:14px}
+  .next:hover{background:var(--orange-dark)}
+
+  .paychoice{display:grid;grid-template-columns:1fr 1fr;gap:12px}
+  .pay{border:1.5px solid var(--line);border-radius:14px;padding:18px;cursor:pointer;text-align:center}
+  .pay:hover{border-color:var(--orange)}
+  .pay b{font-size:16px;display:flex;align-items:center;justify-content:center;gap:8px}
+  .pay .dot{width:12px;height:12px;border-radius:4px}
+  .pay p{font-size:11px;color:var(--muted);margin-top:6px;line-height:1.5}
+
+  .finish{text-align:center}
+  .finish .qr{width:170px;height:170px;border:1px solid var(--line);border-radius:14px;padding:8px;margin:8px auto}
+  .handle{display:flex;align-items:center;gap:8px;background:#F7F5F0;border:1px solid var(--line);border-radius:9px;padding:9px 13px;font-size:13.5px;font-weight:600;margin:10px 0;text-align:left}
+  .copy{margin-left:auto;border:none;background:var(--orange);color:#fff;font-size:11px;font-weight:700;padding:5px 13px;border-radius:99px;cursor:pointer;font-family:inherit}
+  .copy.done{background:var(--green)}
+  .deeplink{display:block;background:var(--venmo);color:#fff;text-decoration:none;font-size:14px;font-weight:700;padding:12px;border-radius:99px;margin-top:6px}
+  .notebox{background:var(--orange-bg);border-radius:10px;padding:9px 13px;font-size:12px;color:var(--muted);text-align:left;margin-top:10px}
+  .notebox b{color:var(--orange-dark)}
+</style>
+</head>
+<body>
+
+<div class="optlabel"><b>Option B — Donate Wizard 分步捐款向导：</b>页面顶部一个大大的「❤️ Donate 捐款」按钮 → 弹出三步向导：<b>① 选金额 → ② 选 Zelle/Venmo → ③ 扫码/复制/一键跳转</b>。Venmo 深链会把金额和备注自动带入（venmo.com/NewBee-Running?txn=pay&amount=50&note=Donation-张三）；Zelle 显示二维码+复制邮箱+提醒填备注。手机上体验最佳，也最能引导完成。</div>
+
+<h2>1 · Page CTA 页面入口 <small>Sponsors 页顶部（也可放到全站 NavBar）</small></h2>
+<div class="pagestrip">
+  <div>
+    <h3>Support NewBee 支持新蜂跑团</h3>
+    <p>Every gift funds our races, events and community 每一份捐赠都将用于赛事与社区</p>
+  </div>
+  <button class="cta">❤️ Donate 捐款</button>
+</div>
+
+<h2>2 · Step 1 — Amount 金额 <small>快捷金额 + 自定义 + 姓名(用于备注)</small></h2>
+<div class="dialog">
+  <div class="dsteps"><div class="dstep on"></div><div class="dstep"></div><div class="dstep"></div></div>
+  <h3>Choose an amount 选择金额</h3>
+  <div class="sub">Your gift is tax-deductible — NewBee Running Inc is a 501(c)(3). 可抵税</div>
+  <div class="amounts">
+    <button class="amt">$20<small>Cheer 加油</small></button>
+    <button class="amt active">$50<small>Supporter 支持者</small></button>
+    <button class="amt">$100<small>Friend 挚友</small></button>
+    <button class="amt">$300<small>Sponsor 赞助</small></button>
+    <button class="amt">$1,000<small>Champion 冠军</small></button>
+    <button class="amt">Other<small>其他</small></button>
+  </div>
+  <input class="other" placeholder="Your name for the memo 备注中的姓名（可选，方便我们致谢）">
+  <button class="next">Continue 下一步 →</button>
+</div>
+
+<h2>3 · Step 2 — Method 支付方式</h2>
+<div class="dialog">
+  <div class="dsteps"><div class="dstep on"></div><div class="dstep on"></div><div class="dstep"></div></div>
+  <h3>How would you like to send $50? 如何支付 $50？</h3>
+  <div class="sub"></div>
+  <div class="paychoice">
+    <div class="pay"><b><span class="dot" style="background:var(--venmo)"></span>Venmo</b><p>One tap on mobile — amount &amp; memo prefilled 手机一键跳转，金额备注自动填好</p></div>
+    <div class="pay"><b><span class="dot" style="background:var(--zelle)"></span>Zelle</b><p>From your banking app — no fees 银行 App 转账，零手续费</p></div>
+  </div>
+</div>
+
+<h2>4 · Step 3 — Pay 完成支付 <small>左：Venmo（深链带金额）；右：Zelle（扫码/复制）</small></h2>
+<div style="display:flex;gap:14px;flex-wrap:wrap">
+<div class="dialog" style="flex:1;min-width:340px;margin:0">
+  <div class="dsteps"><div class="dstep on"></div><div class="dstep on"></div><div class="dstep on"></div></div>
+  <div class="finish">
+    <h3><span style="color:var(--venmo)">Venmo</span> · $50</h3>
+    <img class="qr" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQgAAAEIAQAAAACLjVdSAAABnElEQVR4nO1Zwa7DMAjDUf//l/0EDml32mkMPZa1ako5IIuAzUB7s9Y7B/t5/F88LjNoRwPN732ldRweFkcGZoSDEsCAxzoPD3Ms9IqNyMM6EI/nghGJSKtIV7kHIiHOWflaHF/PD8YW20REIUlQukS6SjyMmQueFc9ffh6XH3zmheWT3SJdVR7wC/Au64kBpyHEOT6NIq3x4Dk2dGAcC38GJZvKPxCw4NBU5UeU1S6RrjoPMssqA5Pdcdkv0hoPbGZKNVo4I/OXQKdVpCX1FF5F7wpK9ZjowOPOy3X0XADCo+zCME/fQucjMTG1F19u9K9dIl21HsiMcAxEUSfWU6jNRiZYdt3bBg6sp/SNE1TzBpPULIdkjSKt0y/QVMxESZ8yb6R+MaUC1VkiORCKZlw9xT36wR58SOTu8jqtfuAxSbeTKo7MLqdj+ZgFTZWeO/JuXH+5XgenJmYaAmZDMhAPLaTEj/m6Os2487LuLZN3qIRI1rWM9NP5Qe2RU3Xp/z0amocHtIX+qFRjQbtIVzX/aB7p+nm8rBo8/gAWdroPcrwvtwAAAABJRU5ErkJggg==" alt="Venmo QR">
+    <a class="deeplink" href="#">Open Venmo — $50 prefilled 打开 Venmo（已填 $50）</a>
+    <div class="handle">@NewBee-Running <button class="copy" onclick="this.textContent='✓ 已复制';this.classList.add('done')">Copy 复制</button></div>
+    <div class="notebox">Memo prefilled 备注已自动填: <b>Donation 捐款 - 张三</b></div>
+  </div>
+</div>
+<div class="dialog" style="flex:1;min-width:340px;margin:0">
+  <div class="dsteps"><div class="dstep on"></div><div class="dstep on"></div><div class="dstep on"></div></div>
+  <div class="finish">
+    <h3><span style="color:var(--zelle)">Zelle</span> · $50</h3>
+    <img class="qr" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQgAAAEIAQAAAACLjVdSAAABjklEQVR4nO1aXQ8CIQxbif//L9fso5zxxSdxOiHeAbfEWbeuoKC9aOuVgf0tfhePmxly5IECasq9Og4Pi5RBonHNdO/i6TpnAXg0IBYQnXu1l6dHLegBEhmDN77LN1nAgyJi47N+fJY/rGoudGMM2cvTdcTCKAHCp67H4+KD1wz0XuAc9WM10h+MRGHc/HIxCBt5uo5YoD57lBX6FA9azJfm4YHgTwejhEdW3gJroj5FKlMkKKVMfYCR8WHPFySbDowPSHtkungTfVTgdPF0HbOAQGCIEYQmSZzYy9MjFnA6RSgOeMIwa4yEWiNPz+QLSn9AVVc5NJQ/oKMOFp3uFgtD6y1Spl+bOwE18TzIPDhQWjUCJJPIT4RaeXrGgkoT1DGq+rz4uClJ8swDu/RKxg/c31o0L7OBQG1iEhEbyacmDqG/8BAgE+uL6dcFczASCtFJH0/XeQsUjzgmrt1Dv7f09L3xsRvqBKTYNQhkIB6MIbXfD2bdSnUeHsgh6kD5gmVgfcH//w4tv5fVxOIOk3qvEZI3EjkAAAAASUVORK5CYII=" alt="Zelle QR">
+    <div class="handle">newbeerunningclub@gmail.com <button class="copy" onclick="this.textContent='✓ 已复制';this.classList.add('done')">Copy 复制</button></div>
+    <div class="notebox">In your banking app: Zelle → send $50 to this email · Memo: <b>Donation 捐款 - 张三</b><br>打开银行 App → Zelle → 向此邮箱转 $50，备注填写捐款+姓名</div>
+  </div>
+</div>
+</div>
+
+</body>
+</html>

--- a/design-mockups/donate-c-floating.html
+++ b/design-mockups/donate-c-floating.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="zh">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Donate Option C — Site-wide Floating Donate · NewBee</title>
+<link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;600;700&family=Noto+Sans+SC:wght@400;500;700&display=swap" rel="stylesheet">
+<style>
+  :root{--orange:#FFA500;--orange-dark:#F29400;--orange-bg:#FFF6E8;--ink:#212121;--muted:#757575;--line:#EEE7DC;--green:#2e7d32;--zelle:#6d1ed4;--venmo:#008CFF}
+  *{margin:0;padding:0;box-sizing:border-box}
+  body{font-family:Roboto,'Noto Sans SC',sans-serif;background:#fff;color:var(--ink);max-width:1180px;margin:0 auto;padding:32px 24px 140px}
+  .optlabel{background:var(--orange-bg);border:1px dashed var(--orange);border-radius:10px;padding:10px 16px;font-size:12.5px;color:var(--muted);margin-bottom:20px}
+  .optlabel b{color:var(--orange-dark)}
+  .ghost{border:1px solid var(--line);border-radius:12px;padding:40px 30px;color:#bbb;font-size:13px;margin:12px 0;text-align:center}
+
+  /* floating button */
+  .fab{position:fixed;right:26px;bottom:26px;border:none;background:var(--orange);color:#fff;font-family:inherit;
+    font-size:15px;font-weight:700;padding:14px 26px;border-radius:99px;cursor:pointer;box-shadow:0 10px 30px rgba(255,165,0,.5);z-index:50}
+  .fab:hover{background:var(--orange-dark)}
+
+  /* slide-up panel */
+  .panel{position:fixed;right:26px;bottom:88px;width:390px;background:#fff;border:1px solid var(--line);border-radius:16px;
+    box-shadow:0 20px 60px rgba(0,0,0,.22);z-index:49;overflow:hidden}
+  .phead{background:linear-gradient(135deg,#FFF6E8,#fff);padding:16px 20px;border-bottom:1px solid var(--line)}
+  .phead b{font-size:15.5px}
+  .phead p{font-size:11.5px;color:var(--muted);margin-top:3px}
+  .ptabs{display:flex;border-bottom:1px solid var(--line)}
+  .ptab{flex:1;text-align:center;padding:11px;font-size:13.5px;font-weight:700;color:var(--muted);cursor:pointer;border-bottom:3px solid transparent}
+  .ptab.venmo.active{color:var(--venmo);border-color:var(--venmo)}
+  .ptab.zelle{color:var(--muted)}
+  .pbody{padding:18px 20px;text-align:center}
+  .qr{width:150px;height:150px;border:1px solid var(--line);border-radius:12px;padding:6px}
+  .handle{display:flex;align-items:center;gap:8px;background:#F7F5F0;border:1px solid var(--line);border-radius:9px;padding:9px 13px;font-size:13px;font-weight:600;margin:12px 0;text-align:left}
+  .copy{margin-left:auto;border:none;background:var(--orange);color:#fff;font-size:11px;font-weight:700;padding:5px 13px;border-radius:99px;cursor:pointer;font-family:inherit}
+  .copy.done{background:var(--green)}
+  .deeplink{display:block;background:var(--venmo);color:#fff;text-decoration:none;font-size:13.5px;font-weight:700;padding:11px;border-radius:99px}
+  .note{font-size:11px;color:var(--muted);margin-top:10px;line-height:1.6;text-align:left;background:var(--orange-bg);border-radius:9px;padding:8px 12px}
+  .note b{color:var(--orange-dark)}
+
+  /* navbar hint */
+  .nav{display:flex;align-items:center;gap:18px;background:#fff;border:1px solid var(--line);border-radius:12px;padding:12px 20px;font-size:13px;font-weight:700;box-shadow:0 2px 4px rgba(0,0,0,.05)}
+  .nav span{color:var(--muted);font-weight:500}
+  .navdonate{margin-left:auto;background:var(--orange);color:#fff;padding:8px 20px;border-radius:99px}
+</style>
+</head>
+<body>
+
+<div class="optlabel"><b>Option C — Site-wide Floating Donate 全站悬浮捐款：</b>右下角常驻「❤️ Donate 捐款」悬浮按钮（全站每一页都有，不只 Sponsors 页），点开一个紧凑面板：<b>Venmo / Zelle 两个页签</b>，二维码 + 复制 + 深链 + 备注提示。访客看活动照片、看排行榜时随时可捐，转化面最大；Sponsors 页顶部同时保留一个简洁入口条。</div>
+
+<div class="nav">NEWBEE NEW YORK <span>Home · About Us · Upcoming · Memories · Credits/Records · Sponsors</span><span class="navdonate">❤️ Donate 捐款</span></div>
+<div style="font-size:11px;color:#b5b5b5;margin:6px 2px 0">↑ 可选：NavBar 也放一个 Donate 入口（与悬浮按钮打开同一面板）</div>
+
+<div class="ghost">…any page: homepage, memories, records… 任意页面内容…<br><br><br>floating button stays bottom-right ↘ 悬浮按钮常驻右下角</div>
+
+<!-- open panel state -->
+<div class="panel">
+  <div class="phead"><b>❤️ Support NewBee 支持新蜂跑团</b>
+    <p>501(c)(3) tax-deductible · EIN 93-4936132 可抵税</p>
+  </div>
+  <div class="ptabs">
+    <div class="ptab venmo active">Venmo</div>
+    <div class="ptab zelle">Zelle</div>
+  </div>
+  <div class="pbody">
+    <img class="qr" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQgAAAEIAQAAAACLjVdSAAABnElEQVR4nO1Zwa7DMAjDUf//l/0EDml32mkMPZa1ako5IIuAzUB7s9Y7B/t5/F88LjNoRwPN732ldRweFkcGZoSDEsCAxzoPD3Ms9IqNyMM6EI/nghGJSKtIV7kHIiHOWflaHF/PD8YW20REIUlQukS6SjyMmQueFc9ffh6XH3zmheWT3SJdVR7wC/Au64kBpyHEOT6NIq3x4Dk2dGAcC38GJZvKPxCw4NBU5UeU1S6RrjoPMssqA5Pdcdkv0hoPbGZKNVo4I/OXQKdVpCX1FF5F7wpK9ZjowOPOy3X0XADCo+zCME/fQucjMTG1F19u9K9dIl21HsiMcAxEUSfWU6jNRiZYdt3bBg6sp/SNE1TzBpPULIdkjSKt0y/QVMxESZ8yb6R+MaUC1VkiORCKZlw9xT36wR58SOTu8jqtfuAxSbeTKo7MLqdj+ZgFTZWeO/JuXH+5XgenJmYaAmZDMhAPLaTEj/m6Os2487LuLZN3qIRI1rWM9NP5Qe2RU3Xp/z0amocHtIX+qFRjQbtIVzX/aB7p+nm8rBo8/gAWdroPcrwvtwAAAABJRU5ErkJggg==" alt="Venmo QR">
+    <div class="handle">@NewBee-Running <button class="copy" onclick="this.textContent='✓ 已复制';this.classList.add('done')">Copy 复制</button></div>
+    <a class="deeplink" href="https://venmo.com/u/NewBee-Running">Open in Venmo 打开 Venmo →</a>
+    <div class="note">Memo 备注请写: <b>Donation 捐款 + your name 姓名</b> — so we can thank you and send your receipt! 方便我们致谢并寄送收据</div>
+  </div>
+</div>
+
+<button class="fab">❤️ Donate 捐款</button>
+
+</body>
+</html>

--- a/design-mockups/finance-a-ledger-tabs.html
+++ b/design-mockups/finance-a-ledger-tabs.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html lang="zh">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Finance Option A — Ledger Grows Up · NewBee</title>
+<link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;600;700&family=Noto+Sans+SC:wght@400;500;700&display=swap" rel="stylesheet">
+<style>
+  :root{--orange:#FFA500;--orange-dark:#F29400;--orange-bg:#FFF6E8;--ink:#212121;--muted:#757575;--line:#EEE7DC;--green:#2e7d32;--green-bg:#eaf5ea;--blue:#1a63d0;--blue-bg:#e8f0fe;--purple:#7b3ff2;--purple-bg:#f3e8ff;--red:#c62828;--teal:#00796b;--teal-bg:#e0f2f1}
+  *{margin:0;padding:0;box-sizing:border-box}
+  body{font-family:Roboto,'Noto Sans SC',sans-serif;background:#fff;color:var(--ink);max-width:1280px;margin:0 auto;padding:30px 24px 80px}
+  .optlabel{background:var(--orange-bg);border:1px dashed var(--orange);border-radius:10px;padding:10px 16px;font-size:12.5px;color:var(--muted);margin-bottom:18px}
+  .optlabel b{color:var(--orange-dark)}
+  h2{font-size:14px;margin:26px 0 8px;color:var(--muted)}
+  .tabs{display:flex;border-bottom:1px solid var(--line);margin-bottom:12px;font-weight:700;font-size:15px}
+  .tab{padding:11px 22px;color:var(--muted)}
+  .tab.active{color:var(--orange);border-bottom:3px solid var(--orange)}
+  .lock{font-size:10px;background:var(--ink);color:#fff;border-radius:99px;padding:2px 8px;margin-left:6px;vertical-align:2px}
+  .subnav{display:flex;gap:8px;margin:12px 0;flex-wrap:wrap}
+  .pill{border:1.5px solid var(--line);background:#fff;color:var(--muted);font-size:12.5px;font-weight:700;padding:7px 16px;border-radius:99px;cursor:pointer}
+  .pill.active{background:var(--orange);border-color:var(--orange);color:#fff}
+  .pill .n{background:rgba(0,0,0,.12);border-radius:99px;font-size:10px;padding:1px 7px;margin-left:5px}
+  .pill.active .n{background:rgba(255,255,255,.25)}
+  table{width:100%;border-collapse:collapse;border:1px solid var(--line);border-radius:12px;overflow:hidden;box-shadow:0 2px 4px rgba(0,0,0,.05)}
+  th{background:#FDFBF7;font-size:10.5px;font-weight:700;color:var(--muted);text-transform:uppercase;letter-spacing:.4px;text-align:left;padding:10px 12px;border-bottom:1px solid var(--line)}
+  td{font-size:13px;padding:10px 12px;border-bottom:1px solid var(--line);vertical-align:middle}
+  tr:hover td{background:var(--orange-bg)}
+  tr.pending td{background:#FFFDF8;border-left:3px solid var(--orange)}
+  .amt{font-weight:700;color:var(--orange);white-space:nowrap}
+  .amt.out{color:var(--red)}
+  .chip{font-size:10px;font-weight:700;padding:2px 9px;border-radius:99px;white-space:nowrap}
+  .c-don{background:var(--green-bg);color:var(--green)}
+  .c-rev{background:var(--teal-bg);color:var(--teal)}
+  .c-pass{background:var(--blue-bg);color:var(--blue)}
+  .c-event{background:var(--purple-bg);color:var(--purple)}
+  .c-pend{background:var(--orange);color:#fff}
+  select{font-family:inherit;font-size:11.5px;font-weight:700;padding:4px 8px;border:1.5px solid var(--line);border-radius:8px;color:var(--ink);background:#fff}
+  .ackbar{display:flex;align-items:center;gap:12px;background:var(--green-bg);border:1px solid #cfe6cf;border-radius:12px;padding:11px 16px;margin:12px 0;font-size:13px}
+  .btn{border:none;background:var(--orange);color:#fff;font-family:inherit;font-size:12px;font-weight:700;padding:8px 18px;border-radius:99px;cursor:pointer}
+  .btn.green{background:var(--green)}
+  .btn.ghost{background:#fff;border:1.5px solid var(--orange);color:var(--orange)}
+  .note{font-size:11px;color:#9a9a9a;margin:6px 2px}
+</style>
+</head>
+<body>
+
+<div class="optlabel"><b>Option A — Ledger Grows Up 账本升级（最小改动）：</b>一切仍在 Sponsors 页的 admin 页签里。原「All Donations · Ledger」升级为 <b>Finance 财务</b>，下设子页签：<b>Income 收入 · Expenses 支出 · Acknowledgments 致谢 · Reports 报表 · Settings 设置</b>。审核从「approve/ignore」变成<b>两层分类</b>：每行选「款项属性」(Donation/Event Revenue/Pass-through/Mistake) +「Event」。导航结构不变，学习成本最低。</div>
+
+<div class="tabs"><div class="tab">Individual Donors 个人赞助者</div><div class="tab">Enterprise Donors 企业赞助者</div><div class="tab active">Finance 财务<span class="lock">ADMIN</span></div></div>
+
+<div class="subnav">
+  <button class="pill active">Income 收入 <span class="n">3 pending</span></button>
+  <button class="pill">Expenses 支出</button>
+  <button class="pill">Acknowledgments 致谢 <span class="n">12</span></button>
+  <button class="pill">Reports 报表</button>
+  <button class="pill">Year-end 年度汇总</button>
+  <button class="pill">Settings 设置</button>
+</div>
+
+<h2>Income 收入 — 审核 = 给每行选两个下拉（属性 × Event）；选完即完成分类，Donation 自动上公开墙 + 进入致谢队列</h2>
+<table>
+  <thead><tr><th>Date</th><th>From 来自</th><th>Amount</th><th>Source 来源</th><th>Type 属性</th><th>Event 活动</th><th>Ack 致谢</th></tr></thead>
+  <tbody>
+    <tr class="pending"><td>Jul 8</td><td><b>connie zhou</b> <span class="chip c-pend">NEW</span></td><td class="amt">$20.00</td><td>✉ Venmo</td>
+      <td><select><option>— classify 分类 —</option><option>Donation 捐款</option><option selected>Pass-through 代收</option><option>Event Revenue 活动收入</option><option>Mistake 误记</option></select></td>
+      <td><select><option selected>Bear Mt. Run 熊山</option><option>General</option><option>Anniversary</option></select></td><td>—</td></tr>
+    <tr class="pending"><td>Jul 7</td><td><b>Haotian Fu</b> <span class="chip c-pend">NEW</span></td><td class="amt">$23.00</td><td>✉ Zelle</td>
+      <td><select><option selected>Event Revenue 活动收入</option></select></td>
+      <td><select><option selected>Anniversary 十周年</option></select></td><td>—</td></tr>
+    <tr><td>Jul 6</td><td>Kevin Gu</td><td class="amt">$15.00</td><td>✉ Venmo</td><td><span class="chip c-don">DONATION 捐款</span></td><td><span class="chip c-event">General</span></td><td style="color:var(--green);font-weight:700;font-size:11.5px">✓ Sent</td></tr>
+    <tr><td>Jun 4</td><td>Yue Ma</td><td class="amt">$500.00</td><td>✉ Venmo</td><td><span class="chip c-don">DONATION 捐款</span></td><td><span class="chip c-event">Anniversary</span></td><td><button class="btn ghost" style="font-size:10.5px;padding:4px 12px">Send 致谢</button></td></tr>
+    <tr><td>Jun 3</td><td>Tracy Chen</td><td class="amt">$23.00</td><td>✉ Venmo</td><td><span class="chip c-rev">EVENT REVENUE 活动收入</span></td><td><span class="chip c-event">Anniversary</span></td><td>—</td></tr>
+    <tr><td>Jul 8</td><td>Ryan Young</td><td class="amt">$20.00</td><td>✉ Venmo</td><td><span class="chip c-pass">PASS-THROUGH 代收</span></td><td><span class="chip c-event">Bear Mt.</span></td><td>—</td></tr>
+  </tbody>
+</table>
+<div class="note">规则迁移：现有「confirmed」→ Donation；「ignored」的拼车/队服 → 一键批量改为 Pass-through / Event Revenue（保留 dedup）。关键词自动分类升级：拼车/车费→Pass-through(带Event猜测)，队服/tee→Event Revenue。</div>
+
+<h2>Acknowledgments 致谢 — Brandon 的每周批量流程（模板已分档）</h2>
+<div class="ackbar">
+  📮 <b>12 confirmed donations un-acknowledged 笔捐款待致谢</b>
+  <span style="color:var(--muted);font-size:12px">uniform tiered templates · receipts attached · emails from DonorDirectory 统一分档模板 · 附收据 · 邮箱自动补全</span>
+  <span style="flex:1"></span>
+  <button class="btn ghost">Preview list 预览名单</button>
+  <button class="btn green">✉ Send all 12 一键群发</button>
+</div>
+<div class="note">每行仍可单独发定制信（Tiffany）；DonorDirectory 记住 姓名→邮箱，缺邮箱的行会列出来等补填。后期在 Settings 里打开「Auto-send weekly 每周自动发送」开关即全自动。</div>
+
+<h2>Expenses 支出 — Chase CSV 拖入导入，同样两层分类</h2>
+<table>
+  <thead><tr><th>Date</th><th>Vendor 商家</th><th>Amount</th><th>Method</th><th>Event 活动</th><th>Category 费用类别</th></tr></thead>
+  <tbody>
+    <tr><td>Jun 2</td><td>COSTCO WHOLESALE</td><td class="amt out">-$412.88</td><td>Debit</td><td><span class="chip c-event">Anniversary</span></td><td><span class="chip c-rev">Event Food & Drink</span></td></tr>
+    <tr><td>May 28</td><td>PARTY CITY</td><td class="amt out">-$86.20</td><td>Debit</td><td><span class="chip c-event">Anniversary</span></td><td><span class="chip c-rev">Event Supplies</span></td></tr>
+  </tbody>
+</table>
+<div class="note">Reports 子页签：Income/Expense by Event（cash basis）、Event YoY 对比、509(a)(1)/(a)(2) public support test、年度汇总 —— 均可导出 CSV/PDF，与老克 Sheet 报表口径一致。</div>
+
+</body>
+</html>

--- a/design-mockups/finance-b-treasury-console.html
+++ b/design-mockups/finance-b-treasury-console.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<html lang="zh">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Finance Option B — Treasury Console · NewBee</title>
+<link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;600;700&family=Noto+Sans+SC:wght@400;500;700&display=swap" rel="stylesheet">
+<style>
+  :root{--orange:#FFA500;--orange-dark:#F29400;--orange-bg:#FFF6E8;--ink:#212121;--muted:#757575;--line:#EEE7DC;--green:#2e7d32;--green-bg:#eaf5ea;--blue:#1a63d0;--blue-bg:#e8f0fe;--purple:#7b3ff2;--purple-bg:#f3e8ff;--red:#c62828;--teal:#00796b;--teal-bg:#e0f2f1}
+  *{margin:0;padding:0;box-sizing:border-box}
+  body{font-family:Roboto,'Noto Sans SC',sans-serif;background:#F2EFE9;color:var(--ink);max-width:1320px;margin:0 auto;padding:30px 24px 80px}
+  .optlabel{background:var(--orange-bg);border:1px dashed var(--orange);border-radius:10px;padding:10px 16px;font-size:12.5px;color:var(--muted);margin-bottom:18px}
+  .optlabel b{color:var(--orange-dark)}
+  .console{display:flex;background:#fff;border:1px solid var(--line);border-radius:16px;overflow:hidden;box-shadow:0 6px 24px rgba(0,0,0,.08);min-height:640px}
+  .side{width:210px;background:#FDFBF7;border-right:1px solid var(--line);padding:18px 0}
+  .side h4{font-size:12px;font-weight:700;padding:0 18px 12px;color:var(--ink)}
+  .side h4 small{display:block;color:var(--muted);font-weight:400;font-size:10.5px;margin-top:2px}
+  .nav{list-style:none}
+  .nav li{display:flex;align-items:center;gap:9px;padding:10px 18px;font-size:13px;font-weight:600;color:var(--muted);cursor:pointer}
+  .nav li.on{background:var(--orange-bg);color:var(--orange-dark);border-right:3px solid var(--orange)}
+  .nav li .n{margin-left:auto;background:var(--orange);color:#fff;font-size:10px;font-weight:700;border-radius:99px;padding:1px 7px}
+  .main{flex:1;padding:22px 26px}
+  .main h3{font-size:16px;margin-bottom:4px}
+  .main .sub{font-size:11.5px;color:var(--muted);margin-bottom:16px}
+  .tiles{display:grid;grid-template-columns:repeat(4,1fr);gap:12px;margin-bottom:18px}
+  .tile{border:1px solid var(--line);border-radius:12px;padding:13px 15px;background:#fff}
+  .tile .k{font-size:10px;font-weight:700;color:var(--muted);text-transform:uppercase;letter-spacing:.5px}
+  .tile .v{font-size:20px;font-weight:700;margin-top:3px}
+  .tile .v.in{color:var(--green)}
+  .tile .v.out{color:var(--red)}
+  .tile .v.orange{color:var(--orange)}
+  .tile .s{font-size:10.5px;color:var(--muted);margin-top:2px}
+  .queue{border:1px solid var(--line);border-radius:12px;overflow:hidden;margin-bottom:14px}
+  .qhead{display:flex;align-items:center;gap:10px;background:#FDFBF7;border-bottom:1px solid var(--line);padding:10px 16px;font-size:13px;font-weight:700}
+  .qhead .btn{margin-left:auto}
+  .qrow{display:flex;align-items:center;gap:12px;padding:10px 16px;border-bottom:1px solid var(--line);font-size:12.5px}
+  .qrow:last-child{border-bottom:none}
+  .amt{font-weight:700;color:var(--orange);white-space:nowrap;min-width:70px}
+  .chip{font-size:10px;font-weight:700;padding:2px 9px;border-radius:99px;white-space:nowrap}
+  .c-don{background:var(--green-bg);color:var(--green)}
+  .c-rev{background:var(--teal-bg);color:var(--teal)}
+  .c-pass{background:var(--blue-bg);color:var(--blue)}
+  .c-event{background:var(--purple-bg);color:var(--purple)}
+  select{font-family:inherit;font-size:11px;font-weight:700;padding:4px 8px;border:1.5px solid var(--line);border-radius:8px;background:#fff}
+  .btn{border:none;background:var(--orange);color:#fff;font-family:inherit;font-size:11.5px;font-weight:700;padding:7px 16px;border-radius:99px;cursor:pointer}
+  .btn.green{background:var(--green)}
+  .btn.ghost{background:#fff;border:1.5px solid var(--orange);color:var(--orange)}
+  .drop{border:2px dashed var(--line);border-radius:12px;padding:18px;text-align:center;color:var(--muted);font-size:12.5px;margin-bottom:14px}
+  .drop b{color:var(--orange-dark)}
+  .note{font-size:11px;color:#9a9a9a;margin-top:10px}
+</style>
+</head>
+<body>
+
+<div class="optlabel"><b>Option B — Treasury Console 财务工作台（独立页面）：</b>新建 admin-only 页面 <b>/finance</b>（NavBar 管理入口），左侧固定导航把 Brandon/Tiffany 的所有工作集中在一个专属工作台：<b>Dashboard 总览 → Review 待分类 → Income / Expenses → Acknowledgments → Reports → Year-end → Settings</b>。Sponsors 页只保留公开捐款墙 + 轻量审核入口。空间最大、成长性最好（以后加预算、审批流都放得下），是「把老克整个 Sheet 搬上网站」的完整形态。</div>
+
+<div class="console">
+  <div class="side">
+    <h4>💰 NewBee Finance<small>财务工作台 · cash basis</small></h4>
+    <ul class="nav">
+      <li class="on">📊 Dashboard 总览</li>
+      <li>📥 Review 待分类 <span class="n">3</span></li>
+      <li>💵 Income 收入</li>
+      <li>💸 Expenses 支出</li>
+      <li>📮 Acknowledgments 致谢 <span class="n">12</span></li>
+      <li>🧾 Reports 报表</li>
+      <li>📆 Year-end 年度汇总</li>
+      <li>⚙️ Settings 设置</li>
+    </ul>
+  </div>
+  <div class="main">
+    <h3>Dashboard 总览</h3>
+    <div class="sub">FY2026 · cash basis · synced from Gmail (Zelle/Venmo) + Chase CSV imports</div>
+    <div class="tiles">
+      <div class="tile"><div class="k">YTD Income 收入</div><div class="v in">$12,436</div><div class="s">Donation $8,120 · Revenue $3,236 · Pass-thru $1,080</div></div>
+      <div class="tile"><div class="k">YTD Expenses 支出</div><div class="v out">$7,912</div><div class="s">across 6 events</div></div>
+      <div class="tile"><div class="k">Net 结余</div><div class="v">$4,524</div><div class="s">excl. pass-through 不含代收</div></div>
+      <div class="tile"><div class="k">Needs attention 待处理</div><div class="v orange">3 + 12</div><div class="s">to classify 待分类 · to acknowledge 待致谢</div></div>
+    </div>
+
+    <div class="queue">
+      <div class="qhead">📥 Review queue 待分类 — 每行选属性 × Event，选完自动归档 <button class="btn">Classify all 批量分类</button></div>
+      <div class="qrow"><span>Jul 8 · <b>connie zhou</b> · ✉ Venmo</span><span class="amt">$20.00</span>
+        <select><option>Pass-through 代收</option><option>Donation 捐款</option><option>Event Revenue</option><option>Mistake</option></select>
+        <select><option>Bear Mt. Run</option><option>General</option></select><button class="btn" style="margin-left:auto">✓</button></div>
+      <div class="qrow"><span>Jul 7 · <b>Haotian Fu</b> · ✉ Zelle</span><span class="amt">$23.00</span>
+        <select><option>Event Revenue 活动收入</option></select><select><option>Anniversary 十周年</option></select><button class="btn" style="margin-left:auto">✓</button></div>
+    </div>
+
+    <div class="queue">
+      <div class="qhead">📮 Acknowledgment queue 待致谢 <span style="color:var(--muted);font-weight:400;font-size:11px">tiered templates · receipt attached · weekly batch (Brandon 流程)</span><button class="btn green">✉ Send all 12 群发</button></div>
+      <div class="qrow"><span>Yue Ma · $500 · Anniversary</span><span class="chip c-don">tier ≥$300 template</span><span style="color:var(--muted)">yue.ma@… (directory)</span><button class="btn ghost" style="margin-left:auto">Custom 定制</button></div>
+      <div class="qrow"><span>Jian Shen · $666 · General</span><span class="chip c-don">tier ≥$300 template</span><span style="color:var(--red);font-size:11px">✗ no email — fill in directory 缺邮箱</span></div>
+    </div>
+
+    <div class="drop">⬆ <b>Drop Chase CSV here 拖入银行对账单</b> — expenses & non-Gmail income import with dedupe, then classify above 导入后进入待分类队列</div>
+
+    <div class="note">Settings 设置：Events(1xxx) / Income types(2xxx) / Expense categories(5xxx) 与老克 Sheet 同码 · 感谢信分档模板 · DonorDirectory 姓名↔邮箱 · 「Auto-send acknowledgments weekly 每周自动致谢」总开关（后期打开即全自动）。Reports 报表：Income & Expense by Event 矩阵、Event YoY、509(a)(1)/(a)(2)，均可导出。</div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/design-mockups/finance-bc-hybrid.html
+++ b/design-mockups/finance-bc-hybrid.html
@@ -1,0 +1,232 @@
+<!DOCTYPE html>
+<html lang="zh">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Finance B+C Hybrid — Treasury Console with Books Grid · NewBee</title>
+<link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;600;700&family=Noto+Sans+SC:wght@400;500;700&display=swap" rel="stylesheet">
+<style>
+  :root{--orange:#FFA500;--orange-dark:#F29400;--orange-bg:#FFF6E8;--ink:#212121;--muted:#757575;--line:#EEE7DC;--green:#2e7d32;--green-bg:#eaf5ea;--blue:#1a63d0;--blue-bg:#e8f0fe;--purple:#7b3ff2;--purple-bg:#f3e8ff;--red:#c62828;--teal:#00796b;--teal-bg:#e0f2f1}
+  *{margin:0;padding:0;box-sizing:border-box}
+  body{font-family:Roboto,'Noto Sans SC',sans-serif;background:#F2EFE9;color:var(--ink);max-width:1360px;margin:0 auto;padding:26px 22px 70px}
+  .optlabel{background:var(--orange-bg);border:1px dashed var(--orange);border-radius:10px;padding:10px 16px;font-size:12.5px;color:var(--muted);margin-bottom:16px}
+  .optlabel b{color:var(--orange-dark)}
+  .console{display:flex;background:#fff;border:1px solid var(--line);border-radius:16px;overflow:hidden;box-shadow:0 6px 24px rgba(0,0,0,.08);min-height:660px}
+  .side{width:212px;background:#FDFBF7;border-right:1px solid var(--line);padding:18px 0;flex-shrink:0}
+  .side h4{font-size:12.5px;font-weight:700;padding:0 18px 12px}
+  .side h4 small{display:block;color:var(--muted);font-weight:400;font-size:10.5px;margin-top:2px}
+  .nav{list-style:none}
+  .nav li{display:flex;align-items:center;gap:9px;padding:10px 18px;font-size:13px;font-weight:600;color:var(--muted);cursor:pointer;user-select:none}
+  .nav li:hover{color:var(--orange-dark)}
+  .nav li.on{background:var(--orange-bg);color:var(--orange-dark);border-right:3px solid var(--orange)}
+  .nav li .n{margin-left:auto;background:var(--orange);color:#fff;font-size:10px;font-weight:700;border-radius:99px;padding:1px 7px}
+  .main{flex:1;padding:20px 24px;min-width:0}
+  .main h3{font-size:16px;margin-bottom:3px}
+  .main .sub{font-size:11.5px;color:var(--muted);margin-bottom:14px}
+  .view{display:none}
+  .view.on{display:block}
+
+  .tiles{display:grid;grid-template-columns:repeat(4,1fr);gap:12px;margin-bottom:16px}
+  .tile{border:1px solid var(--line);border-radius:12px;padding:13px 15px;background:#fff}
+  .tile.alert{border-color:var(--orange);background:var(--orange-bg)}
+  .tile .k{font-size:10px;font-weight:700;color:var(--muted);text-transform:uppercase;letter-spacing:.5px}
+  .tile .v{font-size:20px;font-weight:700;margin-top:3px}
+  .tile .v.in{color:var(--green)} .tile .v.out{color:var(--red)} .tile .v.orange{color:var(--orange)}
+  .tile .s{font-size:10.5px;color:var(--muted);margin-top:2px}
+
+  .toolbar{display:flex;align-items:center;gap:8px;margin-bottom:10px;flex-wrap:wrap}
+  .btn{border:none;background:var(--orange);color:#fff;font-family:inherit;font-size:11.5px;font-weight:700;padding:7px 16px;border-radius:99px;cursor:pointer}
+  .btn.green{background:var(--green)}
+  .btn.ghost{background:#fff;border:1.5px solid var(--orange);color:var(--orange)}
+  .fchip{border:1.5px solid var(--line);background:#fff;color:var(--muted);font-size:11.5px;font-weight:700;padding:6px 13px;border-radius:99px;cursor:pointer}
+  .fchip.active{background:var(--orange);border-color:var(--orange);color:#fff}
+  .sp{flex:1}
+
+  .grid{border:1px solid var(--line);border-radius:10px;overflow:auto;box-shadow:0 2px 6px rgba(0,0,0,.05)}
+  table{width:100%;border-collapse:collapse;min-width:980px}
+  th{background:#FDFBF7;font-size:10px;font-weight:700;color:var(--muted);text-transform:uppercase;letter-spacing:.4px;text-align:left;padding:8px 10px;border:1px solid var(--line)}
+  td{font-size:12.5px;padding:7px 10px;border:1px solid #F1EDE4;vertical-align:middle;background:#fff}
+  tr.new td{background:#FFFDF8}
+  td.rowno{background:#FDFBF7;color:#b5b5b5;font-size:10px;text-align:center;width:32px}
+  .amt{font-weight:700;color:var(--orange);white-space:nowrap;text-align:right}
+  .amt.out{color:var(--red)}
+  .cellchip{display:inline-flex;align-items:center;gap:4px;font-size:10.5px;font-weight:700;padding:3px 10px;border-radius:99px;cursor:pointer;border:1px dashed transparent;white-space:nowrap}
+  .cellchip:hover{border-color:var(--orange)}
+  .c-don{background:var(--green-bg);color:var(--green)}
+  .c-rev{background:var(--teal-bg);color:var(--teal)}
+  .c-pass{background:var(--blue-bg);color:var(--blue)}
+  .c-event{background:var(--purple-bg);color:var(--purple)}
+  .c-empty{background:#fff;border:1.5px dashed var(--orange);color:var(--orange)}
+  .ack-sent{color:var(--green);font-weight:700;font-size:11px;white-space:nowrap}
+  .bulkbar{display:flex;align-items:center;gap:10px;background:var(--ink);color:#fff;border-radius:10px;padding:9px 14px;margin-top:10px;font-size:12px;flex-wrap:wrap}
+  .bulkbar select{font-family:inherit;font-size:11px;font-weight:700;padding:4px 8px;border-radius:8px;border:none}
+  .note{font-size:11px;color:#9a9a9a;margin-top:8px;line-height:1.6}
+
+  .queue{border:1px solid var(--line);border-radius:12px;overflow:hidden;margin-bottom:12px}
+  .qhead{display:flex;align-items:center;gap:10px;background:#FDFBF7;border-bottom:1px solid var(--line);padding:10px 14px;font-size:13px;font-weight:700}
+  .qrow{display:flex;align-items:center;gap:10px;padding:9px 14px;border-bottom:1px solid var(--line);font-size:12px;flex-wrap:wrap}
+  .qrow:last-child{border-bottom:none}
+  .report td.head{font-weight:700;background:#FDFBF7}
+  .report td.tot{font-weight:700;background:var(--orange-bg);color:var(--orange-dark)}
+  .drop{border:2px dashed var(--orange);background:var(--orange-bg);border-radius:12px;padding:16px;text-align:center;color:var(--orange-dark);font-size:12.5px;font-weight:600;margin-bottom:12px}
+  .setrow{display:flex;align-items:center;gap:10px;padding:10px 0;border-bottom:1px solid var(--line);font-size:13px}
+  .switch{width:38px;height:20px;border-radius:99px;background:#ddd;position:relative;cursor:pointer;flex-shrink:0}
+  .switch.on{background:var(--green)}
+  .switch::after{content:'';position:absolute;width:16px;height:16px;border-radius:50%;background:#fff;top:2px;left:2px}
+  .switch.on::after{left:20px}
+</style>
+</head>
+<body>
+
+<div class="optlabel"><b>B+C Hybrid — Treasury Console 工作台 × Books Grid 电子账本：</b>独立 admin 页面 <b>/finance</b>，左侧 B 的导航；<b>Income / Expenses 用 C 的表格账本</b>（彩色 chip 单元格点开即改、多选批量分类、✉ 群发勾选）。左侧导航是<b>可点击的</b> —— 点每一项查看对应界面。</div>
+
+<div class="console">
+  <div class="side">
+    <h4>💰 NewBee Finance<small>财务工作台 · cash basis · FY2026</small></h4>
+    <ul class="nav" id="nav">
+      <li class="on" data-v="dash">📊 Dashboard 总览</li>
+      <li data-v="income">💵 Income 收入 <span class="n">3</span></li>
+      <li data-v="exp">💸 Expenses 支出</li>
+      <li data-v="ack">📮 Acknowledgments 致谢 <span class="n">12</span></li>
+      <li data-v="rpt">🧾 Reports 报表</li>
+      <li data-v="ye">📆 Year-end 年度汇总</li>
+      <li data-v="set">⚙️ Settings 设置</li>
+    </ul>
+  </div>
+
+  <div class="main">
+    <!-- DASHBOARD -->
+    <div class="view on" id="v-dash">
+      <h3>Dashboard 总览</h3>
+      <div class="sub">Gmail (Zelle/Venmo) 自动同步 + Chase CSV 导入 · 数字实时来自账本</div>
+      <div class="tiles">
+        <div class="tile"><div class="k">YTD Income 收入</div><div class="v in">$12,436</div><div class="s">Donation $8,120 · Revenue $3,236 · Pass-thru $1,080</div></div>
+        <div class="tile"><div class="k">YTD Expenses 支出</div><div class="v out">$7,912</div><div class="s">across 6 events</div></div>
+        <div class="tile"><div class="k">Net 结余</div><div class="v">$4,524</div><div class="s">excl. pass-through 不含代收</div></div>
+        <div class="tile alert"><div class="k">Needs attention 待处理</div><div class="v orange">3 + 12</div><div class="s">待分类 · 待致谢 → 点击直达</div></div>
+      </div>
+      <div class="queue">
+        <div class="qhead">本周概况 This week</div>
+        <div class="qrow">🔄 Gmail sync: <b style="color:var(--green)">● Healthy</b> · last run Jul 11 · 2 new rows → Income</div>
+        <div class="qrow">📮 12 confirmed donations waiting for acknowledgment → Acknowledgments</div>
+        <div class="qrow">⬆ Last bank import: Jun 30 (43 rows, 0 duplicates) → Expenses</div>
+      </div>
+    </div>
+
+    <!-- INCOME (C-style grid) -->
+    <div class="view" id="v-income">
+      <h3>Income 收入</h3>
+      <div class="sub">C 式账本：Type/Event 是可点的彩色单元格；新行来自 Gmail 同步与银行导入 · 分类为 Donation 后自动上公开墙 + 进致谢队列</div>
+      <div class="toolbar">
+        <button class="fchip active">All 全部</button><button class="fchip">Unclassified 待分类 (3)</button><button class="fchip">Donation</button><button class="fchip">Event Revenue</button><button class="fchip">Pass-through</button>
+        <span class="sp"></span>
+        <button class="btn ghost">↻ Scan Gmail 扫描邮件</button><button class="btn ghost">＋ Manual row 手动记一笔</button>
+      </div>
+      <div class="grid"><table>
+        <thead><tr><th>☑</th><th>Date</th><th>From 来自</th><th style="text-align:right">Amount</th><th>Method</th><th>Memo</th><th>Type 属性 ▾</th><th>Event 活动 ▾</th><th>Ack 致谢</th></tr></thead>
+        <tbody>
+          <tr class="new"><td class="rowno"><input type="checkbox" checked></td><td>Jul 8</td><td><b>connie zhou</b></td><td class="amt">$20.00</td><td>Venmo</td><td>carpool bear mountain - 岑岑</td>
+            <td><span class="cellchip c-empty">＋ classify 分类</span></td><td><span class="cellchip c-empty">＋ event</span></td><td>—</td></tr>
+          <tr class="new"><td class="rowno"><input type="checkbox" checked></td><td>Jul 8</td><td><b>Ryan Young</b></td><td class="amt">$20.00</td><td>Venmo</td><td>拼车费用</td>
+            <td><span class="cellchip c-empty">＋ classify 分类</span></td><td><span class="cellchip c-empty">＋ event</span></td><td>—</td></tr>
+          <tr class="new"><td class="rowno"><input type="checkbox"></td><td>Jul 7</td><td><b>Haotian Fu</b></td><td class="amt">$23.00</td><td>Zelle</td><td>tee</td>
+            <td><span class="cellchip c-rev">Event Revenue ▾</span></td><td><span class="cellchip c-event">Anniversary ▾</span></td><td>—</td></tr>
+          <tr><td class="rowno"></td><td>Jul 6</td><td>Kevin Gu</td><td class="amt">$15.00</td><td>Venmo</td><td>🍉 梅老板加油 🇦🇷</td>
+            <td><span class="cellchip c-don">Donation ▾</span></td><td><span class="cellchip c-event">General ▾</span></td><td class="ack-sent">✓ Jul 11</td></tr>
+          <tr><td class="rowno"></td><td>Jun 4</td><td>Yue Ma</td><td class="amt">$500.00</td><td>Venmo</td><td>Happy 10th anniversary!</td>
+            <td><span class="cellchip c-don">Donation ▾</span></td><td><span class="cellchip c-event">Anniversary ▾</span></td><td><input type="checkbox" checked> ✉</td></tr>
+          <tr><td class="rowno"></td><td>Jun 3</td><td>Tracy Chen</td><td class="amt">$23.00</td><td>Venmo</td><td>1 red + 1 white 队服</td>
+            <td><span class="cellchip c-rev">Event Revenue ▾</span></td><td><span class="cellchip c-event">Anniversary ▾</span></td><td>—</td></tr>
+        </tbody>
+      </table></div>
+      <div class="bulkbar">☑ 2 rows selected 已选 2 行 → Type: <select><option>Pass-through 代收</option><option>Donation</option><option>Event Revenue</option><option>Mistake</option></select> Event: <select><option>Bear Mt. Run 熊山</option><option>General</option></select> <button class="btn">Apply 应用</button></div>
+      <div class="note">迁移规则：现有 confirmed → Donation；已忽略的拼车/队服 → 批量设为 Pass-through / Event Revenue（dedup 保留，永不重复导入）。关键词自动分类：拼车/车费→Pass-through，队服/tee→Event Revenue（不再只是"忽略"）。</div>
+    </div>
+
+    <!-- EXPENSES (C-style grid) -->
+    <div class="view" id="v-exp">
+      <h3>Expenses 支出</h3>
+      <div class="sub">同样的账本 grid：Event × 费用类别 两层分类（5001-5006 与老克 Sheet 同码）</div>
+      <div class="drop">⬆ Drop Chase CSV here 拖入银行对账单 — 自动解析 outflow、按 Import ID 去重、进入下方待分类</div>
+      <div class="grid"><table>
+        <thead><tr><th>☑</th><th>Date</th><th>Vendor 商家</th><th style="text-align:right">Amount</th><th>Method</th><th>Bank description</th><th>Event 活动 ▾</th><th>Category 费用类别 ▾</th></tr></thead>
+        <tbody>
+          <tr class="new"><td class="rowno"><input type="checkbox"></td><td>Jun 30</td><td><b>SHERWIN THE PARTY</b></td><td class="amt out">-$220.00</td><td>Debit</td><td>POS PURCHASE SHERWIN…</td>
+            <td><span class="cellchip c-empty">＋ event</span></td><td><span class="cellchip c-empty">＋ category</span></td></tr>
+          <tr><td class="rowno"></td><td>Jun 2</td><td>COSTCO WHOLESALE</td><td class="amt out">-$412.88</td><td>Debit</td><td>COSTCO WHSE #0334</td>
+            <td><span class="cellchip c-event">Anniversary ▾</span></td><td><span class="cellchip c-rev">Event Food & Drink ▾</span></td></tr>
+          <tr><td class="rowno"></td><td>May 28</td><td>PARTY CITY</td><td class="amt out">-$86.20</td><td>Debit</td><td>PARTY CITY 1099</td>
+            <td><span class="cellchip c-event">Anniversary ▾</span></td><td><span class="cellchip c-rev">Event Supplies ▾</span></td></tr>
+          <tr><td class="rowno"></td><td>May 12</td><td>NYRR</td><td class="amt out">-$300.00</td><td>ACH</td><td>NYRR TEAM CHAMPS</td>
+            <td><span class="cellchip c-event">Team Championship ▾</span></td><td><span class="cellchip c-rev">Others (General) ▾</span></td></tr>
+        </tbody>
+      </table></div>
+    </div>
+
+    <!-- ACKNOWLEDGMENTS -->
+    <div class="view" id="v-ack">
+      <h3>Acknowledgments 致谢</h3>
+      <div class="sub">Brandon 的每周批量流程：统一分档模板 + 收据附件；Tiffany 可对任意行单独定制</div>
+      <div class="queue">
+        <div class="qhead">📮 12 donations un-acknowledged 待致谢 <span class="sp"></span><button class="btn ghost">Preview all 预览</button><button class="btn green">✉ Send all 12 群发</button></div>
+        <div class="qrow"><b>Yue Ma</b> · $500 · Anniversary <span class="cellchip c-don">tier ≥$300</span> <span style="color:var(--muted)">yue.ma@gmail.com (directory)</span><span class="sp"></span><button class="btn ghost">Custom 定制</button></div>
+        <div class="qrow"><b>Jian Shen</b> · $666 · General <span class="cellchip c-don">tier ≥$300</span> <span style="color:var(--red)">✗ no email 缺邮箱 → 填入右侧即记住</span><span class="sp"></span><input placeholder="email…" style="border:1px solid var(--line);border-radius:8px;padding:4px 8px;font-size:11px"></div>
+        <div class="qrow"><b>Siyi Chen</b> · $15 · General <span class="cellchip c-don">tier ≥$0</span> <span style="color:var(--muted)">siyi.c@…（directory）</span><span class="sp"></span><button class="btn ghost">Custom 定制</button></div>
+      </div>
+      <div class="note">DonorDirectory 姓名↔邮箱在 Settings 里可整表维护（从老克 Sheet 一次性导入）。发送后：行变 ✓ Sent、致谢信全文进 notes、收据 PDF 附上 —— 与现有单发一致。Settings 里可开「每周自动发送」实现全自动。</div>
+    </div>
+
+    <!-- REPORTS -->
+    <div class="view" id="v-rpt">
+      <h3>Reports 报表</h3>
+      <div class="sub">cash basis · 一键生成 · 导出 CSV / PDF · 口径与老克 Sheet 一致</div>
+      <div class="toolbar"><button class="fchip active">Income & Expense by Event</button><button class="fchip">Event YoY 对比</button><button class="fchip">509(a)(1)/(a)(2) test</button><span class="sp"></span><button class="btn ghost">⬇ Export CSV</button><button class="btn ghost">⬇ Export PDF</button></div>
+      <div class="grid report"><table>
+        <thead><tr><th>FY2026</th><th>Donation</th><th>Gala Tickets</th><th>Merch 商品</th><th>Pass-through</th><th>Income TOTAL</th><th>Expenses</th><th>NET 净额</th></tr></thead>
+        <tbody>
+          <tr><td class="head">General</td><td>$5,320</td><td>—</td><td>—</td><td>—</td><td>$5,320</td><td style="color:var(--red);font-weight:700">-$1,214</td><td>$4,106</td></tr>
+          <tr><td class="head">Anniversary 十周年</td><td>$1,800</td><td>—</td><td>$2,156</td><td>—</td><td>$3,956</td><td style="color:var(--red);font-weight:700">-$3,890</td><td>$66</td></tr>
+          <tr><td class="head">Bear Mt. Run 熊山</td><td>$500</td><td>—</td><td>—</td><td>$1,080</td><td>$1,580</td><td style="color:var(--red);font-weight:700">-$1,466</td><td>$114</td></tr>
+          <tr><td class="head">BK Half Preview</td><td>$500</td><td>—</td><td>—</td><td>—</td><td>$500</td><td style="color:var(--red);font-weight:700">-$342</td><td>$158</td></tr>
+          <tr><td class="tot">TOTAL</td><td class="tot">$8,120</td><td class="tot">—</td><td class="tot">$2,156</td><td class="tot">$1,080</td><td class="tot">$11,356</td><td class="tot">-$6,912</td><td class="tot">$4,444</td></tr>
+        </tbody>
+      </table></div>
+    </div>
+
+    <!-- YEAR-END -->
+    <div class="view" id="v-ye">
+      <h3>Year-end 年度捐赠汇总</h3>
+      <div class="sub">每位捐赠人一封含 IRS 语言的年度明细信（收据信里已承诺）— preview → 批量发送</div>
+      <div class="queue">
+        <div class="qhead">Tax year 2026 · 51 donors · $8,120 total <span class="sp"></span><button class="btn ghost">Build preview 生成预览</button><button class="btn green">Send 51 statements 发送</button></div>
+        <div class="qrow"><b>Yue Ma</b> · 3 donations · $530 total <span class="sp"></span><span class="ack-sent">preview ready</span></div>
+        <div class="qrow"><b>Kevin Gu</b> · 2 donations · $30 total <span class="sp"></span><span class="ack-sent">preview ready</span></div>
+      </div>
+    </div>
+
+    <!-- SETTINGS -->
+    <div class="view" id="v-set">
+      <h3>Settings 设置</h3>
+      <div class="sub">与老克 Sheet 同一套编码；在这里加活动/类别，全站下拉即时生效</div>
+      <div class="setrow"><b style="width:210px">Events 活动 (1xxx)</b><span style="color:var(--muted);font-size:12px">1001 General · 1002 Gala · 1003 Anniversary · 1004 Bear Mt. · …</span><span class="sp"></span><button class="btn ghost">Manage 管理</button></div>
+      <div class="setrow"><b style="width:210px">Income types 收入属性 (2xxx)</b><span style="color:var(--muted);font-size:12px">Donation · Gala Tickets · Merchandise · Pass-through</span><span class="sp"></span><button class="btn ghost">Manage 管理</button></div>
+      <div class="setrow"><b style="width:210px">Expense categories (5xxx)</b><span style="color:var(--muted);font-size:12px">Food & Drink · Supplies · Transportation · Rental · Office · Others</span><span class="sp"></span><button class="btn ghost">Manage 管理</button></div>
+      <div class="setrow"><b style="width:210px">Thank-you templates 模板</b><span style="color:var(--muted);font-size:12px">tiered ≥$0 / ≥$300 / … (existing 现有功能)</span><span class="sp"></span><button class="btn ghost">Manage 管理</button></div>
+      <div class="setrow"><b style="width:210px">DonorDirectory 通讯录</b><span style="color:var(--muted);font-size:12px">name ↔ email · import from 老克 Sheet 一次性导入</span><span class="sp"></span><button class="btn ghost">Manage 管理</button></div>
+      <div class="setrow"><b style="width:210px">Auto-send acks 每周自动致谢</b><span style="color:var(--muted);font-size:12px">weekly, uniform templates — flip when trusted 模板稳定后打开即全自动</span><span class="sp"></span><div class="switch"></div></div>
+    </div>
+  </div>
+</div>
+
+<script>
+document.getElementById('nav').addEventListener('click', function(e){
+  const li = e.target.closest('li'); if(!li) return;
+  document.querySelectorAll('#nav li').forEach(x=>x.classList.remove('on'));
+  li.classList.add('on');
+  document.querySelectorAll('.view').forEach(v=>v.classList.remove('on'));
+  document.getElementById('v-'+li.dataset.v).classList.add('on');
+});
+</script>
+
+</body>
+</html>

--- a/design-mockups/finance-c-books-grid.html
+++ b/design-mockups/finance-c-books-grid.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="zh">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Finance Option C — Books Grid · NewBee</title>
+<link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;600;700&family=Noto+Sans+SC:wght@400;500;700&display=swap" rel="stylesheet">
+<style>
+  :root{--orange:#FFA500;--orange-dark:#F29400;--orange-bg:#FFF6E8;--ink:#212121;--muted:#757575;--line:#EEE7DC;--green:#2e7d32;--green-bg:#eaf5ea;--blue:#1a63d0;--blue-bg:#e8f0fe;--purple:#7b3ff2;--purple-bg:#f3e8ff;--red:#c62828;--teal:#00796b;--teal-bg:#e0f2f1}
+  *{margin:0;padding:0;box-sizing:border-box}
+  body{font-family:Roboto,'Noto Sans SC',sans-serif;background:#fff;color:var(--ink);max-width:1320px;margin:0 auto;padding:30px 24px 80px}
+  .optlabel{background:var(--orange-bg);border:1px dashed var(--orange);border-radius:10px;padding:10px 16px;font-size:12.5px;color:var(--muted);margin-bottom:18px}
+  .optlabel b{color:var(--orange-dark)}
+  .toolbar{display:flex;align-items:center;gap:8px;margin-bottom:10px;flex-wrap:wrap}
+  .sheettabs{display:flex;gap:2px}
+  .stab{background:#EFEBE2;border:1px solid var(--line);border-bottom:none;border-radius:8px 8px 0 0;padding:8px 18px;font-size:12.5px;font-weight:700;color:var(--muted);cursor:pointer}
+  .stab.on{background:#fff;color:var(--orange-dark);border-color:var(--orange)}
+  .btn{border:none;background:var(--orange);color:#fff;font-family:inherit;font-size:11.5px;font-weight:700;padding:7px 16px;border-radius:99px;cursor:pointer}
+  .btn.green{background:var(--green)}
+  .btn.ghost{background:#fff;border:1.5px solid var(--orange);color:var(--orange)}
+  .grid{border:1px solid var(--orange);border-radius:0 10px 10px 10px;overflow:auto;box-shadow:0 2px 8px rgba(0,0,0,.06)}
+  table{width:100%;border-collapse:collapse;min-width:1100px}
+  th{background:#FDFBF7;font-size:10px;font-weight:700;color:var(--muted);text-transform:uppercase;letter-spacing:.4px;text-align:left;padding:8px 10px;border:1px solid var(--line);position:sticky;top:0}
+  td{font-size:12.5px;padding:7px 10px;border:1px solid #F1EDE4;vertical-align:middle;background:#fff}
+  tr.new td{background:#FFFDF8}
+  td.rowno{background:#FDFBF7;color:#b5b5b5;font-size:10px;text-align:center;width:34px}
+  .amt{font-weight:700;color:var(--orange);white-space:nowrap;text-align:right}
+  .amt.out{color:var(--red)}
+  .cellchip{display:inline-flex;align-items:center;gap:4px;font-size:10.5px;font-weight:700;padding:3px 10px;border-radius:99px;cursor:pointer;border:1px dashed transparent}
+  .cellchip:hover{border-color:var(--orange)}
+  .c-don{background:var(--green-bg);color:var(--green)}
+  .c-rev{background:var(--teal-bg);color:var(--teal)}
+  .c-pass{background:var(--blue-bg);color:var(--blue)}
+  .c-event{background:var(--purple-bg);color:var(--purple)}
+  .c-empty{background:#fff;border:1.5px dashed var(--orange);color:var(--orange)}
+  .ack-sent{color:var(--green);font-weight:700;font-size:11px;white-space:nowrap}
+  .bulkbar{display:flex;align-items:center;gap:10px;background:var(--ink);color:#fff;border-radius:12px;padding:10px 16px;margin:12px 0;font-size:12.5px}
+  .bulkbar select{font-family:inherit;font-size:11.5px;font-weight:700;padding:5px 9px;border-radius:8px;border:none}
+  .note{font-size:11px;color:#9a9a9a;margin:8px 2px}
+  h2{font-size:14px;margin:24px 0 8px;color:var(--muted)}
+  .report{border:1px solid var(--line);border-radius:12px;overflow:hidden}
+  .report th,.report td{border:1px solid #F1EDE4;font-size:12px;padding:7px 10px}
+  .report td.head{font-weight:700;background:#FDFBF7}
+  .report td.tot{font-weight:700;background:var(--orange-bg);color:var(--orange-dark)}
+</style>
+</head>
+<body>
+
+<div class="optlabel"><b>Option C — Books Grid 电子账本（最像 Google Sheet）：</b>admin 页面做成<b>表格账本</b>：底部式工作表页签 Income / Expenses / Reports，行内彩色单元格 chip 点开即改（属性、Event、费用类别），支持<b>多选行 + 底部批量分类栏</b>、键盘上下移动。Brandon 从 Sheet 迁移零学习成本；勾选行 → 群发致谢与 Sheet 的 ✉ checkbox 完全同感。报表页签就是老克的矩阵（by Event × 属性/类别 + YoY）。</div>
+
+<div class="toolbar">
+  <div class="sheettabs">
+    <div class="stab on">💵 Income 收入</div>
+    <div class="stab">💸 Expenses 支出</div>
+    <div class="stab">🧾 Reports 报表</div>
+    <div class="stab">👥 Directory 通讯录</div>
+    <div class="stab">⚙️ Settings</div>
+  </div>
+  <span style="flex:1"></span>
+  <button class="btn ghost">↻ Scan Gmail 扫描邮件</button>
+  <button class="btn ghost">⬆ Import Chase CSV 导入账单</button>
+  <button class="btn green">✉ Send 12 acks 群发致谢</button>
+</div>
+
+<div class="grid">
+<table>
+  <thead><tr><th></th><th>Date</th><th>From 来自</th><th style="text-align:right">Amount</th><th>Method</th><th>Memo</th><th>Type 属性 ▾</th><th>Event 活动 ▾</th><th>Ack 致谢</th></tr></thead>
+  <tbody>
+    <tr class="new"><td class="rowno">1</td><td>Jul 8</td><td><b>connie zhou</b></td><td class="amt">$20.00</td><td>Venmo</td><td>carpool bear mountain - 岑岑</td>
+      <td><span class="cellchip c-empty">＋ classify 分类</span></td><td><span class="cellchip c-empty">＋ event</span></td><td>—</td></tr>
+    <tr class="new"><td class="rowno">2</td><td>Jul 7</td><td><b>Haotian Fu</b></td><td class="amt">$23.00</td><td>Zelle</td><td>tee</td>
+      <td><span class="cellchip c-rev">Event Revenue ▾</span></td><td><span class="cellchip c-event">Anniversary ▾</span></td><td>—</td></tr>
+    <tr><td class="rowno">3</td><td>Jul 6</td><td>Kevin Gu</td><td class="amt">$15.00</td><td>Venmo</td><td>🍉 梅老板加油 🇦🇷</td>
+      <td><span class="cellchip c-don">Donation ▾</span></td><td><span class="cellchip c-event">General ▾</span></td><td class="ack-sent">✓ Jul 11</td></tr>
+    <tr><td class="rowno">4</td><td>Jun 4</td><td>Yue Ma</td><td class="amt">$500.00</td><td>Venmo</td><td>Happy 10th anniversary!</td>
+      <td><span class="cellchip c-don">Donation ▾</span></td><td><span class="cellchip c-event">Anniversary ▾</span></td><td><input type="checkbox" checked> ✉</td></tr>
+    <tr><td class="rowno">5</td><td>Jun 3</td><td>Tracy Chen</td><td class="amt">$23.00</td><td>Venmo</td><td>1 red + 1 white 队服</td>
+      <td><span class="cellchip c-rev">Event Revenue ▾</span></td><td><span class="cellchip c-event">Anniversary ▾</span></td><td>—</td></tr>
+    <tr><td class="rowno">6</td><td>Jul 8</td><td>Ryan Young</td><td class="amt">$20.00</td><td>Venmo</td><td>拼车费用</td>
+      <td><span class="cellchip c-pass">Pass-through ▾</span></td><td><span class="cellchip c-event">Bear Mt. ▾</span></td><td>—</td></tr>
+  </tbody>
+</table>
+</div>
+
+<div class="bulkbar">☑ 2 rows selected 已选 2 行 → set Type 属性: <select><option>Pass-through 代收</option></select> set Event: <select><option>Bear Mt. Run</option></select> <button class="btn">Apply 应用</button> <span style="opacity:.7">or ✉ send acks for selected 或对所选行发致谢</span></div>
+
+<h2>Reports 报表页签 — 老克的矩阵原样搬进来（cash basis · 可导出 CSV/PDF · YoY 对比 · 509(a) 测试）</h2>
+<div class="report"><table>
+  <thead><tr><th>FY2026 · Income 收入</th><th>Donation</th><th>Gala Tickets</th><th>Merch 商品</th><th>Pass-through</th><th>TOTAL</th><th>Expenses 支出</th><th>NET 净额</th></tr></thead>
+  <tbody>
+    <tr><td class="head">General</td><td>$5,320</td><td>—</td><td>—</td><td>—</td><td>$5,320</td><td class="amt out" style="text-align:left">-$1,214</td><td>$4,106</td></tr>
+    <tr><td class="head">Anniversary 十周年</td><td>$1,800</td><td>—</td><td>$2,156</td><td>—</td><td>$3,956</td><td class="amt out" style="text-align:left">-$3,890</td><td>$66</td></tr>
+    <tr><td class="head">Bear Mt. Run 熊山</td><td>$500</td><td>—</td><td>—</td><td>$1,080</td><td>$1,580</td><td class="amt out" style="text-align:left">-$1,466</td><td>$114</td></tr>
+    <tr><td class="head">BK Half Preview</td><td>$500</td><td>—</td><td>—</td><td>—</td><td>$500</td><td class="amt out" style="text-align:left">-$342</td><td>$158</td></tr>
+    <tr><td class="tot">TOTAL</td><td class="tot">$8,120</td><td class="tot">—</td><td class="tot">$2,156</td><td class="tot">$1,080</td><td class="tot">$11,356</td><td class="tot">-$6,912</td><td class="tot">$4,444</td></tr>
+  </tbody>
+</table></div>
+<div class="note">同页签内：Event YoY comparison（2025 vs 2026 每活动收支）、Public support test 509(a)(1)/(a)(2)、Year-end 年度捐赠汇总（批量发送）。</div>
+
+</body>
+</html>


### PR DESCRIPTION
Implements the approved **pure Option C "Books Grid"** design (`design-mockups/finance-c-books-grid.html`) — porting 老克's Google Sheet "DONATION & EXPENSE WORKFLOW" onto the website, same category codes (events 1xxx · income types 2xxx · expense categories 5xxx).

## New admin page: /finance
Worksheet-style tabs with spreadsheet-feel grids:
- **💵 Income** — every money-in row with clickable chip cells for **Type** (Donation 捐款 / Event Revenue 活动收入 / Pass-through 代收 / Mistake) × **Event**; filters, bulk-classify bar, manual entry dialog. Only Donations publish to the public wall; pass-through excluded from NET. The old ledger and the Gmail auto-ignore keywords stay in sync with the books.
- **💸 Expenses** — Chase CSV import (outflows→expenses, other inflows→pending income, BANK| dedupe, idempotent), Event × expense-category chips, bulk classify.
- **🧾 Reports** — Income & Expense by Event matrix (cash basis, CSV export), Event year-over-year, and 509(a)(1)/(a)(2) public-support tests (management model; 990 preparer owns final numbers).
- **👥 Directory** — donor name↔email memory (+ insider flag for the 509 test), feeding the acknowledgment queue.
- **⚙️ Settings** — category management, org start / FYE month, and the **weekly auto-send acknowledgments switch** (off by default — Brandon's manual-first plan).

Toolbar: Scan Gmail · Import Chase CSV · **Send N acks 群发致谢** (batch acknowledgments with tiered templates + receipts + per-row results). Year-end per-donor itemized statements (preview → batch send, double-send guarded) via `/api/finance/year-end/*`.

## Deployment
- Run `python migrate_finance_module.py` on the server (adds donors.income_type/event_code, seeds categories, backfills from the old two-state model). New tables auto-create at startup. No new pip deps.
- ⚠️ Once live, 老克's Google Sheet script must stop scanning Gmail/sending acks (double-acknowledgment risk); import its DonorDirectory into /finance → Directory.

## Known simplification
Income layer-2 = the three behavioral types; Gala Tickets vs Merch both roll up as Event Revenue for now (2xxx codes seeded for a finer split later).

## Test plan
Backend 880 tests pass (98.5% cov — new: 29 finance tests covering categories, classification, bank import idempotency, directory, batch acks incl. auto-send switch, all three reports with hand-checked math, year-end guard). Frontend 1207 tests pass (98.4% lines; all new components >95%). Production build compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)