### PR TITLE
Remove 'Mistake' income type — unidentified rows stay unclassified

### DIFF
--- a/ProjectCode/client/src/components/finance/IncomeGrid.js
+++ b/ProjectCode/client/src/components/finance/IncomeGrid.js
@@ -29,7 +29,6 @@ export const INCOME_TYPES = [
   { key: 'donation', label: 'Donation 捐款', color: GREEN, bg: GREEN_BG },
   { key: 'event_revenue', label: 'Event Revenue 活动收入', color: TEAL, bg: TEAL_BG },
   { key: 'pass_through', label: 'Pass-through 代收', color: BLUE, bg: BLUE_BG },
-  { key: 'mistake', label: 'Mistake 误操作', color: MUTED, bg: '#f1f1f1' },
 ];
 
 const FILTERS = [

--- a/ProjectCode/server/database.py
+++ b/ProjectCode/server/database.py
@@ -79,7 +79,7 @@ class Donor(Base):
 
     # Two-layer bookkeeping (mirrors the club's Google Sheet):
     # income_type: NULL = unclassified, else 'donation' | 'event_revenue'
-    #   | 'pass_through' | 'mistake'. Only 'donation' rows appear publicly.
+    #   | 'pass_through'. Only 'donation' rows appear publicly.
     # event_code: finance_categories code (1xxx), e.g. 1001 General.
     income_type = Column(String(20), nullable=True)
     event_code = Column(Integer, nullable=True)

--- a/ProjectCode/server/migrate_finance_module.py
+++ b/ProjectCode/server/migrate_finance_module.py
@@ -3,13 +3,13 @@
 One-time migration for the finance module (Books Grid).
 
 1. Adds two-layer bookkeeping columns to donors:
-       income_type VARCHAR(20) NULL   (donation | event_revenue | pass_through | mistake)
+       income_type VARCHAR(20) NULL   (donation | event_revenue | pass_through; NULL=unclassified)
        event_code  INTEGER NULL       (finance_categories 1xxx)
 2. Creates the new tables (finance_categories, expenses, donor_directory)
    and seeds the category codes used in the club's Google Sheet.
 3. Backfills income_type from the old two-state model:
        confirmed -> donation
-       dismissed -> pass_through / event_revenue by memo keywords, else mistake
+       dismissed -> pass_through / event_revenue by memo keywords, else left unclassified
        pending   -> NULL (unclassified)
 
 Safe to re-run. Works on SQLite (dev) and MySQL (prod):
@@ -83,7 +83,7 @@ def migrate():
             "SELECT donation_id, status, message, notes FROM donors "
             "WHERE income_type IS NULL"
         )).fetchall()
-        counts = {"donation": 0, "pass_through": 0, "event_revenue": 0, "mistake": 0}
+        counts = {"donation": 0, "pass_through": 0, "event_revenue": 0, "unclassified": 0}
         for donation_id, status, message, notes in rows:
             memo = f"{message or ''} {notes or ''}".lower()
             income_type = None
@@ -95,7 +95,7 @@ def migrate():
                 elif any(k in memo for k in EVENT_REVENUE_KEYWORDS):
                     income_type = "event_revenue"
                 else:
-                    income_type = "mistake"
+                    counts["unclassified"] += 1  # left NULL for committee review
             if income_type:
                 counts[income_type] += 1
                 db.execute(text(
@@ -103,6 +103,14 @@ def migrate():
                     "event_code = COALESCE(event_code, 1001) "
                     "WHERE donation_id = :id"
                 ), {"t": income_type, "id": donation_id})
+        # Earlier runs used a 'mistake' type — those rows belong in the
+        # unclassified queue instead
+        fixed = db.execute(text(
+            "UPDATE donors SET income_type = NULL WHERE income_type = 'mistake'"
+        ))
+        if fixed.rowcount:
+            counts["unclassified"] += fixed.rowcount
+            print(f"Converted {fixed.rowcount} 'mistake' row(s) to unclassified.")
         db.commit()
         print(f"Backfilled income_type: {counts}")
     finally:

--- a/ProjectCode/server/models.py
+++ b/ProjectCode/server/models.py
@@ -85,7 +85,7 @@ class DonorLedgerEntry(DonorResponse):
     thank_you_sent_at: Optional[datetime] = None
     email_excerpt: Optional[str] = None
     # Two-layer bookkeeping (finance module)
-    income_type: Optional[str] = None  # donation | event_revenue | pass_through | mistake
+    income_type: Optional[str] = None  # donation | event_revenue | pass_through | NULL=unclassified
     event_code: Optional[int] = None
     # The ledger shows every row, including legacy/imported ones where these
     # can be NULL (rows inserted outside SQLAlchemy get no column defaults)
@@ -168,7 +168,7 @@ class ThankYouTemplateResponse(ThankYouTemplateBase):
 # Finance module (Books Grid)
 # ---------------------------------------------------------------------------
 
-INCOME_TYPES = ("donation", "event_revenue", "pass_through", "mistake")
+INCOME_TYPES = ("donation", "event_revenue", "pass_through")
 
 
 class FinanceCategoryCreate(BaseModel):
@@ -195,7 +195,7 @@ class FinanceCategoryOut(BaseModel):
 
 class ClassifyIncomeRequest(BaseModel):
     donation_ids: List[int]
-    income_type: str = Field(..., pattern="^(donation|event_revenue|pass_through|mistake)$")
+    income_type: str = Field(..., pattern="^(donation|event_revenue|pass_through)$")
     event_code: Optional[int] = None
 
 
@@ -205,7 +205,7 @@ class ManualIncomeRequest(BaseModel):
     donation_date: Optional[dt.date] = None
     method: Optional[str] = Field(None, max_length=50)
     memo: Optional[str] = None
-    income_type: str = Field(..., pattern="^(donation|event_revenue|pass_through|mistake)$")
+    income_type: str = Field(..., pattern="^(donation|event_revenue|pass_through)$")
     event_code: Optional[int] = None
 
 

--- a/ProjectCode/server/routes/donors.py
+++ b/ProjectCode/server/routes/donors.py
@@ -279,9 +279,10 @@ def dismiss_donation(
         )
 
     donor.status = "dismissed"
-    # Keep the finance books in sync; committee can refine the type later
-    if donor.income_type in (None, "donation"):
-        donor.income_type = "mistake"
+    # Keep the finance books in sync: an ignored donation goes back to
+    # unclassified; real classifications (pass-through etc.) are preserved
+    if donor.income_type == "donation":
+        donor.income_type = None
     db.commit()
     db.refresh(donor)
     return donor

--- a/ProjectCode/server/tests/test_finance.py
+++ b/ProjectCode/server/tests/test_finance.py
@@ -137,7 +137,7 @@ def test_classify_income_donation_publishes(client, db_session, committee_member
 
 def test_classify_income_unknown_id_404(client, committee_member):
     resp = client.post("/api/finance/income/classify", json={
-        "donation_ids": [999], "income_type": "mistake",
+        "donation_ids": [999], "income_type": "pass_through",
     }, headers=auth(committee_member))
     assert resp.status_code == 404
 
@@ -167,7 +167,7 @@ def test_legacy_ledger_actions_sync_income_type(client, db_session, committee_me
     client.post(f"/api/donors/donations/{row.donation_id}/dismiss",
                 headers=auth(committee_member))
     db_session.refresh(row)
-    assert row.income_type == "mistake"
+    assert row.income_type is None  # ignored donation returns to unclassified
 
     client.post(f"/api/donors/donations/{row.donation_id}/revert",
                 headers=auth(committee_member))
@@ -365,8 +365,8 @@ def test_report_by_event_matrix(client, db_session, committee_member):
                 status="dismissed", event_code=1003)
     seed_income(db_session, "P1", amount=50, income_type="pass_through",
                 status="dismissed", event_code=1004)
-    seed_income(db_session, "M1", amount=999, income_type="mistake",
-                status="dismissed", event_code=1004)  # excluded entirely
+    seed_income(db_session, "M1", amount=999, income_type=None,
+                status="dismissed", event_code=1004)  # unclassified: excluded
     seed_expense(db_session, amount=120, event_code=1003)
 
     report = client.get("/api/finance/reports/by-event",


### PR DESCRIPTION
Committee feedback: filtering Unclassified showed nothing because the migration invented a 'Mistake' type for the leftover rows — misleading and wrong. Now:

- Income types are exactly three: Donation / Event Revenue / Pass-through; anything unidentified stays **NULL = unclassified** and shows under the Unclassified filter
- Re-running `migrate_finance_module.py` converts the existing 'mistake' rows back to unclassified (prod has 6)
- The legacy ledger's Ignore returns a donation to unclassified rather than typing it

Backend 880 / frontend 1207 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)