### PR TITLE
Unified event cards: EventCard + EventComposer (Proposal B)

### DIFF
--- a/ProjectCode/client/src/components/EventCard.js
+++ b/ProjectCode/client/src/components/EventCard.js
@@ -1,0 +1,307 @@
+import { Box, Button, Card, Chip, IconButton, Tooltip, Typography } from '@mui/material';
+import AccessTimeIcon from '@mui/icons-material/AccessTime';
+import PlaceIcon from '@mui/icons-material/Place';
+import RepeatIcon from '@mui/icons-material/Repeat';
+import ShareIcon from '@mui/icons-material/Share';
+import EventCardImage from './EventCardImage';
+import EventEngagementBar from './EventEngagementBar';
+import EventGalleryPreview from './EventGalleryPreview';
+import {
+  ORANGE, ORANGE_DARK, ORANGE_BG, LINE, MUTED,
+  GREEN, GREEN_BG, RED, RED_BG, BLUE, BLUE_BG,
+  CARD_SHADOW, CARD_HOVER_SHADOW, FALLBACK_EVENT_IMAGE,
+} from '../theme/tokens';
+import { parseBubbleDate } from '../helpers/eventDate';
+
+// Normalize the three field-naming conventions that coexist in event data
+// (API snake_case, page-cache camelCase, banner event_* prefixes) so every
+// surface can hand its cached shape straight to the card.
+export function normalizeEvent(event) {
+  return {
+    id: event.id,
+    name: event.name || event.title || event.event_name || '',
+    chineseName: event.chinese_name || event.chineseName || event.chineseTitle || '',
+    date: event.date || event.event_date || '',
+    time: event.time || event.event_time || '',
+    location: event.location || event.event_location || '',
+    chineseLocation: event.chinese_location || event.chineseLocation || '',
+    description: event.description || event.event_description || '',
+    image: event.image || event.image_url || event.event_image || '',
+    imagePosition: event.image_position || 'center center',
+    signupLink: event.signup_link || event.signupLink || event.event_signup_link || '',
+    status: event.status || 'Upcoming',
+    eventType: event.event_type || event.eventType || 'standard',
+    isRecurring: Boolean(event.is_recurring || event.isRecurring),
+  };
+}
+
+const statusChip = {
+  Upcoming: { label: 'UPCOMING', bg: GREEN_BG, fg: GREEN },
+  Past: { label: 'MEMORY 回忆', bg: '#f0ede7', fg: MUTED },
+  Cancelled: { label: 'CANCELLED 已取消', bg: RED_BG, fg: RED },
+};
+
+function EventChip({ label, bg, fg, icon }) {
+  return (
+    <Chip
+      icon={icon}
+      label={label}
+      size="small"
+      sx={{
+        backgroundColor: bg,
+        color: fg,
+        fontWeight: 700,
+        fontSize: '0.65rem',
+        letterSpacing: '0.02em',
+        height: 20,
+        '& .MuiChip-icon': { color: fg, fontSize: 14 },
+      }}
+    />
+  );
+}
+
+/**
+ * The one event card. Used by CalendarPage (featured grid + upcoming list),
+ * HighlightsPage and any future surface.
+ *
+ * density: 'grid' (vertical, image on top) | 'row' (horizontal, image left)
+ * adminActions: node rendered in the top-right icon cluster (pages own their
+ *   admin logic — edit/delete/star/QR/drag — and pass the buttons in)
+ * interactive: false renders a static preview (used by EventComposer)
+ */
+export default function EventCard({
+  event,
+  density = 'grid',
+  onClick,
+  onShare,
+  adminActions = null,
+  showEngagement = true,
+  showGalleryPreview = false,
+  showDescription = false,
+  interactive = true,
+  sx = {},
+}) {
+  const ev = normalizeEvent(event);
+  const bubble = parseBubbleDate(ev.date);
+  const isCancelled = ev.status === 'Cancelled';
+  const isUpcoming = ev.status === 'Upcoming';
+  const hasSignup = Boolean(ev.signupLink) && isUpcoming;
+  const chip = statusChip[ev.status];
+  const isGrid = density === 'grid';
+
+  const handleCardClick = () => {
+    if (interactive && onClick) onClick(event);
+  };
+
+  const handleCta = (e) => {
+    e.stopPropagation();
+    if (!interactive) return;
+    if (hasSignup) {
+      window.open(ev.signupLink, '_blank', 'noopener,noreferrer');
+    } else if (onClick) {
+      onClick(event);
+    }
+  };
+
+  const handleShare = (e) => {
+    e.stopPropagation();
+    if (interactive && onShare) onShare(event);
+  };
+
+  const handleImageError = (e) => {
+    e.target.src = FALLBACK_EVENT_IMAGE;
+  };
+
+  return (
+    <Card
+      elevation={0}
+      onClick={handleCardClick}
+      data-testid="event-card"
+      sx={{
+        display: 'flex',
+        flexDirection: isGrid ? 'column' : { xs: 'column', sm: 'row' },
+        height: isGrid ? '100%' : 'auto',
+        minHeight: isGrid ? 'auto' : { sm: 180 },
+        backgroundColor: 'white',
+        border: `1px solid ${LINE}`,
+        borderRadius: '12px',
+        boxShadow: CARD_SHADOW,
+        overflow: 'hidden',
+        position: 'relative',
+        opacity: isCancelled ? 0.75 : 1,
+        ...(interactive && {
+          cursor: 'pointer',
+          transition: 'all 0.2s ease',
+          '&:hover': {
+            transform: 'translateY(-3px)',
+            boxShadow: CARD_HOVER_SHADOW,
+          },
+        }),
+        ...sx,
+      }}
+    >
+      {/* Image with date bubble */}
+      <Box
+        sx={{
+          position: 'relative',
+          flexShrink: 0,
+          width: isGrid ? '100%' : { xs: '100%', sm: 220 },
+        }}
+      >
+        <EventCardImage
+          event={{ ...event, image: ev.image || FALLBACK_EVENT_IMAGE, image_position: ev.imagePosition }}
+          onError={handleImageError}
+          sx={{
+            height: isGrid ? 190 : { xs: 150, sm: '100%' },
+            filter: isCancelled ? 'grayscale(0.6)' : 'none',
+          }}
+        />
+        {bubble && (
+          <Box
+            sx={{
+              position: 'absolute',
+              left: 10,
+              bottom: 10,
+              width: 48,
+              height: 48,
+              borderRadius: '12px',
+              backgroundColor: 'rgba(255,255,255,0.95)',
+              boxShadow: '0 2px 6px rgba(0,0,0,0.18)',
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}
+          >
+            <Typography sx={{ fontSize: '1.05rem', fontWeight: 700, color: ORANGE, lineHeight: 1.1 }}>
+              {bubble.day}
+            </Typography>
+            <Typography sx={{ fontSize: '0.59rem', fontWeight: 700, letterSpacing: '0.1em', color: MUTED }}>
+              {bubble.month}
+            </Typography>
+          </Box>
+        )}
+      </Box>
+
+      {/* Body */}
+      <Box sx={{ p: 2, display: 'flex', flexDirection: 'column', gap: 1, flex: 1, minWidth: 0 }}>
+        {/* Chip row + action icons */}
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, flexWrap: 'wrap' }}>
+          {chip && <EventChip label={chip.label} bg={chip.bg} fg={chip.fg} />}
+          {ev.eventType === 'race' && <EventChip label="RACE 比赛" bg={BLUE_BG} fg={BLUE} />}
+          {ev.eventType === 'heylo' && <EventChip label="HEYLO" bg={BLUE_BG} fg={BLUE} />}
+          {ev.isRecurring && (
+            <EventChip icon={<RepeatIcon />} label="RECURRING" bg={ORANGE_BG} fg={ORANGE} />
+          )}
+          <Box sx={{ marginLeft: 'auto', display: 'flex', gap: 0.25 }} onClick={(e) => e.stopPropagation()}>
+            {onShare && (
+              <Tooltip title="Share event / 分享活动">
+                <IconButton size="small" onClick={handleShare} aria-label="share event" sx={{ color: MUTED, '&:hover': { color: ORANGE, backgroundColor: ORANGE_BG } }}>
+                  <ShareIcon sx={{ fontSize: 16 }} />
+                </IconButton>
+              </Tooltip>
+            )}
+            {adminActions}
+          </Box>
+        </Box>
+
+        {/* Title */}
+        <Typography
+          variant="h6"
+          sx={{
+            fontSize: { xs: '1rem', sm: '1.05rem' },
+            fontWeight: 600,
+            lineHeight: 1.3,
+            textDecoration: isCancelled ? 'line-through' : 'none',
+            color: isCancelled ? MUTED : 'inherit',
+          }}
+        >
+          {ev.name}
+          {ev.chineseName && (
+            <Typography component="span" sx={{ fontSize: '0.85rem', color: MUTED, ml: 1 }}>
+              {ev.chineseName}
+            </Typography>
+          )}
+        </Typography>
+
+        {/* Meta: time + location */}
+        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: '4px 16px' }}>
+          {(ev.date || ev.time) && (
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+              <AccessTimeIcon sx={{ fontSize: 15, color: ORANGE }} />
+              <Typography variant="body2" sx={{ color: MUTED, fontSize: '0.8rem' }}>
+                {[ev.date, ev.time].filter(Boolean).join(' · ')}
+              </Typography>
+            </Box>
+          )}
+          {ev.location && (
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+              <PlaceIcon sx={{ fontSize: 15, color: ORANGE }} />
+              <Typography variant="body2" sx={{ color: MUTED, fontSize: '0.8rem' }}>
+                {ev.location}
+                {ev.chineseLocation ? ` ${ev.chineseLocation}` : ''}
+              </Typography>
+            </Box>
+          )}
+        </Box>
+
+        {/* Description (grid/featured density only) */}
+        {showDescription && ev.description && (
+          <Typography
+            variant="body2"
+            sx={{
+              color: MUTED,
+              fontSize: '0.8rem',
+              lineHeight: 1.5,
+              display: '-webkit-box',
+              WebkitLineClamp: 2,
+              WebkitBoxOrient: 'vertical',
+              overflow: 'hidden',
+            }}
+          >
+            {ev.description}
+          </Typography>
+        )}
+
+        {showGalleryPreview && ev.id && (
+          <EventGalleryPreview eventId={ev.id} maxImages={5} size={36} />
+        )}
+
+        {showEngagement && ev.id && <EventEngagementBar eventId={ev.id} />}
+
+        {/* Context-aware CTA */}
+        <Button
+          variant={hasSignup ? 'contained' : 'outlined'}
+          disableElevation
+          onClick={handleCta}
+          sx={{
+            mt: 'auto',
+            alignSelf: isGrid ? 'stretch' : 'flex-start',
+            borderRadius: '99px',
+            textTransform: 'none',
+            fontWeight: 600,
+            fontSize: { xs: '0.8125rem', sm: '0.875rem' },
+            px: 2.5,
+            py: 0.9,
+            opacity: isCancelled ? 0.6 : 1,
+            ...(hasSignup
+              ? {
+                  backgroundColor: ORANGE,
+                  color: 'white',
+                  '&:hover': { backgroundColor: ORANGE_DARK },
+                }
+              : {
+                  borderColor: ORANGE,
+                  borderWidth: '1.5px',
+                  color: ORANGE,
+                  '&:hover': { backgroundColor: ORANGE, borderColor: ORANGE, color: 'white', borderWidth: '1.5px' },
+                }),
+            '&:active': { transform: 'scale(0.98)' },
+          }}
+        >
+          {hasSignup ? 'Sign Up 报名' : 'View Details 查看详情'}
+        </Button>
+      </Box>
+    </Card>
+  );
+}

--- a/ProjectCode/client/src/components/EventCard.test.js
+++ b/ProjectCode/client/src/components/EventCard.test.js
@@ -1,0 +1,161 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import EventCard, { normalizeEvent } from './EventCard';
+
+jest.mock('./EventEngagementBar', () => () => <div data-testid="engagement-bar" />);
+jest.mock('./EventGalleryPreview', () => () => <div data-testid="gallery-preview" />);
+
+const baseEvent = {
+  id: 1,
+  name: 'Saturday Long Run',
+  chinese_name: '周六长跑',
+  date: '2026-07-19',
+  time: '8:00 AM',
+  location: 'Central Park',
+  chinese_location: '中央公园',
+  description: 'Weekly long run with paced groups.',
+  image: '/images/2025/20250620_queens_10k.jpg',
+  status: 'Upcoming',
+  event_type: 'standard',
+};
+
+describe('normalizeEvent', () => {
+  test('reads snake_case API fields', () => {
+    const ev = normalizeEvent(baseEvent);
+    expect(ev.name).toBe('Saturday Long Run');
+    expect(ev.chineseName).toBe('周六长跑');
+    expect(ev.signupLink).toBe('');
+  });
+
+  test('reads page-cache camelCase and featured title fields', () => {
+    const ev = normalizeEvent({
+      id: 2,
+      title: 'Team Championship',
+      chineseTitle: '团队锦标赛',
+      signupLink: 'https://nyrr.org',
+      eventType: 'race',
+    });
+    expect(ev.name).toBe('Team Championship');
+    expect(ev.chineseName).toBe('团队锦标赛');
+    expect(ev.signupLink).toBe('https://nyrr.org');
+    expect(ev.eventType).toBe('race');
+  });
+
+  test('reads banner event_* prefixed fields', () => {
+    const ev = normalizeEvent({
+      event_name: 'Fun Run',
+      event_date: '2026-07-04',
+      event_signup_link: 'https://example.com',
+    });
+    expect(ev.name).toBe('Fun Run');
+    expect(ev.date).toBe('2026-07-04');
+    expect(ev.signupLink).toBe('https://example.com');
+  });
+});
+
+describe('EventCard', () => {
+  test('renders title, chinese title, meta and date bubble', () => {
+    render(<EventCard event={baseEvent} />);
+    expect(screen.getByText('Saturday Long Run')).toBeInTheDocument();
+    expect(screen.getByText('周六长跑')).toBeInTheDocument();
+    expect(screen.getByText(/2026-07-19 · 8:00 AM/)).toBeInTheDocument();
+    expect(screen.getByText(/Central Park 中央公园/)).toBeInTheDocument();
+    expect(screen.getByText('19')).toBeInTheDocument();
+    expect(screen.getByText('JUL')).toBeInTheDocument();
+    expect(screen.getByText('UPCOMING')).toBeInTheDocument();
+  });
+
+  test('whole card click fires onClick', () => {
+    const onClick = jest.fn();
+    render(<EventCard event={baseEvent} onClick={onClick} />);
+    fireEvent.click(screen.getByTestId('event-card'));
+    expect(onClick).toHaveBeenCalledWith(baseEvent);
+  });
+
+  test('CTA is View Details without signup link and fires onClick', () => {
+    const onClick = jest.fn();
+    render(<EventCard event={baseEvent} onClick={onClick} />);
+    fireEvent.click(screen.getByRole('button', { name: /View Details/ }));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  test('CTA is Sign Up when upcoming with signup link and opens it', () => {
+    const openSpy = jest.spyOn(window, 'open').mockImplementation(() => {});
+    const onClick = jest.fn();
+    render(
+      <EventCard event={{ ...baseEvent, signup_link: 'https://nyrr.org' }} onClick={onClick} />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /Sign Up 报名/ }));
+    expect(openSpy).toHaveBeenCalledWith('https://nyrr.org', '_blank', 'noopener,noreferrer');
+    expect(onClick).not.toHaveBeenCalled();
+    openSpy.mockRestore();
+  });
+
+  test('past event with signup link falls back to View Details', () => {
+    render(
+      <EventCard event={{ ...baseEvent, status: 'Past', signup_link: 'https://nyrr.org' }} />
+    );
+    expect(screen.getByRole('button', { name: /View Details/ })).toBeInTheDocument();
+    expect(screen.getByText('MEMORY 回忆')).toBeInTheDocument();
+  });
+
+  test('cancelled event shows chip and strikethrough title', () => {
+    render(<EventCard event={{ ...baseEvent, status: 'Cancelled' }} />);
+    expect(screen.getByText('CANCELLED 已取消')).toBeInTheDocument();
+    expect(screen.getByText('Saturday Long Run')).toHaveStyle('text-decoration: line-through');
+  });
+
+  test('race and recurring chips render', () => {
+    render(<EventCard event={{ ...baseEvent, event_type: 'race', is_recurring: true }} />);
+    expect(screen.getByText('RACE 比赛')).toBeInTheDocument();
+    expect(screen.getByText('RECURRING')).toBeInTheDocument();
+  });
+
+  test('share button fires onShare, not onClick', () => {
+    const onShare = jest.fn();
+    const onClick = jest.fn();
+    render(<EventCard event={baseEvent} onShare={onShare} onClick={onClick} />);
+    fireEvent.click(screen.getByLabelText('share event'));
+    expect(onShare).toHaveBeenCalledWith(baseEvent);
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  test('renders adminActions in the icon cluster', () => {
+    render(<EventCard event={baseEvent} adminActions={<button>edit-me</button>} />);
+    expect(screen.getByText('edit-me')).toBeInTheDocument();
+  });
+
+  test('engagement bar renders by default and hides when disabled', () => {
+    const { rerender } = render(<EventCard event={baseEvent} />);
+    expect(screen.getByTestId('engagement-bar')).toBeInTheDocument();
+    rerender(<EventCard event={baseEvent} showEngagement={false} />);
+    expect(screen.queryByTestId('engagement-bar')).not.toBeInTheDocument();
+  });
+
+  test('gallery preview renders only when requested', () => {
+    const { rerender } = render(<EventCard event={baseEvent} />);
+    expect(screen.queryByTestId('gallery-preview')).not.toBeInTheDocument();
+    rerender(<EventCard event={baseEvent} showGalleryPreview />);
+    expect(screen.getByTestId('gallery-preview')).toBeInTheDocument();
+  });
+
+  test('description renders only in showDescription mode', () => {
+    const { rerender } = render(<EventCard event={baseEvent} />);
+    expect(screen.queryByText(/Weekly long run/)).not.toBeInTheDocument();
+    rerender(<EventCard event={baseEvent} showDescription />);
+    expect(screen.getByText(/Weekly long run/)).toBeInTheDocument();
+  });
+
+  test('non-interactive preview ignores clicks', () => {
+    const onClick = jest.fn();
+    render(<EventCard event={baseEvent} onClick={onClick} interactive={false} />);
+    fireEvent.click(screen.getByTestId('event-card'));
+    fireEvent.click(screen.getByRole('button', { name: /View Details/ }));
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  test('event without id skips engagement and gallery', () => {
+    render(<EventCard event={{ name: 'Draft', date: '2026-08-01' }} showGalleryPreview />);
+    expect(screen.queryByTestId('engagement-bar')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('gallery-preview')).not.toBeInTheDocument();
+  });
+});

--- a/ProjectCode/client/src/components/EventComposer.js
+++ b/ProjectCode/client/src/components/EventComposer.js
@@ -1,0 +1,709 @@
+import { useEffect, useRef, useState } from 'react';
+import {
+  Alert, Box, Button, Chip, CircularProgress, Dialog, DialogActions, DialogContent,
+  DialogTitle, FormControlLabel, MenuItem, Snackbar, Step, StepLabel, Stepper,
+  Switch, TextField, Typography,
+} from '@mui/material';
+import CloudUploadIcon from '@mui/icons-material/CloudUpload';
+import RepeatIcon from '@mui/icons-material/Repeat';
+import EventCard from './EventCard';
+import { useAuth } from '../context';
+import { useAutoFillOnTab, useTranslationAutoFill } from '../hooks';
+import {
+  createEvent, updateEvent, getEventWithRecurrence,
+  createEventRecurrence, updateEventRecurrence, deleteEventRecurrence,
+} from '../api';
+import { uploadImage } from '../api/homepageSections';
+import { ORANGE, ORANGE_DARK, MUTED } from '../theme/tokens';
+import { to24Hour, to12Hour } from '../helpers/eventDate';
+
+const STEPS = ['Basics 基本', 'Details 详情', 'Publish 发布'];
+
+const emptyForm = {
+  name: '',
+  chinese_name: '',
+  date: '',
+  time: '',
+  location: '',
+  chinese_location: '',
+  description: '',
+  chinese_description: '',
+  image: '',
+  signup_link: '',
+  status: 'Upcoming',
+  is_highlight: false,
+  event_type: 'standard',
+  heylo_embed: '',
+  wechat_qr_code: '',
+  // Recurrence (synced via dedicated rule endpoints, not the event payload)
+  is_recurring: false,
+  recurrence_type: 'weekly',
+  days_of_week: '',
+  day_of_month: '',
+  week_of_month: '',
+  month_of_year: '',
+  recurrence_end_date: '',
+};
+
+function isValidUrl(value) {
+  return !value || /^https?:\/\/\S+/.test(value);
+}
+
+/**
+ * The single event create/edit dialog — a 3-step composer with a live
+ * EventCard preview. Mounted from CalendarPage, AdminPanelPage and
+ * EventDetailModal; replaces the three divergent editors those surfaces
+ * used to carry.
+ *
+ * Props:
+ *   open      — dialog visibility
+ *   onClose   — close without saving
+ *   event     — event to edit (any of the cached field shapes; re-fetched
+ *               by id for authoritative state) or null to create
+ *   onSaved   — called with the saved event after a successful save
+ */
+export default function EventComposer({ open, onClose, event = null, onSaved, sx = {} }) {
+  const { currentUser } = useAuth();
+  const [activeStep, setActiveStep] = useState(0);
+  const [formData, setFormData] = useState(emptyForm);
+  const [hadRecurrenceRule, setHadRecurrenceRule] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [uploading, setUploading] = useState(false);
+  const [uploadingQr, setUploadingQr] = useState(false);
+  const [touched, setTouched] = useState(false);
+  const [snackbar, setSnackbar] = useState({ open: false, message: '', severity: 'error' });
+  const imageInputRef = useRef(null);
+  const qrInputRef = useRef(null);
+
+  const isEditing = Boolean(event?.id);
+
+  useEffect(() => {
+    if (!open) return;
+    setActiveStep(0);
+    setTouched(false);
+    setHadRecurrenceRule(false);
+    if (!event?.id) {
+      // Create mode: date defaults to today so the quickest path is name → save
+      setFormData({ ...emptyForm, date: new Date().toISOString().split('T')[0] });
+      return;
+    }
+    // Edit mode: re-fetch authoritative state — page caches are transformed
+    // projections that drop fields like is_highlight or wechat_qr_code
+    let cancelled = false;
+    (async () => {
+      let fresh = event;
+      let recurrence = null;
+      try {
+        const withRule = await getEventWithRecurrence(event.id);
+        fresh = withRule;
+        recurrence = withRule.recurrence || null;
+      } catch (err) {
+        console.error('Error fetching event for editing:', err);
+      }
+      if (cancelled) return;
+      setFormData({
+        name: fresh.name ?? fresh.title ?? '',
+        chinese_name: fresh.chinese_name ?? fresh.chineseName ?? fresh.chineseTitle ?? '',
+        date: fresh.date ?? '',
+        time: fresh.time ?? '',
+        location: fresh.location ?? '',
+        chinese_location: fresh.chinese_location ?? fresh.chineseLocation ?? '',
+        description: fresh.description ?? '',
+        chinese_description: fresh.chinese_description ?? fresh.chineseDescription ?? '',
+        image: fresh.image ?? '',
+        signup_link: fresh.signup_link ?? fresh.signupLink ?? '',
+        status: fresh.status === 'Highlight' ? 'Past' : (fresh.status ?? 'Upcoming'),
+        is_highlight: fresh.status === 'Highlight' ? true : Boolean(fresh.is_highlight),
+        event_type: fresh.event_type ?? fresh.eventType ?? 'standard',
+        heylo_embed: fresh.heylo_embed ?? fresh.heyloEmbed ?? '',
+        wechat_qr_code: fresh.wechat_qr_code ?? fresh.wechatQrCode ?? '',
+        is_recurring: Boolean(recurrence),
+        recurrence_type: recurrence?.recurrence_type ?? 'weekly',
+        days_of_week: recurrence?.days_of_week != null ? String(recurrence.days_of_week) : '',
+        day_of_month: recurrence?.day_of_month != null ? String(recurrence.day_of_month) : '',
+        week_of_month: recurrence?.week_of_month != null ? String(recurrence.week_of_month) : '',
+        month_of_year: recurrence?.month_of_year != null ? String(recurrence.month_of_year) : '',
+        recurrence_end_date: recurrence?.end_date ?? '',
+      });
+      setHadRecurrenceRule(Boolean(recurrence));
+    })();
+    return () => { cancelled = true; };
+  }, [open, event?.id]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const setField = (field, value) => setFormData(prev => ({ ...prev, [field]: value }));
+  const handleChange = (field) => (e) => setField(field, e.target.value);
+
+  const handleAutoFill = useAutoFillOnTab({
+    setValue: setField,
+    defaultValues: {
+      name: 'New Event',
+      chinese_name: '新活动',
+      location: 'Central Park',
+      chinese_location: '中央公园',
+      description: 'Event description goes here.',
+      chinese_description: '活动描述在此。',
+      signup_link: 'https://newbeerunningclub.org/signup',
+    },
+  });
+  const {
+    handleKeyDown: handleTranslationKeyDown,
+    handleBlur: handleTranslationBlur,
+    isTranslating,
+  } = useTranslationAutoFill({
+    setValue: setField,
+    getValue: (field) => formData[field],
+    fieldPairs: [
+      ['name', 'chinese_name'],
+      ['location', 'chinese_location'],
+      ['description', 'chinese_description'],
+    ],
+  });
+  const handleFieldKeyDown = (e) => {
+    handleAutoFill(e);
+    handleTranslationKeyDown(e);
+  };
+
+  const nameMissing = touched && !formData.name;
+  const dateMissing = touched && !formData.date;
+  const signupLinkInvalid = !isValidUrl(formData.signup_link);
+  const basicsValid = Boolean(formData.name && formData.date);
+
+  const handleNext = () => {
+    if (activeStep === 0 && !basicsValid) {
+      setTouched(true);
+      return;
+    }
+    setActiveStep(s => Math.min(s + 1, STEPS.length - 1));
+  };
+
+  const uploadFile = async (e, field, setBusy) => {
+    const file = e.target.files[0];
+    if (!file) return;
+    if (!file.type.startsWith('image/')) {
+      setSnackbar({ open: true, message: 'Please select an image file / 请选择图片文件', severity: 'error' });
+      return;
+    }
+    if (file.size > 5 * 1024 * 1024) {
+      setSnackbar({ open: true, message: 'Image must be less than 5MB / 图片必须小于5MB', severity: 'error' });
+      return;
+    }
+    setBusy(true);
+    try {
+      // Upload immediately so a failure surfaces now, not at Save
+      const { url } = await uploadImage(file, currentUser.uid);
+      setField(field, url);
+    } catch (err) {
+      console.error('Error uploading image:', err);
+      setSnackbar({ open: true, message: 'Failed to upload image / 图片上传失败', severity: 'error' });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const syncRecurrenceRule = async (eventId) => {
+    if (formData.is_recurring) {
+      const rulePayload = {
+        recurrence_type: formData.recurrence_type,
+        days_of_week: formData.days_of_week || null,
+        day_of_month: formData.day_of_month ? Number(formData.day_of_month) : null,
+        week_of_month: formData.week_of_month ? Number(formData.week_of_month) : null,
+        month_of_year: formData.month_of_year ? Number(formData.month_of_year) : null,
+        end_date: formData.recurrence_end_date || null,
+      };
+      if (hadRecurrenceRule) {
+        await updateEventRecurrence(eventId, rulePayload, currentUser.uid);
+      } else {
+        try {
+          await createEventRecurrence(eventId, rulePayload, currentUser.uid);
+        } catch (error) {
+          // A rule already exists (stale local state) — update it instead
+          if (error.status === 400) {
+            await updateEventRecurrence(eventId, rulePayload, currentUser.uid);
+          } else {
+            throw error;
+          }
+        }
+      }
+    } else if (hadRecurrenceRule) {
+      await deleteEventRecurrence(eventId, currentUser.uid);
+    }
+  };
+
+  const handleSave = async () => {
+    if (!basicsValid) {
+      setTouched(true);
+      setActiveStep(0);
+      return;
+    }
+    if (signupLinkInvalid) {
+      setActiveStep(1);
+      return;
+    }
+    if (!currentUser?.uid) {
+      setSnackbar({ open: true, message: 'You must be logged in to manage events / 您必须登录才能管理活动', severity: 'error' });
+      return;
+    }
+    setSaving(true);
+    try {
+      const {
+        is_recurring, recurrence_type, days_of_week, day_of_month,
+        week_of_month, month_of_year, recurrence_end_date,
+        ...eventFields
+      } = formData;
+      // Empty strings become null so every surface persists the same shape
+      const cleaned = Object.fromEntries(
+        Object.entries(eventFields).map(([key, value]) => [key, value === '' ? null : value])
+      );
+      let saved;
+      if (isEditing) {
+        saved = await updateEvent(event.id, cleaned, currentUser.uid);
+      } else {
+        saved = await createEvent(cleaned, currentUser.uid);
+      }
+      await syncRecurrenceRule(isEditing ? event.id : saved.id);
+      if (onSaved) await onSaved(saved ?? cleaned);
+      onClose();
+    } catch (error) {
+      console.error('Error saving event:', error);
+      setSnackbar({ open: true, message: `Error: ${error.message || 'Failed to save event'}`, severity: 'error' });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  // Live preview mirrors what the Calendar page will render
+  const previewEvent = {
+    id: event?.id,
+    name: formData.name || 'Event name',
+    chinese_name: formData.chinese_name,
+    date: formData.date,
+    time: formData.time,
+    location: formData.location,
+    chinese_location: formData.chinese_location,
+    description: formData.description,
+    image: formData.image,
+    signup_link: formData.signup_link,
+    status: formData.status,
+    event_type: formData.event_type,
+    is_recurring: formData.is_recurring,
+  };
+
+  const translatingAdornment = isTranslating
+    ? { endAdornment: <CircularProgress size={16} /> }
+    : undefined;
+
+  return (
+    <Dialog open={open} onClose={saving ? undefined : onClose} maxWidth="lg" fullWidth sx={sx}>
+      <DialogTitle sx={{ fontWeight: 700 }}>
+        {isEditing ? 'Edit Event / 编辑活动' : 'Add Event / 添加活动'}
+      </DialogTitle>
+      <DialogContent dividers>
+        <Box sx={{ display: 'flex', gap: 3, flexDirection: { xs: 'column', md: 'row' } }}>
+          {/* Form column */}
+          <Box sx={{ flex: 1.3, minWidth: 0 }}>
+            <Stepper activeStep={activeStep} sx={{ mb: 3 }}>
+              {STEPS.map(label => (
+                <Step key={label}><StepLabel>{label}</StepLabel></Step>
+              ))}
+            </Stepper>
+
+            {activeStep === 0 && (
+              <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr' }, gap: 2 }}>
+                <TextField
+                  label="Event Name / 活动名称"
+                  value={formData.name}
+                  onChange={handleChange('name')}
+                  onKeyDown={handleFieldKeyDown}
+                  onBlur={handleTranslationBlur}
+                  name="name"
+                  required
+                  error={nameMissing}
+                  helperText={nameMissing ? 'Required / 必填' : ' '}
+                />
+                <TextField
+                  label="Chinese Name / 中文名称"
+                  value={formData.chinese_name}
+                  onChange={handleChange('chinese_name')}
+                  onKeyDown={handleFieldKeyDown}
+                  onBlur={handleTranslationBlur}
+                  name="chinese_name"
+                  helperText="Press Tab to auto-fill / 按 Tab 自动填充"
+                  InputProps={translatingAdornment}
+                />
+                <TextField
+                  type="date"
+                  label="Date / 日期"
+                  value={formData.date}
+                  onChange={handleChange('date')}
+                  required
+                  error={dateMissing}
+                  helperText={dateMissing ? 'Required / 必填' : ' '}
+                  InputLabelProps={{ shrink: true }}
+                />
+                <TextField
+                  type="time"
+                  label="Time / 时间"
+                  value={to24Hour(formData.time)}
+                  onChange={(e) => setField('time', to12Hour(e.target.value))}
+                  InputLabelProps={{ shrink: true }}
+                  helperText={formData.time && !to24Hour(formData.time)
+                    ? `Current value "${formData.time}" — pick a time to replace it`
+                    : ' '}
+                />
+                <TextField
+                  label="Location / 地点"
+                  value={formData.location}
+                  onChange={handleChange('location')}
+                  onKeyDown={handleFieldKeyDown}
+                  onBlur={handleTranslationBlur}
+                  name="location"
+                />
+                <TextField
+                  label="Chinese Location / 中文地点"
+                  value={formData.chinese_location}
+                  onChange={handleChange('chinese_location')}
+                  onKeyDown={handleFieldKeyDown}
+                  onBlur={handleTranslationBlur}
+                  name="chinese_location"
+                  InputProps={translatingAdornment}
+                />
+              </Box>
+            )}
+
+            {activeStep === 1 && (
+              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+                <TextField
+                  label="Description / 描述"
+                  value={formData.description}
+                  onChange={handleChange('description')}
+                  onKeyDown={handleFieldKeyDown}
+                  onBlur={handleTranslationBlur}
+                  name="description"
+                  multiline
+                  rows={3}
+                />
+                <TextField
+                  label="Chinese Description / 中文描述"
+                  value={formData.chinese_description}
+                  onChange={handleChange('chinese_description')}
+                  onKeyDown={handleFieldKeyDown}
+                  onBlur={handleTranslationBlur}
+                  name="chinese_description"
+                  multiline
+                  rows={3}
+                  InputProps={translatingAdornment}
+                />
+                <Box sx={{ display: 'flex', gap: 2, alignItems: 'center', flexWrap: 'wrap' }}>
+                  <input
+                    type="file"
+                    accept="image/*"
+                    hidden
+                    ref={imageInputRef}
+                    onChange={(e) => uploadFile(e, 'image', setUploading)}
+                  />
+                  <Button
+                    variant="outlined"
+                    startIcon={uploading ? <CircularProgress size={16} /> : <CloudUploadIcon />}
+                    onClick={() => imageInputRef.current?.click()}
+                    disabled={uploading}
+                    sx={{ textTransform: 'none', borderRadius: '99px' }}
+                  >
+                    {formData.image ? 'Replace Image / 更换图片' : 'Upload Image / 上传图片'}
+                  </Button>
+                  {formData.image && (
+                    <>
+                      <Box component="img" src={formData.image} alt="Event" sx={{ height: 56, borderRadius: 1 }} />
+                      <Button size="small" color="error" onClick={() => setField('image', '')} sx={{ textTransform: 'none' }}>
+                        Remove / 移除
+                      </Button>
+                    </>
+                  )}
+                </Box>
+                <TextField
+                  label="Signup Link / 报名链接"
+                  value={formData.signup_link}
+                  onChange={handleChange('signup_link')}
+                  onKeyDown={handleFieldKeyDown}
+                  name="signup_link"
+                  error={signupLinkInvalid}
+                  helperText={signupLinkInvalid ? 'Must start with http:// or https:// / 链接格式错误' : ' '}
+                />
+                <TextField
+                  select
+                  label="Event Type / 活动类型"
+                  value={formData.event_type}
+                  onChange={handleChange('event_type')}
+                >
+                  <MenuItem value="standard">Standard / 标准</MenuItem>
+                  <MenuItem value="heylo">Heylo</MenuItem>
+                  <MenuItem value="race">Race / 比赛</MenuItem>
+                </TextField>
+                {formData.event_type === 'heylo' && (
+                  <TextField
+                    label="Heylo Embed / Heylo 嵌入代码"
+                    value={formData.heylo_embed}
+                    onChange={handleChange('heylo_embed')}
+                    multiline
+                    rows={2}
+                  />
+                )}
+                <Box sx={{ display: 'flex', gap: 2, alignItems: 'center', flexWrap: 'wrap' }}>
+                  <input
+                    type="file"
+                    accept="image/*"
+                    hidden
+                    ref={qrInputRef}
+                    onChange={(e) => uploadFile(e, 'wechat_qr_code', setUploadingQr)}
+                  />
+                  <Button
+                    variant="outlined"
+                    startIcon={uploadingQr ? <CircularProgress size={16} /> : <CloudUploadIcon />}
+                    onClick={() => qrInputRef.current?.click()}
+                    disabled={uploadingQr}
+                    sx={{ textTransform: 'none', borderRadius: '99px', borderColor: '#07C160', color: '#07C160' }}
+                  >
+                    {formData.wechat_qr_code ? 'Replace WeChat QR / 更换群二维码' : 'WeChat Group QR / 微信群二维码'}
+                  </Button>
+                  {formData.wechat_qr_code && (
+                    <>
+                      <Box component="img" src={formData.wechat_qr_code} alt="WeChat QR" sx={{ height: 56, borderRadius: 1 }} />
+                      <Button size="small" color="error" onClick={() => setField('wechat_qr_code', '')} sx={{ textTransform: 'none' }}>
+                        Remove / 移除
+                      </Button>
+                    </>
+                  )}
+                </Box>
+              </Box>
+            )}
+
+            {activeStep === 2 && (
+              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+                <TextField
+                  select
+                  label="Status / 状态"
+                  value={formData.status}
+                  onChange={handleChange('status')}
+                >
+                  <MenuItem value="Upcoming">Upcoming / 即将举行</MenuItem>
+                  <MenuItem value="Past">Past / 已结束</MenuItem>
+                  <MenuItem value="Cancelled">Cancelled / 已取消</MenuItem>
+                </TextField>
+                <FormControlLabel
+                  control={
+                    <Switch
+                      checked={formData.is_highlight}
+                      onChange={(e) => setField('is_highlight', e.target.checked)}
+                    />
+                  }
+                  label="Featured highlight / 精选回忆"
+                />
+
+                <Box sx={{ p: 2, border: '1px solid', borderColor: 'divider', borderRadius: 2 }}>
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
+                    <RepeatIcon color="action" />
+                    <Typography variant="subtitle2" fontWeight={600}>
+                      Recurring Event / 重复活动
+                    </Typography>
+                  </Box>
+                  <FormControlLabel
+                    control={
+                      <Switch
+                        checked={formData.is_recurring}
+                        onChange={(e) => setField('is_recurring', e.target.checked)}
+                      />
+                    }
+                    label="Enable recurrence / 启用重复"
+                  />
+                  {formData.is_recurring && (
+                    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 2 }}>
+                      <TextField
+                        select
+                        label="Recurrence Type / 重复类型"
+                        value={formData.recurrence_type}
+                        onChange={handleChange('recurrence_type')}
+                        fullWidth
+                      >
+                        <MenuItem value="weekly">Weekly / 每周</MenuItem>
+                        <MenuItem value="biweekly">Biweekly / 每两周</MenuItem>
+                        <MenuItem value="monthly">Monthly / 每月</MenuItem>
+                        <MenuItem value="yearly">Yearly / 每年</MenuItem>
+                      </TextField>
+                      {(formData.recurrence_type === 'weekly' || formData.recurrence_type === 'biweekly') && (
+                        <Box>
+                          <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+                            Days of Week / 每周哪几天
+                          </Typography>
+                          <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap' }}>
+                            {['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'].map((day, index) => {
+                              const days = formData.days_of_week ? formData.days_of_week.split(',').map(Number) : [];
+                              const isSelected = days.includes(index);
+                              return (
+                                <Chip
+                                  key={day}
+                                  label={day}
+                                  size="small"
+                                  color={isSelected ? 'primary' : 'default'}
+                                  onClick={() => {
+                                    const newDays = isSelected
+                                      ? days.filter(d => d !== index)
+                                      : [...days, index].sort();
+                                    setField('days_of_week', newDays.join(','));
+                                  }}
+                                  sx={{ cursor: 'pointer' }}
+                                />
+                              );
+                            })}
+                          </Box>
+                        </Box>
+                      )}
+                      {formData.recurrence_type === 'monthly' && (
+                        <Box sx={{ display: 'flex', gap: 2 }}>
+                          <TextField
+                            type="number"
+                            label="Day of Month / 每月几号"
+                            value={formData.day_of_month}
+                            onChange={handleChange('day_of_month')}
+                            inputProps={{ min: 1, max: 31 }}
+                            sx={{ flex: 1 }}
+                            helperText="1-31 (or leave empty for week-based)"
+                          />
+                          <TextField
+                            select
+                            label="Week of Month / 每月第几周"
+                            value={formData.week_of_month}
+                            onChange={handleChange('week_of_month')}
+                            sx={{ flex: 1 }}
+                          >
+                            <MenuItem value="">None</MenuItem>
+                            <MenuItem value="1">1st / 第一周</MenuItem>
+                            <MenuItem value="2">2nd / 第二周</MenuItem>
+                            <MenuItem value="3">3rd / 第三周</MenuItem>
+                            <MenuItem value="4">4th / 第四周</MenuItem>
+                            <MenuItem value="5">Last / 最后一周</MenuItem>
+                          </TextField>
+                        </Box>
+                      )}
+                      {formData.recurrence_type === 'yearly' && (
+                        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+                          <TextField
+                            select
+                            label="Month / 月份"
+                            value={formData.month_of_year}
+                            onChange={handleChange('month_of_year')}
+                            fullWidth
+                          >
+                            {['January / 一月', 'February / 二月', 'March / 三月', 'April / 四月',
+                              'May / 五月', 'June / 六月', 'July / 七月', 'August / 八月',
+                              'September / 九月', 'October / 十月', 'November / 十一月', 'December / 十二月',
+                            ].map((label, i) => (
+                              <MenuItem key={label} value={String(i + 1)}>{label}</MenuItem>
+                            ))}
+                          </TextField>
+                          <Box sx={{ display: 'flex', gap: 2 }}>
+                            <TextField
+                              select
+                              label="Week / 第几周"
+                              value={formData.week_of_month}
+                              onChange={handleChange('week_of_month')}
+                              sx={{ flex: 1 }}
+                            >
+                              <MenuItem value="1">1st / 第一</MenuItem>
+                              <MenuItem value="2">2nd / 第二</MenuItem>
+                              <MenuItem value="3">3rd / 第三</MenuItem>
+                              <MenuItem value="4">4th / 第四</MenuItem>
+                              <MenuItem value="5">Last / 最后</MenuItem>
+                            </TextField>
+                            <TextField
+                              select
+                              label="Day / 星期几"
+                              value={formData.days_of_week}
+                              onChange={handleChange('days_of_week')}
+                              sx={{ flex: 1 }}
+                            >
+                              <MenuItem value="0">Sunday / 周日</MenuItem>
+                              <MenuItem value="1">Monday / 周一</MenuItem>
+                              <MenuItem value="2">Tuesday / 周二</MenuItem>
+                              <MenuItem value="3">Wednesday / 周三</MenuItem>
+                              <MenuItem value="4">Thursday / 周四</MenuItem>
+                              <MenuItem value="5">Friday / 周五</MenuItem>
+                              <MenuItem value="6">Saturday / 周六</MenuItem>
+                            </TextField>
+                          </Box>
+                        </Box>
+                      )}
+                      <TextField
+                        type="date"
+                        label="End Date (optional) / 结束日期"
+                        value={formData.recurrence_end_date}
+                        onChange={handleChange('recurrence_end_date')}
+                        fullWidth
+                        InputLabelProps={{ shrink: true }}
+                        helperText="Leave empty for no end date / 留空表示无结束日期"
+                      />
+                    </Box>
+                  )}
+                </Box>
+              </Box>
+            )}
+          </Box>
+
+          {/* Live preview column */}
+          <Box sx={{ flex: 1, minWidth: 0, display: { xs: 'none', md: 'block' } }}>
+            <Typography
+              variant="caption"
+              sx={{ fontWeight: 700, letterSpacing: '0.06em', color: MUTED, display: 'block', mb: 1.5 }}
+            >
+              LIVE PREVIEW — WHAT MEMBERS WILL SEE 会员所见预览
+            </Typography>
+            <EventCard event={previewEvent} interactive={false} showEngagement={false} showDescription />
+          </Box>
+        </Box>
+      </DialogContent>
+      <DialogActions sx={{ px: 3, py: 2 }}>
+        <Button onClick={onClose} disabled={saving} sx={{ textTransform: 'none', color: MUTED }}>
+          Cancel / 取消
+        </Button>
+        <Box sx={{ flex: 1 }} />
+        {activeStep > 0 && (
+          <Button onClick={() => setActiveStep(s => s - 1)} disabled={saving} sx={{ textTransform: 'none' }}>
+            Back / 上一步
+          </Button>
+        )}
+        {activeStep < STEPS.length - 1 && (
+          <Button
+            variant="outlined"
+            onClick={handleNext}
+            sx={{ textTransform: 'none', borderRadius: '99px', borderColor: ORANGE, color: ORANGE }}
+          >
+            Continue / 下一步
+          </Button>
+        )}
+        <Button
+          variant="contained"
+          disableElevation
+          onClick={handleSave}
+          disabled={saving || uploading || uploadingQr || !basicsValid}
+          sx={{
+            textTransform: 'none',
+            borderRadius: '99px',
+            fontWeight: 600,
+            backgroundColor: ORANGE,
+            '&:hover': { backgroundColor: ORANGE_DARK },
+          }}
+        >
+          {saving ? <CircularProgress size={20} sx={{ color: 'white' }} /> : (isEditing ? 'Save Event / 保存' : 'Create Event / 创建')}
+        </Button>
+      </DialogActions>
+      <Snackbar
+        open={snackbar.open}
+        autoHideDuration={5000}
+        onClose={() => setSnackbar(prev => ({ ...prev, open: false }))}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert severity={snackbar.severity} onClose={() => setSnackbar(prev => ({ ...prev, open: false }))}>
+          {snackbar.message}
+        </Alert>
+      </Snackbar>
+    </Dialog>
+  );
+}

--- a/ProjectCode/client/src/components/EventComposer.test.js
+++ b/ProjectCode/client/src/components/EventComposer.test.js
@@ -1,0 +1,224 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import EventComposer from './EventComposer';
+import {
+  createEvent, updateEvent, getEventWithRecurrence,
+  createEventRecurrence, updateEventRecurrence, deleteEventRecurrence,
+} from '../api';
+import { uploadImage } from '../api/homepageSections';
+
+jest.mock('./EventCard', () => ({ event }) => (
+  <div data-testid="card-preview">{event.name}</div>
+));
+jest.mock('../context', () => ({ useAuth: jest.fn() }));
+jest.mock('../hooks', () => ({
+  useAutoFillOnTab: () => () => {},
+  useTranslationAutoFill: () => ({
+    handleKeyDown: () => {},
+    handleBlur: () => {},
+    translations: {},
+    isTranslating: false,
+  }),
+}));
+jest.mock('../api', () => ({
+  createEvent: jest.fn(),
+  updateEvent: jest.fn(),
+  getEventWithRecurrence: jest.fn(),
+  createEventRecurrence: jest.fn(),
+  updateEventRecurrence: jest.fn(),
+  deleteEventRecurrence: jest.fn(),
+}));
+jest.mock('../api/homepageSections', () => ({ uploadImage: jest.fn() }));
+
+const { useAuth } = require('../context');
+
+describe('EventComposer', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useAuth.mockReturnValue({ currentUser: { uid: 'admin-1' } });
+    createEvent.mockResolvedValue({ id: 42 });
+    updateEvent.mockResolvedValue({ id: 7 });
+    createEventRecurrence.mockResolvedValue({});
+    updateEventRecurrence.mockResolvedValue({});
+    deleteEventRecurrence.mockResolvedValue({});
+    uploadImage.mockResolvedValue({ url: 'https://s3/img.jpg' });
+  });
+
+  test('create mode defaults date to today and shows live preview', () => {
+    render(<EventComposer open onClose={jest.fn()} />);
+    const today = new Date().toISOString().split('T')[0];
+    expect(screen.getByLabelText(/Date \/ 日期/)).toHaveValue(today);
+    expect(screen.getByTestId('card-preview')).toHaveTextContent('Event name');
+    expect(getEventWithRecurrence).not.toHaveBeenCalled();
+  });
+
+  test('Continue is gated on name; error shows inline', () => {
+    render(<EventComposer open onClose={jest.fn()} />);
+    fireEvent.click(screen.getByRole('button', { name: /Continue/ }));
+    expect(screen.getByText('Required / 必填')).toBeInTheDocument();
+    // Still on step 1
+    expect(screen.getByLabelText(/Event Name/)).toBeInTheDocument();
+  });
+
+  test('stepping through reaches Details and Publish', () => {
+    render(<EventComposer open onClose={jest.fn()} />);
+    fireEvent.change(screen.getByLabelText(/Event Name/), { target: { value: 'Fun Run' } });
+    fireEvent.click(screen.getByRole('button', { name: /Continue/ }));
+    expect(screen.getByLabelText(/Description \/ 描述/)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /Continue/ }));
+    expect(screen.getByLabelText(/Status \/ 状态/)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /Back/ }));
+    expect(screen.getByLabelText(/Description \/ 描述/)).toBeInTheDocument();
+  });
+
+  test('creates event with empty strings nulled and calls onSaved + onClose', async () => {
+    const onClose = jest.fn();
+    const onSaved = jest.fn();
+    render(<EventComposer open onClose={onClose} onSaved={onSaved} />);
+    fireEvent.change(screen.getByLabelText(/Event Name/), { target: { value: 'Fun Run' } });
+    fireEvent.click(screen.getByRole('button', { name: /Create Event/ }));
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+    const [payload, uid] = createEvent.mock.calls[0];
+    expect(uid).toBe('admin-1');
+    expect(payload.name).toBe('Fun Run');
+    expect(payload.chinese_name).toBeNull();
+    expect(payload.status).toBe('Upcoming');
+    expect(payload.is_recurring).toBeUndefined();
+    expect(createEventRecurrence).not.toHaveBeenCalled();
+    expect(onSaved).toHaveBeenCalledWith({ id: 42 });
+  });
+
+  test('displays stored 12-hour time in the time picker', () => {
+    getEventWithRecurrence.mockResolvedValue(null);
+    render(<EventComposer open onClose={jest.fn()} />);
+    const time = screen.getByLabelText(/Time \/ 时间/);
+    fireEvent.change(time, { target: { value: '18:30' } });
+    expect(time).toHaveValue('18:30');
+  });
+
+  test('invalid signup link shows error and blocks save', async () => {
+    render(<EventComposer open onClose={jest.fn()} />);
+    fireEvent.change(screen.getByLabelText(/Event Name/), { target: { value: 'Fun Run' } });
+    fireEvent.click(screen.getByRole('button', { name: /Continue/ }));
+    fireEvent.change(screen.getByLabelText(/Signup Link/), { target: { value: 'not-a-url' } });
+    expect(screen.getByText(/Must start with http/)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /Create Event/ }));
+    await waitFor(() => expect(screen.getByLabelText(/Signup Link/)).toBeInTheDocument());
+    expect(createEvent).not.toHaveBeenCalled();
+  });
+
+  test('image upload happens immediately on file select', async () => {
+    render(<EventComposer open onClose={jest.fn()} />);
+    fireEvent.change(screen.getByLabelText(/Event Name/), { target: { value: 'Fun Run' } });
+    fireEvent.click(screen.getByRole('button', { name: /Continue/ }));
+    const file = new File(['x'], 'photo.jpg', { type: 'image/jpeg' });
+    // MUI Dialog portals to document.body, so query the document
+    const input = document.querySelector('input[type="file"]');
+    fireEvent.change(input, { target: { files: [file] } });
+    await waitFor(() => expect(uploadImage).toHaveBeenCalledWith(file, 'admin-1'));
+    expect(await screen.findByText(/Replace Image/)).toBeInTheDocument();
+    expect(createEvent).not.toHaveBeenCalled();
+  });
+
+  test('rejects non-image and oversized files without uploading', async () => {
+    render(<EventComposer open onClose={jest.fn()} />);
+    fireEvent.change(screen.getByLabelText(/Event Name/), { target: { value: 'Fun Run' } });
+    fireEvent.click(screen.getByRole('button', { name: /Continue/ }));
+    const input = document.querySelector('input[type="file"]');
+    fireEvent.change(input, { target: { files: [new File(['x'], 'doc.pdf', { type: 'application/pdf' })] } });
+    expect(await screen.findByText(/Please select an image file/)).toBeInTheDocument();
+    const big = new File([new ArrayBuffer(6 * 1024 * 1024)], 'big.jpg', { type: 'image/jpeg' });
+    fireEvent.change(input, { target: { files: [big] } });
+    expect(await screen.findByText(/less than 5MB/)).toBeInTheDocument();
+    expect(uploadImage).not.toHaveBeenCalled();
+  });
+
+  test('edit mode re-fetches authoritative state and pre-fills recurrence', async () => {
+    getEventWithRecurrence.mockResolvedValue({
+      id: 7,
+      name: 'Saturday Long Run',
+      chinese_name: '周六长跑',
+      date: '2026-07-19',
+      time: '8:00 AM',
+      status: 'Upcoming',
+      is_highlight: false,
+      recurrence: { recurrence_type: 'weekly', days_of_week: '6', end_date: null },
+    });
+    render(<EventComposer open onClose={jest.fn()} event={{ id: 7, title: 'Stale Cache Name' }} />);
+    await waitFor(() =>
+      expect(screen.getByLabelText(/Event Name/)).toHaveValue('Saturday Long Run')
+    );
+    expect(getEventWithRecurrence).toHaveBeenCalledWith(7);
+    expect(screen.getByLabelText(/Time \/ 时间/)).toHaveValue('08:00');
+  });
+
+  test('edit save calls updateEvent and keeps existing recurrence rule updated', async () => {
+    getEventWithRecurrence.mockResolvedValue({
+      id: 7,
+      name: 'Saturday Long Run',
+      date: '2026-07-19',
+      status: 'Upcoming',
+      recurrence: { recurrence_type: 'weekly', days_of_week: '6' },
+    });
+    const onSaved = jest.fn();
+    render(<EventComposer open onClose={jest.fn()} event={{ id: 7 }} onSaved={onSaved} />);
+    await waitFor(() =>
+      expect(screen.getByLabelText(/Event Name/)).toHaveValue('Saturday Long Run')
+    );
+    fireEvent.click(screen.getByRole('button', { name: /Save Event/ }));
+    await waitFor(() => expect(onSaved).toHaveBeenCalled());
+    expect(updateEvent.mock.calls[0][0]).toBe(7);
+    expect(updateEventRecurrence).toHaveBeenCalledWith(
+      7,
+      expect.objectContaining({ recurrence_type: 'weekly', days_of_week: '6' }),
+      'admin-1'
+    );
+  });
+
+  test('disabling recurrence on an event that had a rule deletes the rule', async () => {
+    getEventWithRecurrence.mockResolvedValue({
+      id: 7,
+      name: 'Saturday Long Run',
+      date: '2026-07-19',
+      status: 'Upcoming',
+      recurrence: { recurrence_type: 'weekly', days_of_week: '6' },
+    });
+    render(<EventComposer open onClose={jest.fn()} event={{ id: 7 }} />);
+    await waitFor(() =>
+      expect(screen.getByLabelText(/Event Name/)).toHaveValue('Saturday Long Run')
+    );
+    // Go to Publish and turn recurrence off
+    fireEvent.click(screen.getByRole('button', { name: /Continue/ }));
+    fireEvent.click(screen.getByRole('button', { name: /Continue/ }));
+    fireEvent.click(screen.getByLabelText(/Enable recurrence/));
+    fireEvent.click(screen.getByRole('button', { name: /Save Event/ }));
+    await waitFor(() => expect(deleteEventRecurrence).toHaveBeenCalledWith(7, 'admin-1'));
+    expect(updateEventRecurrence).not.toHaveBeenCalled();
+  });
+
+  test('save failure shows error snackbar and keeps dialog open', async () => {
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    createEvent.mockRejectedValue(new Error('boom'));
+    const onClose = jest.fn();
+    render(<EventComposer open onClose={onClose} />);
+    fireEvent.change(screen.getByLabelText(/Event Name/), { target: { value: 'Fun Run' } });
+    fireEvent.click(screen.getByRole('button', { name: /Create Event/ }));
+    expect(await screen.findByText(/Error: boom/)).toBeInTheDocument();
+    expect(onClose).not.toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+
+  test('create recurrence falls back to update on 400 (stale state)', async () => {
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const err = new Error('exists');
+    err.status = 400;
+    createEventRecurrence.mockRejectedValue(err);
+    render(<EventComposer open onClose={jest.fn()} />);
+    fireEvent.change(screen.getByLabelText(/Event Name/), { target: { value: 'Fun Run' } });
+    fireEvent.click(screen.getByRole('button', { name: /Continue/ }));
+    fireEvent.click(screen.getByRole('button', { name: /Continue/ }));
+    fireEvent.click(screen.getByLabelText(/Enable recurrence/));
+    fireEvent.click(screen.getByRole('button', { name: /Create Event/ }));
+    await waitFor(() => expect(updateEventRecurrence).toHaveBeenCalledWith(42, expect.anything(), 'admin-1'));
+    consoleSpy.mockRestore();
+  });
+});

--- a/ProjectCode/client/src/components/EventDetailModal.js
+++ b/ProjectCode/client/src/components/EventDetailModal.js
@@ -10,30 +10,26 @@ import {
   Typography,
   Divider,
   CircularProgress,
-  TextField,
   IconButton,
   Snackbar,
   Alert,
-  Tooltip,
-  MenuItem,
-  FormControlLabel,
-  Switch
+  Tooltip
 } from '@mui/material';
 import CollectionsIcon from '@mui/icons-material/Collections';
 import EditIcon from '@mui/icons-material/Edit';
-import SaveIcon from '@mui/icons-material/Save';
-import CloseIcon from '@mui/icons-material/Close';
 import ShareIcon from '@mui/icons-material/Share';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import { useAuth } from '../context/AuthContext';
 import { useAdmin } from '../context/AdminContext';
 import ImagePositionEditor from './ImagePositionEditor';
-import { getEventEngagement, updateEvent, getEventById } from '../api';
+import EventComposer from './EventComposer';
+import { getEventEngagement, getEventById } from '../api';
 import LikeButton from './LikeButton';
 import ReactionPicker from './ReactionPicker';
 import CommentSection from './CommentSection';
 import AdminModerationPanel from './AdminModerationPanel';
 import EventGalleryPreview from './EventGalleryPreview';
+import { FALLBACK_EVENT_IMAGE } from '../theme/tokens';
 
 export default function EventDetailModal({ event, onClose, onEventUpdate }) {
   const navigate = useNavigate();
@@ -43,9 +39,7 @@ export default function EventDetailModal({ event, onClose, onEventUpdate }) {
   const [loading, setLoading] = useState(true);
   const [shareSnackbar, setShareSnackbar] = useState(false);
   const [errorSnackbar, setErrorSnackbar] = useState({ open: false, message: '' });
-  const [editing, setEditing] = useState(false);
-  const [editForm, setEditForm] = useState(null);
-  const [saving, setSaving] = useState(false);
+  const [composerOpen, setComposerOpen] = useState(false);
 
   useEffect(() => {
     if (event?.id) {
@@ -75,7 +69,7 @@ export default function EventDetailModal({ event, onClose, onEventUpdate }) {
 
   const handleImageError = (e) => {
     console.error('Image failed to load:', e.target.src);
-    e.target.src = '/images/2025/20250517_bk_half.jpg';
+    e.target.src = FALLBACK_EVENT_IMAGE;
   };
 
   const handleLikeUpdate = (result) => {
@@ -96,99 +90,27 @@ export default function EventDetailModal({ event, onClose, onEventUpdate }) {
     }
   };
 
-  const handleEditOpen = async () => {
-    // Fetch authoritative server state. The `event` prop from
-    // CalendarPage/HighlightsPage is a transformed projection that drops
-    // fields like is_highlight, so pre-filling from the prop could silently
-    // flip flags off when admin saves a no-op edit.
-    setEditing(true);
-    let fresh = event;
+  const handleComposerSaved = async (saved) => {
+    if (!onEventUpdate) return;
+    // Re-fetch authoritative server state — the composer's save response may
+    // not include every field the parent page caches.
+    let updated = saved;
     try {
-      if (event?.id) fresh = await getEventById(event.id);
+      if (event?.id) updated = await getEventById(event.id);
     } catch (err) {
-      console.error('Failed to load event for edit, falling back to prop:', err);
+      console.error('Failed to refresh event after save, using save response:', err);
     }
-    setEditForm({
-      name: fresh.name || fresh.title || '',
-      chinese_name: fresh.chinese_name ?? fresh.chineseName ?? fresh.chineseTitle ?? '',
-      date: fresh.date || '',
-      time: fresh.time || '',
-      location: fresh.location || '',
-      chinese_location: fresh.chinese_location ?? fresh.chineseLocation ?? '',
-      description: fresh.description || '',
-      chinese_description: fresh.chinese_description ?? fresh.chineseDescription ?? '',
-      image: fresh.image || '',
-      signup_link: fresh.signup_link ?? fresh.signupLink ?? '',
-      wechat_qr_code: fresh.wechat_qr_code ?? fresh.wechatQrCode ?? '',
-      status: fresh.status === 'Highlight' ? 'Past' : (fresh.status || 'Upcoming'),
-      is_highlight: fresh.is_highlight === true || fresh.status === 'Highlight',
-      event_type: fresh.event_type || fresh.eventType || 'standard',
+    // Mirror to camelCase so pages that cache that shape (CalendarPage,
+    // HighlightsPage) re-render with the new values immediately.
+    onEventUpdate({
+      ...event,
+      ...updated,
+      chineseName: updated.chinese_name,
+      chineseLocation: updated.chinese_location,
+      chineseDescription: updated.chinese_description,
+      signupLink: updated.signup_link,
+      wechatQrCode: updated.wechat_qr_code,
     });
-  };
-
-  const handleEditCancel = () => {
-    setEditing(false);
-    setEditForm(null);
-  };
-
-  const handleEditFieldChange = (field) => (e) => {
-    const value = e?.target?.type === 'checkbox' ? e.target.checked : e?.target?.value;
-    setEditForm(prev => ({ ...prev, [field]: value }));
-  };
-
-  const handleEditSave = async () => {
-    if (!editForm) return;
-    const trimmedName = (editForm.name || '').trim();
-    if (!trimmedName) {
-      setErrorSnackbar({ open: true, message: 'Name cannot be empty / 名称不能为空' });
-      return;
-    }
-    if (!editForm.date) {
-      setErrorSnackbar({ open: true, message: 'Date is required / 日期为必填项' });
-      return;
-    }
-    setSaving(true);
-    try {
-      // Send every field so admins can clear values too. Empty strings → null
-      // so the server stores NULL instead of "".
-      const payload = {
-        name: trimmedName,
-        chinese_name: editForm.chinese_name?.trim() || null,
-        date: editForm.date,
-        time: editForm.time?.trim() || null,
-        location: editForm.location?.trim() || null,
-        chinese_location: editForm.chinese_location?.trim() || null,
-        description: editForm.description ?? null,
-        chinese_description: editForm.chinese_description ?? null,
-        image: editForm.image?.trim() || null,
-        signup_link: editForm.signup_link?.trim() || null,
-        wechat_qr_code: editForm.wechat_qr_code?.trim() || null,
-        status: editForm.status,
-        is_highlight: !!editForm.is_highlight,
-        event_type: editForm.event_type || 'standard',
-      };
-      const updated = await updateEvent(event.id, payload, currentUser.uid);
-      setEditing(false);
-      setEditForm(null);
-      if (onEventUpdate) {
-        // Mirror to camelCase so pages that cache that shape (CalendarPage,
-        // HighlightsPage) re-render with the new values immediately.
-        onEventUpdate({
-          ...event,
-          ...updated,
-          chineseName: updated.chinese_name,
-          chineseLocation: updated.chinese_location,
-          chineseDescription: updated.chinese_description,
-          signupLink: updated.signup_link,
-          wechatQrCode: updated.wechat_qr_code,
-        });
-      }
-    } catch (error) {
-      console.error('Error updating event:', error);
-      setErrorSnackbar({ open: true, message: 'Failed to save event / 保存活动失败' });
-    } finally {
-      setSaving(false);
-    }
   };
 
   const handleSettingsUpdate = (settings) => {
@@ -255,7 +177,7 @@ export default function EventDetailModal({ event, onClose, onEventUpdate }) {
             <CardMedia
               component="img"
               height="300"
-              image={event.image}
+              image={event.image || FALLBACK_EVENT_IMAGE}
               alt={eventTitle}
               onError={handleImageError}
               sx={{
@@ -288,165 +210,7 @@ export default function EventDetailModal({ event, onClose, onEventUpdate }) {
           )}
         </Box>
         <CardContent>
-          {editing && editForm ? (
-            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5, mb: 2 }}>
-              <Box sx={{ display: 'flex', gap: 1 }}>
-                <TextField
-                  label="Event Name / 活动名称"
-                  value={editForm.name}
-                  onChange={handleEditFieldChange('name')}
-                  fullWidth
-                  size="small"
-                  required
-                />
-                <TextField
-                  label="Chinese Name / 中文名称"
-                  value={editForm.chinese_name}
-                  onChange={handleEditFieldChange('chinese_name')}
-                  fullWidth
-                  size="small"
-                />
-              </Box>
-              <Box sx={{ display: 'flex', gap: 1 }}>
-                <TextField
-                  label="Date / 日期"
-                  type="date"
-                  value={editForm.date}
-                  onChange={handleEditFieldChange('date')}
-                  size="small"
-                  InputLabelProps={{ shrink: true }}
-                  required
-                  sx={{ flex: 1 }}
-                />
-                <TextField
-                  label="Time / 时间"
-                  value={editForm.time}
-                  onChange={handleEditFieldChange('time')}
-                  size="small"
-                  placeholder="e.g. 8:00 AM"
-                  sx={{ flex: 1 }}
-                />
-              </Box>
-              <Box sx={{ display: 'flex', gap: 1 }}>
-                <TextField
-                  label="Location / 地点"
-                  value={editForm.location}
-                  onChange={handleEditFieldChange('location')}
-                  size="small"
-                  fullWidth
-                />
-                <TextField
-                  label="Chinese Location / 中文地点"
-                  value={editForm.chinese_location}
-                  onChange={handleEditFieldChange('chinese_location')}
-                  size="small"
-                  fullWidth
-                />
-              </Box>
-              <TextField
-                label="Image URL / 图片链接"
-                value={editForm.image}
-                onChange={handleEditFieldChange('image')}
-                size="small"
-                fullWidth
-                placeholder="https://… or /path/to/image.jpg"
-              />
-              <TextField
-                label="Signup Link / 报名链接"
-                value={editForm.signup_link}
-                onChange={handleEditFieldChange('signup_link')}
-                size="small"
-                fullWidth
-              />
-              <TextField
-                label="WeChat QR Code URL / 微信二维码"
-                value={editForm.wechat_qr_code}
-                onChange={handleEditFieldChange('wechat_qr_code')}
-                size="small"
-                fullWidth
-              />
-              <TextField
-                label="Description / 描述"
-                value={editForm.description}
-                onChange={handleEditFieldChange('description')}
-                multiline
-                minRows={2}
-                size="small"
-                fullWidth
-              />
-              <TextField
-                label="Chinese Description / 中文描述"
-                value={editForm.chinese_description}
-                onChange={handleEditFieldChange('chinese_description')}
-                multiline
-                minRows={2}
-                size="small"
-                fullWidth
-              />
-              <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
-                <TextField
-                  select
-                  label="Status / 状态"
-                  value={editForm.status}
-                  onChange={handleEditFieldChange('status')}
-                  size="small"
-                  sx={{ flex: 1 }}
-                  // Menu must portal above this modal's zIndex: 9999 overlay
-                  SelectProps={{ MenuProps: { sx: { zIndex: 10000 } } }}
-                >
-                  <MenuItem value="Upcoming">Upcoming / 即将举行</MenuItem>
-                  <MenuItem value="Past">Past / 已结束</MenuItem>
-                  <MenuItem value="Cancelled">Cancelled / 已取消</MenuItem>
-                </TextField>
-                <TextField
-                  select
-                  label="Type / 类型"
-                  value={editForm.event_type}
-                  onChange={handleEditFieldChange('event_type')}
-                  size="small"
-                  sx={{ flex: 1 }}
-                  SelectProps={{ MenuProps: { sx: { zIndex: 10000 } } }}
-                >
-                  <MenuItem value="standard">Standard</MenuItem>
-                  <MenuItem value="heylo">Heylo</MenuItem>
-                  <MenuItem value="race">Race</MenuItem>
-                </TextField>
-                <FormControlLabel
-                  control={
-                    <Switch
-                      checked={!!editForm.is_highlight}
-                      onChange={(e) =>
-                        setEditForm(prev => ({ ...prev, is_highlight: e.target.checked }))
-                      }
-                      color="warning"
-                    />
-                  }
-                  label="★ Highlight"
-                />
-              </Box>
-              <Box sx={{ display: 'flex', gap: 1, justifyContent: 'flex-end' }}>
-                <Button
-                  variant="outlined"
-                  onClick={handleEditCancel}
-                  disabled={saving}
-                  startIcon={<CloseIcon />}
-                  sx={{ borderColor: '#f44336', color: '#f44336' }}
-                >
-                  Cancel / 取消
-                </Button>
-                <Button
-                  variant="contained"
-                  onClick={handleEditSave}
-                  disabled={saving}
-                  startIcon={saving ? <CircularProgress size={16} color="inherit" /> : <SaveIcon />}
-                  sx={{ backgroundColor: '#4caf50', '&:hover': { backgroundColor: '#43a047' } }}
-                >
-                  Save / 保存
-                </Button>
-              </Box>
-            </Box>
-          ) : (
-            <>
+          <>
               <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
                 <Typography variant="h5" gutterBottom sx={{ mb: 0, flex: 1, minWidth: 0 }}>
                   {eventTitle}
@@ -454,7 +218,7 @@ export default function EventDetailModal({ event, onClose, onEventUpdate }) {
                 <Box sx={{ display: 'flex', gap: 0.5 }}>
                   {adminModeEnabled && event.id && (
                     <Tooltip title="Edit event / 编辑活动">
-                      <IconButton onClick={handleEditOpen} sx={{ color: '#FFB84D' }}>
+                      <IconButton onClick={() => setComposerOpen(true)} sx={{ color: '#FFB84D' }}>
                         <EditIcon />
                       </IconButton>
                     </Tooltip>
@@ -548,8 +312,7 @@ export default function EventDetailModal({ event, onClose, onEventUpdate }) {
                   {event.chineseDescription || event.chinese_description}
                 </Typography>
               )}
-            </>
-          )}
+          </>
 
           <Divider sx={{ my: 2 }} />
 
@@ -657,6 +420,16 @@ export default function EventDetailModal({ event, onClose, onEventUpdate }) {
             </Button>
           </Box>
         </CardContent>
+        {/* Rendered inside the Card so click events bubbling through the
+            portal are stopped before the overlay's onClick={onClose}. The
+            composer must stack above this modal's zIndex: 9999 overlay. */}
+        <EventComposer
+          open={composerOpen}
+          onClose={() => setComposerOpen(false)}
+          event={event}
+          onSaved={handleComposerSaved}
+          sx={{ zIndex: 10000 }}
+        />
       </Card>
       <Snackbar
         open={shareSnackbar}

--- a/ProjectCode/client/src/components/EventDetailModal.test.js
+++ b/ProjectCode/client/src/components/EventDetailModal.test.js
@@ -1,12 +1,11 @@
-import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import EventDetailModal from './EventDetailModal';
-import { getEventEngagement, updateEvent, getEventById } from '../api';
+import { getEventEngagement, getEventById } from '../api';
 import { useAuth } from '../context/AuthContext';
 import { useAdmin } from '../context/AdminContext';
 
 jest.mock('../api', () => ({
   getEventEngagement: jest.fn(),
-  updateEvent: jest.fn(),
   getEventById: jest.fn(),
 }));
 jest.mock('../context/AuthContext', () => ({ useAuth: jest.fn() }));
@@ -89,6 +88,30 @@ jest.mock('./ImagePositionEditor', () => (props) => {
     { 'data-testid': 'position-editor' },
     React.createElement('span', null, props.currentPosition),
     React.createElement('button', { onClick: () => props.onPositionSaved('5% 5%') }, 'saved-pos')
+  );
+});
+
+// EventComposer has its own test suite — stub it with save/close triggers.
+// Plain function in the factory (not jest.fn) so CRA's resetMocks:true
+// cannot wipe its implementation between tests.
+jest.mock('./EventComposer', () => (props) => {
+  const React = require('react');
+  if (!props.open) return null;
+  return React.createElement(
+    'div',
+    { 'data-testid': 'event-composer' },
+    `composer:${props.event?.id}:z${props.sx?.zIndex}`,
+    React.createElement(
+      'button',
+      {
+        onClick: () => {
+          // Mirror the real composer: onSaved with the saved event, then close
+          Promise.resolve(props.onSaved({ id: props.event?.id, name: 'Saved Name' })).then(props.onClose);
+        },
+      },
+      'composer-save'
+    ),
+    React.createElement('button', { onClick: props.onClose }, 'composer-close')
   );
 });
 
@@ -273,7 +296,7 @@ describe('EventDetailModal', () => {
     const img = screen.getByAltText('Spring Race');
     const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
     fireEvent.error(img);
-    expect(img).toHaveAttribute('src', '/images/2025/20250517_bk_half.jpg');
+    expect(img).toHaveAttribute('src', '/images/placeholder-event.jpg');
     consoleSpy.mockRestore();
     await waitFor(() => expect(getEventEngagement).toHaveBeenCalled());
   });
@@ -344,175 +367,75 @@ describe('EventDetailModal', () => {
       expect(screen.queryByTestId('like-button')).not.toBeInTheDocument();
     });
 
-    test('edit opens with fresh server data; legacy Highlight status maps to Past + flag', async () => {
+    test('edit pencil opens the composer with the event, stacked above the overlay', async () => {
       renderModal();
+      expect(screen.queryByTestId('event-composer')).not.toBeInTheDocument();
       fireEvent.click((await screen.findByTestId('EditIcon')).closest('button'));
 
-      await waitFor(() => expect(getEventById).toHaveBeenCalledWith(1));
-      expect(await screen.findByLabelText(/Event Name/)).toHaveValue('Server Name');
-      expect(screen.getByLabelText(/Chinese Name/)).toHaveValue('服务器名');
-      expect(screen.getByLabelText(/Date \/ 日期/)).toHaveValue('2026-04-02');
-      expect(screen.getByLabelText(/Time \/ 时间/)).toHaveValue('9:00 AM');
-      expect(screen.getByLabelText(/Image URL/)).toHaveValue('/img/server.jpg');
-      expect(screen.getByLabelText(/Signup Link/)).toHaveValue('https://server.example.com');
-      expect(screen.getByText('Past / 已结束')).toBeInTheDocument();
-      expect(screen.getByRole('checkbox')).toBeChecked(); // highlight switch
+      // The modal overlay uses zIndex 9999 — the composer dialog must stack above it
+      expect(await screen.findByTestId('event-composer')).toHaveTextContent('composer:1:z10000');
     });
 
-    test('falls back to the prop event when the fresh fetch fails', async () => {
-      const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-      getEventById.mockRejectedValue(new Error('404'));
-      renderModal();
-      fireEvent.click((await screen.findByTestId('EditIcon')).closest('button'));
-      expect(await screen.findByLabelText(/Event Name/)).toHaveValue('Spring Race');
-      expect(screen.getByLabelText(/Chinese Name/)).toHaveValue('春季赛');
-      consoleSpy.mockRestore();
-    });
-
-    test('validates required name and date before saving', async () => {
-      renderModal();
-      fireEvent.click((await screen.findByTestId('EditIcon')).closest('button'));
-      const nameField = await screen.findByLabelText(/Event Name/);
-
-      fireEvent.change(nameField, { target: { value: '   ' } });
-      fireEvent.click(screen.getByRole('button', { name: /Save \/ 保存/ }));
-      expect(await screen.findByText('Name cannot be empty / 名称不能为空')).toBeInTheDocument();
-      expect(updateEvent).not.toHaveBeenCalled();
-
-      fireEvent.change(nameField, { target: { value: 'Valid' } });
-      fireEvent.change(screen.getByLabelText(/Date \/ 日期/), { target: { value: '' } });
-      fireEvent.click(screen.getByRole('button', { name: /Save \/ 保存/ }));
-      expect(await screen.findByText('Date is required / 日期为必填项')).toBeInTheDocument();
-      expect(updateEvent).not.toHaveBeenCalled();
-    });
-
-    test('saves trimmed values, nulls empty strings, and mirrors camelCase to parent', async () => {
-      updateEvent.mockResolvedValue({
-        id: 1,
-        name: 'New Name',
-        chinese_name: '新名字',
-        chinese_location: null,
-        chinese_description: '服务器描述',
-        signup_link: null,
-        wechat_qr_code: '/img/server-qr.png',
-        status: 'Past',
-        is_highlight: true,
-      });
+    test('composer close hides it without notifying the parent', async () => {
       const { props } = renderModal();
       fireEvent.click((await screen.findByTestId('EditIcon')).closest('button'));
-      const nameField = await screen.findByLabelText(/Event Name/);
+      await screen.findByTestId('event-composer');
 
-      fireEvent.change(nameField, { target: { value: '  New Name  ' } });
-      fireEvent.change(screen.getByLabelText(/Chinese Location/), { target: { value: '   ' } });
-      fireEvent.change(screen.getByLabelText(/Signup Link/), { target: { value: '' } });
-      fireEvent.click(screen.getByRole('button', { name: /Save \/ 保存/ }));
+      fireEvent.click(screen.getByRole('button', { name: 'composer-close' }));
+      await waitFor(() => expect(screen.queryByTestId('event-composer')).not.toBeInTheDocument());
+      expect(props.onEventUpdate).not.toHaveBeenCalled();
+      expect(getEventById).not.toHaveBeenCalled();
+      expect(screen.getByText('Spring Race')).toBeInTheDocument();
+    });
 
-      await waitFor(() =>
-        expect(updateEvent).toHaveBeenCalledWith(
-          1,
-          expect.objectContaining({
-            name: 'New Name',
-            chinese_name: '服务器名',
-            date: '2026-04-02',
-            time: '9:00 AM',
-            location: 'Server Loc',
-            chinese_location: null,
-            signup_link: null,
-            wechat_qr_code: '/img/server-qr.png',
-            status: 'Past',
-            is_highlight: true,
-            event_type: 'race',
-          }),
-          'user-1'
-        )
-      );
+    test('composer save refetches the event and mirrors camelCase to the parent', async () => {
+      const { props } = renderModal();
+      fireEvent.click((await screen.findByTestId('EditIcon')).closest('button'));
+      await screen.findByTestId('event-composer');
+
+      fireEvent.click(screen.getByRole('button', { name: 'composer-save' }));
+
+      await waitFor(() => expect(getEventById).toHaveBeenCalledWith(1));
       await waitFor(() =>
         expect(props.onEventUpdate).toHaveBeenCalledWith(
           expect.objectContaining({
-            name: 'New Name',
-            chineseName: '新名字',
-            chineseLocation: null,
+            name: 'Server Name',
+            chineseName: '服务器名',
+            chineseLocation: '服务器地点',
             chineseDescription: '服务器描述',
-            signupLink: null,
+            signupLink: 'https://server.example.com',
             wechatQrCode: '/img/server-qr.png',
           })
         )
       );
-      // edit mode exits
-      await waitFor(() =>
-        expect(screen.queryByLabelText(/Event Name/)).not.toBeInTheDocument()
-      );
+      await waitFor(() => expect(screen.queryByTestId('event-composer')).not.toBeInTheDocument());
     });
 
-    test('status and type dropdowns open above the overlay and change values', async () => {
-      updateEvent.mockResolvedValue({ id: 1, name: 'Server Name', status: 'Cancelled' });
-      renderModal();
-      fireEvent.click((await screen.findByTestId('EditIcon')).closest('button'));
-      await screen.findByLabelText(/Event Name/);
-
-      // The modal overlay uses zIndex 9999 — menus must portal above it or
-      // they open invisibly behind the backdrop (regression: uneditable selects)
-      fireEvent.mouseDown(screen.getByLabelText(/Status \/ 状态/));
-      let listbox = await screen.findByRole('listbox');
-      expect(Number(getComputedStyle(listbox.closest('.MuiModal-root')).zIndex)).toBeGreaterThan(9999);
-      fireEvent.click(within(listbox).getByText('Cancelled / 已取消'));
-      await waitFor(() => expect(screen.queryByRole('listbox')).not.toBeInTheDocument());
-
-      fireEvent.mouseDown(screen.getByLabelText(/Type \/ 类型/));
-      listbox = await screen.findByRole('listbox');
-      expect(Number(getComputedStyle(listbox.closest('.MuiModal-root')).zIndex)).toBeGreaterThan(9999);
-      fireEvent.click(within(listbox).getByText('Standard'));
-      await waitFor(() => expect(screen.queryByRole('listbox')).not.toBeInTheDocument());
-
-      fireEvent.click(screen.getByRole('button', { name: /Save \/ 保存/ }));
-      await waitFor(() =>
-        expect(updateEvent).toHaveBeenCalledWith(
-          1,
-          expect.objectContaining({ status: 'Cancelled', event_type: 'standard' }),
-          'user-1'
-        )
-      );
-    });
-
-    test('toggling the highlight switch updates the form value sent on save', async () => {
-      updateEvent.mockResolvedValue({ id: 1, name: 'Server Name', status: 'Past' });
-      renderModal();
-      fireEvent.click((await screen.findByTestId('EditIcon')).closest('button'));
-      const highlightSwitch = await screen.findByRole('checkbox');
-      expect(highlightSwitch).toBeChecked();
-      fireEvent.click(highlightSwitch);
-      expect(highlightSwitch).not.toBeChecked();
-
-      fireEvent.click(screen.getByRole('button', { name: /Save \/ 保存/ }));
-      await waitFor(() =>
-        expect(updateEvent).toHaveBeenCalledWith(
-          1,
-          expect.objectContaining({ is_highlight: false }),
-          'user-1'
-        )
-      );
-    });
-
-    test('save failure keeps the form open and shows an error snackbar', async () => {
+    test('falls back to the composer save payload when the refetch fails', async () => {
       const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-      updateEvent.mockRejectedValue(new Error('500'));
-      renderModal();
+      getEventById.mockRejectedValue(new Error('404'));
+      const { props } = renderModal();
       fireEvent.click((await screen.findByTestId('EditIcon')).closest('button'));
-      await screen.findByLabelText(/Event Name/);
-      fireEvent.click(screen.getByRole('button', { name: /Save \/ 保存/ }));
-      expect(await screen.findByText('Failed to save event / 保存活动失败')).toBeInTheDocument();
-      expect(screen.getByLabelText(/Event Name/)).toBeInTheDocument();
+      await screen.findByTestId('event-composer');
+
+      fireEvent.click(screen.getByRole('button', { name: 'composer-save' }));
+
+      await waitFor(() =>
+        expect(props.onEventUpdate).toHaveBeenCalledWith(
+          expect.objectContaining({ id: 1, name: 'Saved Name' })
+        )
+      );
       consoleSpy.mockRestore();
     });
 
-    test('cancel exits edit mode without saving', async () => {
-      renderModal();
+    test('composer save without an onEventUpdate handler is a no-op', async () => {
+      renderModal({ onEventUpdate: undefined });
       fireEvent.click((await screen.findByTestId('EditIcon')).closest('button'));
-      await screen.findByLabelText(/Event Name/);
-      fireEvent.click(screen.getByRole('button', { name: /Cancel \/ 取消/ }));
-      expect(screen.queryByLabelText(/Event Name/)).not.toBeInTheDocument();
-      expect(screen.getByText('Spring Race')).toBeInTheDocument();
-      expect(updateEvent).not.toHaveBeenCalled();
+      await screen.findByTestId('event-composer');
+
+      fireEvent.click(screen.getByRole('button', { name: 'composer-save' }));
+      await waitFor(() => expect(screen.queryByTestId('event-composer')).not.toBeInTheDocument());
+      expect(getEventById).not.toHaveBeenCalled();
     });
   });
 });

--- a/ProjectCode/client/src/components/EventGroupCard.js
+++ b/ProjectCode/client/src/components/EventGroupCard.js
@@ -13,6 +13,7 @@ import EventEngagementBar from './EventEngagementBar';
 import ImagePositionEditor from './ImagePositionEditor';
 import { updateEvent } from '../api';
 import { useAuth } from '../context/AuthContext';
+import { ORANGE, ORANGE_DARK, ORANGE_BG, LINE, CARD_HOVER_SHADOW, FALLBACK_EVENT_IMAGE } from '../theme/tokens';
 
 /**
  * EventGroupCard - iOS-style stacked card for event groups
@@ -30,7 +31,7 @@ const EventGroupCard = ({
   const [coverPosition, setCoverPosition] = useState(group.cover_image_position || 'center center');
 
   const handleImageError = (e) => {
-    e.target.src = '/images/2025/20250517_bk_half.jpg';
+    e.target.src = FALLBACK_EVENT_IMAGE;
   };
 
   const eventCount = group.event_count;
@@ -69,10 +70,10 @@ const EventGroupCard = ({
           zIndex: -2,
           boxShadow: '0 1px 3px rgba(0, 0, 0, 0.05)',
         },
+        transition: 'all 0.2s ease',
         '&:hover': {
-          transform: 'translateY(-2px)',
-          transition: 'transform 0.3s ease-in-out',
-          boxShadow: '0 4px 8px rgba(0, 0, 0, 0.1)',
+          transform: 'translateY(-3px)',
+          boxShadow: CARD_HOVER_SHADOW,
         },
       }}
       onClick={() => onGroupClick(group)}
@@ -108,9 +109,9 @@ const EventGroupCard = ({
               width: '100%',
               objectFit: 'cover',
               objectPosition: coverPosition,
-              backgroundColor: '#f5f5f5',
+              backgroundColor: ORANGE_BG,
             }}
-            image={group.cover_image || '/images/2025/20250517_bk_half.jpg'}
+            image={group.cover_image || FALLBACK_EVENT_IMAGE}
             alt={group.group_name}
             onError={handleImageError}
           />
@@ -141,9 +142,9 @@ const EventGroupCard = ({
           justifyContent: 'center',
           alignItems: 'center',
           backgroundColor: 'white',
-          color: '#FFA500',
+          color: ORANGE,
           p: 2,
-          borderRight: '1px solid #e0e0e0',
+          borderRight: `1px solid ${LINE}`,
           whiteSpace: 'nowrap',
           position: 'relative',
         }}
@@ -203,9 +204,9 @@ const EventGroupCard = ({
               width: '100%',
               objectFit: 'cover',
               objectPosition: coverPosition,
-              backgroundColor: '#f5f5f5',
+              backgroundColor: ORANGE_BG,
             }}
-            image={group.cover_image || '/images/2025/20250517_bk_half.jpg'}
+            image={group.cover_image || FALLBACK_EVENT_IMAGE}
             alt={group.group_name}
             onError={handleImageError}
           />
@@ -222,7 +223,7 @@ const EventGroupCard = ({
         }}
       >
         {/* Mobile: Show date and badge at top of content */}
-        <Box sx={{ display: { xs: 'flex', sm: 'none' }, gap: 2, mb: 1, color: '#FFA500' }}>
+        <Box sx={{ display: { xs: 'flex', sm: 'none' }, gap: 2, mb: 1, color: ORANGE }}>
           <Typography variant="subtitle1" color="text.secondary">
             {new Date(group.most_recent_date).toLocaleDateString('en-US', {
               month: 'short',
@@ -258,24 +259,26 @@ const EventGroupCard = ({
           </Box>
           <Button
             variant="contained"
+            disableElevation
             sx={{
-              backgroundColor: '#FFB84D',
+              backgroundColor: ORANGE,
               color: 'white',
               textTransform: 'none',
-              fontSize: { xs: '14px', sm: '16px' },
-              px: { xs: 1.5, sm: 2 },
-              py: { xs: 1, sm: 1.5 },
-              borderRadius: '12px',
-              border: '2px solid #FFB84D',
+              fontWeight: 600,
+              fontSize: { xs: '0.8125rem', sm: '0.9375rem' },
+              px: { xs: 2, sm: 2.5 },
+              py: { xs: 0.75, sm: 1 },
+              borderRadius: '99px',
               flexShrink: 0,
               '&:hover': {
-                backgroundColor: '#FFA833',
-                boxShadow: '0 4px 8px rgba(0, 0, 0, 0.15)',
-                transform: 'translateY(-2px)',
+                backgroundColor: ORANGE_DARK,
+              },
+              '&:active': {
+                transform: 'scale(0.98)',
               },
             }}
           >
-            View All {eventCount} Events
+            View All {eventCount} Events 查看全部
           </Button>
         </Box>
 

--- a/ProjectCode/client/src/components/EventGroupCard.test.js
+++ b/ProjectCode/client/src/components/EventGroupCard.test.js
@@ -55,7 +55,8 @@ describe('EventGroupCard', () => {
     expect(screen.getByText('布鲁克林半马系列')).toBeInTheDocument();
     expect(screen.getByText('3 Events')).toBeInTheDocument(); // mobile badge
     expect(screen.getByText('3')).toBeInTheDocument(); // desktop badge
-    expect(screen.getByRole('button', { name: 'View All 3 Events' })).toBeInTheDocument();
+    // Bilingual orange pill CTA
+    expect(screen.getByRole('button', { name: 'View All 3 Events 查看全部' })).toBeInTheDocument();
     expect(screen.getByText('3 events from 2023 to 2025')).toBeInTheDocument();
     expect(screen.getAllByText('May 2025')).toHaveLength(2); // mobile + desktop
     expect(screen.getByText('to present')).toBeInTheDocument();
@@ -83,7 +84,7 @@ describe('EventGroupCard', () => {
       expect(img).toHaveStyle({ objectPosition: '30% 40%' });
     });
     fireEvent.error(imgs[0]);
-    expect(imgs[0]).toHaveAttribute('src', '/images/2025/20250517_bk_half.jpg');
+    expect(imgs[0]).toHaveAttribute('src', '/images/placeholder-event.jpg');
   });
 
   test('falls back to default cover image and position when missing', () => {
@@ -91,7 +92,7 @@ describe('EventGroupCard', () => {
     render(<EventGroupCard group={group} onGroupClick={jest.fn()} />);
     const imgs = screen.getAllByAltText('Brooklyn Half Series');
     imgs.forEach((img) => {
-      expect(img).toHaveAttribute('src', '/images/2025/20250517_bk_half.jpg');
+      expect(img).toHaveAttribute('src', '/images/placeholder-event.jpg');
       expect(img).toHaveStyle({ objectPosition: 'center center' });
     });
     // no admin editor without cover image even in admin mode

--- a/ProjectCode/client/src/helpers/eventDate.js
+++ b/ProjectCode/client/src/helpers/eventDate.js
@@ -1,0 +1,41 @@
+// Event date/time helpers shared by EventCard, CalendarPage, HomePage and
+// HighlightsPage — previously each file kept its own identical copy.
+
+export const MONTHS = ['JAN', 'FEB', 'MAR', 'APR', 'MAY', 'JUN', 'JUL', 'AUG', 'SEP', 'OCT', 'NOV', 'DEC'];
+
+// Parse an event date (YYYY-MM-DD) into { day, month } for the date bubble
+export function parseBubbleDate(dateStr) {
+  if (!dateStr) return null;
+  const d = new Date(`${dateStr}T00:00:00`);
+  if (isNaN(d.getTime())) return null;
+  return { day: d.getDate(), month: MONTHS[d.getMonth()] };
+}
+
+// Convert a stored display time ("8:00 AM", "18:30") to the HH:MM value a
+// native <input type="time"> needs. Returns '' when unparseable so the
+// picker starts empty instead of showing garbage.
+export function to24Hour(timeStr) {
+  if (!timeStr) return '';
+  const m = String(timeStr).trim().match(/^(\d{1,2}):(\d{2})\s*(AM|PM)?$/i);
+  if (!m) return '';
+  let hours = Number(m[1]);
+  const minutes = m[2];
+  const meridiem = m[3] ? m[3].toUpperCase() : null;
+  if (hours > 23 || Number(minutes) > 59) return '';
+  if (meridiem === 'PM' && hours < 12) hours += 12;
+  if (meridiem === 'AM' && hours === 12) hours = 0;
+  return `${String(hours).padStart(2, '0')}:${minutes}`;
+}
+
+// Convert an <input type="time"> value ("08:00") back to the 12-hour string
+// the rest of the site displays ("8:00 AM").
+export function to12Hour(timeStr) {
+  if (!timeStr) return '';
+  const m = String(timeStr).trim().match(/^(\d{1,2}):(\d{2})$/);
+  if (!m) return timeStr;
+  let hours = Number(m[1]);
+  const minutes = m[2];
+  const meridiem = hours >= 12 ? 'PM' : 'AM';
+  hours = hours % 12 || 12;
+  return `${hours}:${minutes} ${meridiem}`;
+}

--- a/ProjectCode/client/src/helpers/eventDate.test.js
+++ b/ProjectCode/client/src/helpers/eventDate.test.js
@@ -1,0 +1,55 @@
+import { MONTHS, parseBubbleDate, to24Hour, to12Hour } from './eventDate';
+
+describe('parseBubbleDate', () => {
+  test('parses YYYY-MM-DD into day and month', () => {
+    expect(parseBubbleDate('2026-07-19')).toEqual({ day: 19, month: 'JUL' });
+    expect(parseBubbleDate('2026-01-01')).toEqual({ day: 1, month: 'JAN' });
+    expect(parseBubbleDate('2026-12-31')).toEqual({ day: 31, month: 'DEC' });
+  });
+
+  test('returns null for missing or invalid dates', () => {
+    expect(parseBubbleDate('')).toBeNull();
+    expect(parseBubbleDate(null)).toBeNull();
+    expect(parseBubbleDate('not-a-date')).toBeNull();
+  });
+
+  test('MONTHS has 12 entries', () => {
+    expect(MONTHS).toHaveLength(12);
+  });
+});
+
+describe('to24Hour', () => {
+  test('converts 12-hour strings', () => {
+    expect(to24Hour('8:00 AM')).toBe('08:00');
+    expect(to24Hour('12:00 AM')).toBe('00:00');
+    expect(to24Hour('12:30 PM')).toBe('12:30');
+    expect(to24Hour('6:45 PM')).toBe('18:45');
+  });
+
+  test('passes through 24-hour strings', () => {
+    expect(to24Hour('18:30')).toBe('18:30');
+    expect(to24Hour('08:00')).toBe('08:00');
+  });
+
+  test('returns empty string for unparseable input', () => {
+    expect(to24Hour('')).toBe('');
+    expect(to24Hour(null)).toBe('');
+    expect(to24Hour('after the race')).toBe('');
+    expect(to24Hour('25:00')).toBe('');
+    expect(to24Hour('8:99 AM')).toBe('');
+  });
+});
+
+describe('to12Hour', () => {
+  test('converts 24-hour input values to display strings', () => {
+    expect(to12Hour('08:00')).toBe('8:00 AM');
+    expect(to12Hour('00:15')).toBe('12:15 AM');
+    expect(to12Hour('12:00')).toBe('12:00 PM');
+    expect(to12Hour('18:30')).toBe('6:30 PM');
+  });
+
+  test('returns input unchanged when not HH:MM', () => {
+    expect(to12Hour('')).toBe('');
+    expect(to12Hour('8 in the morning')).toBe('8 in the morning');
+  });
+});

--- a/ProjectCode/client/src/pages/AdminPanelPage.js
+++ b/ProjectCode/client/src/pages/AdminPanelPage.js
@@ -14,14 +14,12 @@ import {
   DialogContentText,
   DialogTitle,
   FormControl,
-  FormControlLabel,
   Grid,
   IconButton,
   InputLabel,
   MenuItem,
   Paper,
   Select,
-  Switch,
   Tab,
   Table,
   TableBody,
@@ -39,9 +37,10 @@ import {
 import React, { useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import MeetingMinutesEditor from '../components/MeetingMinutesEditor';
+import EventComposer from '../components/EventComposer';
 import { useAuth } from '../context/AuthContext';
 import { getPendingMembers, approveMember, rejectMember, getMemberByFirebaseUid, getAllMembers, updateMember, promoteToCommittee, demoteFromCommittee } from '../api/members';
-import { createEvent, getAllEvents, updateEvent, deleteEvent } from '../api/events';
+import { getAllEvents, deleteEvent } from '../api/events';
 import { getDonationSummary } from '../api/donors';
 import { getAllBanners, createBanner, updateBanner, deleteBanner } from '../api/banners';
 import { getAllSections, createSection, updateSection, deleteSection } from '../api/homepageSections';
@@ -158,23 +157,9 @@ export default function AdminPanelPage() {
   const [selectedActivityMember, setSelectedActivityMember] = useState(null);
   const [selectedMemberActivities, setSelectedMemberActivities] = useState([]);
 
-  // Event form state
-  const [eventDialogOpen, setEventDialogOpen] = useState(false);
-  const [editingEvent, setEditingEvent] = useState(null);
-  const [eventFormData, setEventFormData] = useState({
-    name: '',
-    chinese_name: '',
-    date: '',
-    time: '',
-    location: '',
-    chinese_location: '',
-    description: '',
-    chinese_description: '',
-    image: '',
-    signup_link: '',
-    status: 'Upcoming',
-    is_highlight: false
-  });
+  // Event composer state (create/edit handled by the shared EventComposer)
+  const [eventComposerOpen, setEventComposerOpen] = useState(false);
+  const [composerEvent, setComposerEvent] = useState(null);
 
   // Newsletter state
   const [newsletterSubject, setNewsletterSubject] = useState('');
@@ -427,77 +412,23 @@ export default function AdminPanelPage() {
     }
   };
 
-  // Event form handlers
-  const handleEventDialogOpen = (event = null) => {
-    if (event) {
-      setEditingEvent(event);
-      // Legacy 'Highlight' status maps to Past + is_highlight in the new model
-      const rawStatus = event.status || 'Upcoming';
-      const normalizedStatus = rawStatus === 'Highlight' ? 'Past' : rawStatus;
-      const isHighlight = event.is_highlight === true || rawStatus === 'Highlight';
-      setEventFormData({
-        name: event.name || '',
-        chinese_name: event.chinese_name || '',
-        date: event.date || '',
-        time: event.time || '',
-        location: event.location || '',
-        chinese_location: event.chinese_location || '',
-        description: event.description || '',
-        chinese_description: event.chinese_description || '',
-        image: event.image || '',
-        signup_link: event.signup_link || '',
-        status: normalizedStatus,
-        is_highlight: isHighlight
-      });
-    } else {
-      setEditingEvent(null);
-      setEventFormData({
-        name: '',
-        chinese_name: '',
-        date: new Date().toISOString().split('T')[0],
-        time: '',
-        location: '',
-        chinese_location: '',
-        description: '',
-        chinese_description: '',
-        image: '',
-        signup_link: '',
-        status: 'Upcoming',
-        is_highlight: false
-      });
-    }
-    setEventDialogOpen(true);
+  // Event composer handlers — all form logic lives in EventComposer
+  const handleEventComposerOpen = (event = null) => {
+    setComposerEvent(event);
+    setEventComposerOpen(true);
   };
 
-  const handleEventDialogClose = () => {
-    setEventDialogOpen(false);
-    setEditingEvent(null);
+  const handleEventComposerClose = () => {
+    setEventComposerOpen(false);
+    setComposerEvent(null);
   };
 
-  const handleEventFormChange = (e) => {
-    const { name, value } = e.target;
-    setEventFormData(prev => ({ ...prev, [name]: value }));
-  };
-
-  const handleSaveEvent = async () => {
-    setActionLoading('event');
+  const handleEventSaved = async () => {
     try {
-      if (editingEvent) {
-        const updated = await updateEvent(editingEvent.id, eventFormData, currentUser.uid);
-        setEvents(prev => prev.map(e => e.id === editingEvent.id ? updated : e));
-        setSuccessMessage('Event updated successfully!');
-      } else {
-        const created = await createEvent(eventFormData, currentUser.uid);
-        setEvents(prev => [created, ...prev]);
-        setSuccessMessage('Event created successfully!');
-      }
-      handleEventDialogClose();
-      setTimeout(() => setSuccessMessage(''), 5000);
+      const eventList = await getAllEvents();
+      setEvents(eventList);
     } catch (err) {
-      console.error('Error saving event:', err);
-      setError('Failed to save event. Please try again.');
-    } finally {
-      setActionLoading(null);
+      console.error('Error refreshing events:', err);
     }
   };
 
@@ -1232,7 +1163,7 @@ export default function AdminPanelPage() {
             </Typography>
             <Button
               variant="contained"
-              onClick={() => handleEventDialogOpen()}
+              onClick={() => handleEventComposerOpen()}
               sx={orangeButtonSx}
             >
               + Create Event
@@ -1282,7 +1213,7 @@ export default function AdminPanelPage() {
                     </TableCell>
                     <TableCell align="right">
                       <Tooltip title="Edit">
-                        <IconButton size="small" onClick={() => handleEventDialogOpen(event)}>
+                        <IconButton size="small" onClick={() => handleEventComposerOpen(event)}>
                           <EditIcon fontSize="small" />
                         </IconButton>
                       </Tooltip>
@@ -1983,157 +1914,13 @@ export default function AdminPanelPage() {
         )}
       </Container>
 
-      {/* Event Create/Edit Dialog */}
-      <Dialog open={eventDialogOpen} onClose={handleEventDialogClose} maxWidth="md" fullWidth>
-        <DialogTitle>
-          {editingEvent ? 'Edit Event / 编辑活动' : 'Create Event / 创建活动'}
-        </DialogTitle>
-        <DialogContent>
-          <Grid container spacing={2} sx={{ mt: 1 }}>
-            <Grid item xs={12} sm={6}>
-              <TextField
-                fullWidth
-                label="Event Name (English)"
-                name="name"
-                value={eventFormData.name}
-                onChange={handleEventFormChange}
-                required
-              />
-            </Grid>
-            <Grid item xs={12} sm={6}>
-              <TextField
-                fullWidth
-                label="Event Name (Chinese)"
-                name="chinese_name"
-                value={eventFormData.chinese_name}
-                onChange={handleEventFormChange}
-              />
-            </Grid>
-            <Grid item xs={12} sm={6}>
-              <TextField
-                fullWidth
-                label="Date"
-                name="date"
-                type="date"
-                value={eventFormData.date}
-                onChange={handleEventFormChange}
-                InputLabelProps={{ shrink: true }}
-                required
-              />
-            </Grid>
-            <Grid item xs={12} sm={6}>
-              <TextField
-                fullWidth
-                label="Time"
-                name="time"
-                value={eventFormData.time}
-                onChange={handleEventFormChange}
-                placeholder="e.g., 8:00 AM"
-              />
-            </Grid>
-            <Grid item xs={12} sm={6}>
-              <TextField
-                fullWidth
-                label="Location (English)"
-                name="location"
-                value={eventFormData.location}
-                onChange={handleEventFormChange}
-              />
-            </Grid>
-            <Grid item xs={12} sm={6}>
-              <TextField
-                fullWidth
-                label="Location (Chinese)"
-                name="chinese_location"
-                value={eventFormData.chinese_location}
-                onChange={handleEventFormChange}
-              />
-            </Grid>
-            <Grid item xs={12}>
-              <TextField
-                fullWidth
-                label="Description (English)"
-                name="description"
-                value={eventFormData.description}
-                onChange={handleEventFormChange}
-                multiline
-                rows={3}
-              />
-            </Grid>
-            <Grid item xs={12}>
-              <TextField
-                fullWidth
-                label="Description (Chinese)"
-                name="chinese_description"
-                value={eventFormData.chinese_description}
-                onChange={handleEventFormChange}
-                multiline
-                rows={3}
-              />
-            </Grid>
-            <Grid item xs={12} sm={6}>
-              <TextField
-                fullWidth
-                label="Image URL"
-                name="image"
-                value={eventFormData.image}
-                onChange={handleEventFormChange}
-              />
-            </Grid>
-            <Grid item xs={12} sm={6}>
-              <TextField
-                fullWidth
-                label="Signup Link"
-                name="signup_link"
-                value={eventFormData.signup_link}
-                onChange={handleEventFormChange}
-              />
-            </Grid>
-            <Grid item xs={12} sm={6}>
-              <FormControl fullWidth>
-                <InputLabel>Status</InputLabel>
-                <Select
-                  name="status"
-                  value={eventFormData.status}
-                  onChange={handleEventFormChange}
-                  label="Status"
-                >
-                  <MenuItem value="Upcoming">Upcoming / 即将举行</MenuItem>
-                  <MenuItem value="Past">Past (Memories) / 已结束（回忆）</MenuItem>
-                  <MenuItem value="Cancelled">Cancelled / 已取消</MenuItem>
-                </Select>
-              </FormControl>
-            </Grid>
-            <Grid item xs={12} sm={6}>
-              <FormControlLabel
-                control={
-                  <Switch
-                    checked={!!eventFormData.is_highlight}
-                    onChange={(e) =>
-                      setEventFormData((prev) => ({ ...prev, is_highlight: e.target.checked }))
-                    }
-                    color="warning"
-                  />
-                }
-                label="Highlight / 精选"
-              />
-            </Grid>
-          </Grid>
-        </DialogContent>
-        <DialogActions sx={{ px: 3, pb: 2 }}>
-          <Button onClick={handleEventDialogClose} disabled={actionLoading === 'event'}>
-            Cancel
-          </Button>
-          <Button
-            variant="contained"
-            onClick={handleSaveEvent}
-            disabled={actionLoading === 'event' || !eventFormData.name || !eventFormData.date}
-            sx={orangeButtonSx}
-          >
-            {actionLoading === 'event' ? <CircularProgress size={24} /> : 'Save'}
-          </Button>
-        </DialogActions>
-      </Dialog>
+      {/* Event Create/Edit Composer */}
+      <EventComposer
+        open={eventComposerOpen}
+        onClose={handleEventComposerClose}
+        event={composerEvent}
+        onSaved={handleEventSaved}
+      />
 
       {/* Banner Create/Edit Dialog */}
       <Dialog open={bannerDialogOpen} onClose={handleBannerDialogClose} maxWidth="sm" fullWidth>

--- a/ProjectCode/client/src/pages/AdminPanelPage.test.js
+++ b/ProjectCode/client/src/pages/AdminPanelPage.test.js
@@ -49,6 +49,33 @@ jest.mock('../components/MeetingMinutesEditor', () => ({
   },
 }));
 
+// EventComposer has its own test suite — stub it with save/close triggers.
+// Plain function in the factory (not jest.fn) so CRA's resetMocks:true
+// cannot wipe its implementation between tests.
+jest.mock('../components/EventComposer', () => ({
+  __esModule: true,
+  default: (props) => {
+    const ReactLocal = require('react');
+    if (!props.open) return null;
+    return ReactLocal.createElement(
+      'div',
+      { 'data-testid': 'event-composer' },
+      props.event ? `composer-editing:${props.event.id}` : 'composer-creating',
+      ReactLocal.createElement(
+        'button',
+        {
+          onClick: () => {
+            // Mirror the real composer: onSaved with the saved event, then close
+            Promise.resolve(props.onSaved(props.event ?? { id: 99 })).then(props.onClose);
+          },
+        },
+        'composer-save'
+      ),
+      ReactLocal.createElement('button', { onClick: props.onClose }, 'composer-close')
+    );
+  },
+}));
+
 const ADMIN_UID = 'admin-uid';
 const adminUser = { uid: ADMIN_UID, displayName: 'Admin', email: 'a@b.c' };
 
@@ -181,8 +208,6 @@ beforeEach(() => {
   membersApi.promoteToCommittee.mockResolvedValue({});
   membersApi.demoteFromCommittee.mockResolvedValue({});
   eventsApi.getAllEvents.mockResolvedValue(eventsFixture);
-  eventsApi.createEvent.mockResolvedValue({ id: 99, name: 'Brand New Run', date: '2026-07-10', status: 'Past', is_highlight: true });
-  eventsApi.updateEvent.mockResolvedValue({ id: 11, name: 'Legacy Gala Updated', date: '2025-01-01', status: 'Past', is_highlight: true });
   eventsApi.deleteEvent.mockResolvedValue({});
   donorsApi.getDonationSummary.mockResolvedValue(donationFixture);
   bannersApi.getAllBanners.mockResolvedValue(bannersFixture);
@@ -610,76 +635,66 @@ describe('events tab', () => {
     expect(screen.getByText('Cancelled')).toBeInTheDocument();
   });
 
-  test('creates a new event', async () => {
+  test('+ Create Event opens the composer in create mode and closes cleanly', async () => {
     renderPage();
     await waitForDashboard();
     openTab('Events');
 
+    expect(screen.queryByTestId('event-composer')).not.toBeInTheDocument();
     fireEvent.click(await screen.findByRole('button', { name: '+ Create Event' }));
-    const dialog = await screen.findByRole('dialog');
-    expect(within(dialog).getByText('Create Event / 创建活动')).toBeInTheDocument();
+    expect(await screen.findByTestId('event-composer')).toHaveTextContent('composer-creating');
 
-    fireEvent.change(within(dialog).getByLabelText(/Event Name \(English\)/), { target: { value: 'Brand New Run' } });
-    fireEvent.change(within(dialog).getByLabelText('Time'), { target: { value: '9:00 AM' } });
-    selectMuiOption(within(dialog).getByRole('combobox'), /Past \(Memories\)/);
-    fireEvent.click(within(dialog).getByRole('checkbox')); // highlight switch
-
-    fireEvent.click(within(dialog).getByRole('button', { name: 'Save' }));
-
-    await waitFor(() =>
-      expect(eventsApi.createEvent).toHaveBeenCalledWith(
-        expect.objectContaining({
-          name: 'Brand New Run',
-          time: '9:00 AM',
-          status: 'Past',
-          is_highlight: true,
-          date: expect.any(String),
-        }),
-        ADMIN_UID
-      )
-    );
-    expect(await screen.findByText('Event created successfully!')).toBeInTheDocument();
-    expect(screen.getByText('Brand New Run')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'composer-close' }));
+    await waitFor(() => expect(screen.queryByTestId('event-composer')).not.toBeInTheDocument());
+    expect(eventsApi.getAllEvents).toHaveBeenCalledTimes(1); // no refetch on plain close
   });
 
-  test('edits a legacy Highlight event, normalizing its status', async () => {
+  test('row Edit opens the composer with that event', async () => {
     renderPage();
     await waitForDashboard();
     openTab('Events');
 
     const row = (await screen.findByText('Legacy Gala')).closest('tr');
     fireEvent.click(within(row).getByRole('button', { name: 'Edit' }));
-    const dialog = await screen.findByRole('dialog');
-    expect(within(dialog).getByText('Edit Event / 编辑活动')).toBeInTheDocument();
-    // Legacy 'Highlight' normalized to Past + is_highlight
-    expect(within(dialog).getByRole('checkbox')).toBeChecked();
-
-    fireEvent.click(within(dialog).getByRole('button', { name: 'Save' }));
-    await waitFor(() =>
-      expect(eventsApi.updateEvent).toHaveBeenCalledWith(
-        11,
-        expect.objectContaining({ status: 'Past', is_highlight: true, name: 'Legacy Gala' }),
-        ADMIN_UID
-      )
-    );
-    expect(await screen.findByText('Event updated successfully!')).toBeInTheDocument();
-    expect(screen.getByText('Legacy Gala Updated')).toBeInTheDocument();
+    expect(await screen.findByTestId('event-composer')).toHaveTextContent('composer-editing:11');
   });
 
-  test('shows error when saving an event fails, and dialog can be cancelled', async () => {
-    eventsApi.updateEvent.mockRejectedValueOnce(new Error('nope'));
+  test('a composer save refetches the events list', async () => {
+    renderPage();
+    await waitForDashboard();
+    openTab('Events');
+
+    fireEvent.click(await screen.findByRole('button', { name: '+ Create Event' }));
+    await screen.findByTestId('event-composer');
+
+    // The refetch after save returns the list including the new event
+    eventsApi.getAllEvents.mockResolvedValue([
+      ...eventsFixture,
+      { id: 99, name: 'Brand New Run', date: '2026-07-10', status: 'Upcoming' },
+    ]);
+    fireEvent.click(screen.getByRole('button', { name: 'composer-save' }));
+
+    await waitFor(() => expect(eventsApi.getAllEvents).toHaveBeenCalledTimes(2));
+    expect(await screen.findByText('Brand New Run')).toBeInTheDocument();
+    await waitFor(() => expect(screen.queryByTestId('event-composer')).not.toBeInTheDocument());
+  });
+
+  test('keeps the current list when the post-save refetch fails', async () => {
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
     renderPage();
     await waitForDashboard();
     openTab('Events');
 
     const row = (await screen.findByText('Spring Run')).closest('tr');
     fireEvent.click(within(row).getByRole('button', { name: 'Edit' }));
-    let dialog = await screen.findByRole('dialog');
-    fireEvent.click(within(dialog).getByRole('button', { name: 'Save' }));
-    expect(await screen.findByText('Failed to save event. Please try again.')).toBeInTheDocument();
+    await screen.findByTestId('event-composer');
 
-    fireEvent.click(within(dialog).getByRole('button', { name: 'Cancel' }));
-    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+    eventsApi.getAllEvents.mockRejectedValue(new Error('nope'));
+    fireEvent.click(screen.getByRole('button', { name: 'composer-save' }));
+
+    await waitFor(() => expect(eventsApi.getAllEvents).toHaveBeenCalledTimes(2));
+    expect(screen.getByText('Spring Run')).toBeInTheDocument();
+    consoleSpy.mockRestore();
   });
 
   test('deletes an event after confirmation (and honors cancel)', async () => {

--- a/ProjectCode/client/src/pages/CalendarPage.js
+++ b/ProjectCode/client/src/pages/CalendarPage.js
@@ -1,42 +1,21 @@
-import EditIcon from '@mui/icons-material/Edit';
-import DeleteIcon from '@mui/icons-material/Delete';
 import AddIcon from '@mui/icons-material/Add';
+import DeleteIcon from '@mui/icons-material/Delete';
+import EditIcon from '@mui/icons-material/Edit';
 import InfoIcon from '@mui/icons-material/Info';
-import CloudUploadIcon from '@mui/icons-material/CloudUpload';
 import StarIcon from '@mui/icons-material/Star';
-import QrCode2Icon from '@mui/icons-material/QrCode2';
-import { Alert, Box, Button, Card, CardContent, Chip, CircularProgress, Container, Dialog, DialogActions, DialogContent, DialogTitle, FormControlLabel, Grid, IconButton, MenuItem, Snackbar, Switch, TextField, Tooltip, Typography } from '@mui/material';
-import RepeatIcon from '@mui/icons-material/Repeat';
-import ShareIcon from '@mui/icons-material/Share';
-import { useEffect, useState, useRef } from 'react';
-import { useSearchParams } from 'react-router-dom';
-import EventDetailModal from '../components/EventDetailModal';
-import EventCardImage from '../components/EventCardImage';
-import { useAdmin, useAuth } from '../context';
-import { useAutoFillOnTab, useTranslationAutoFill } from '../hooks';
 import {
-  getEventsByStatus, createEvent, updateEvent, deleteEvent,
-  getEventWithRecurrence, createEventRecurrence, updateEventRecurrence, deleteEventRecurrence
-} from '../api';
-import { uploadImage } from '../api/homepageSections';
-
-// Design tokens — match the redesigned HomePage / NavBar
-const ORANGE = '#FFA500';
-const ORANGE_DARK = '#F29400';
-const ORANGE_BG = '#FFF6E8';
-const LINE = '#EEE7DC';
-const INK = '#212121';
-const MUTED = '#757575';
-
-const MONTHS = ['JAN', 'FEB', 'MAR', 'APR', 'MAY', 'JUN', 'JUL', 'AUG', 'SEP', 'OCT', 'NOV', 'DEC'];
-
-// Parse an event date (YYYY-MM-DD) into { day, month } for the date bubble
-function parseBubbleDate(dateStr) {
-  if (!dateStr) return null;
-  const d = new Date(`${dateStr}T00:00:00`);
-  if (isNaN(d.getTime())) return null;
-  return { day: d.getDate(), month: MONTHS[d.getMonth()] };
-}
+  Alert, Box, Button, CircularProgress, Container, Dialog, DialogActions,
+  DialogContent, DialogTitle, Grid, IconButton, MenuItem, Snackbar, TextField,
+  Tooltip, Typography,
+} from '@mui/material';
+import { useCallback, useEffect, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import EventCard from '../components/EventCard';
+import EventComposer from '../components/EventComposer';
+import EventDetailModal from '../components/EventDetailModal';
+import { useAdmin, useAuth } from '../context';
+import { getEventsByStatus, updateEvent, deleteEvent } from '../api';
+import { ORANGE, ORANGE_DARK, LINE, INK, MUTED } from '../theme/tokens';
 
 // Pill styling for the filter selects
 const filterPillSx = {
@@ -50,31 +29,6 @@ const filterPillSx = {
   '& .MuiInputLabel-root.Mui-focused': { color: ORANGE },
 };
 
-const initialFormData = {
-  name: '',
-  chinese_name: '',
-  date: '',
-  time: '',
-  location: '',
-  chinese_location: '',
-  description: '',
-  chinese_description: '',
-  image: '',
-  signup_link: '',
-  status: 'Upcoming',
-  is_highlight: false,
-  event_type: 'standard',
-  heylo_embed: '',
-  // Recurrence fields
-  is_recurring: false,
-  recurrence_type: 'weekly',
-  days_of_week: '',
-  day_of_month: '',
-  week_of_month: '',
-  month_of_year: '',
-  recurrence_end_date: ''
-};
-
 export default function CalendarPage() {
   const { adminModeEnabled } = useAdmin();
   const { currentUser } = useAuth();
@@ -82,162 +36,73 @@ export default function CalendarPage() {
   const [selectedEvent, setSelectedEvent] = useState(null);
   const [upcomingEvents, setUpcomingEvents] = useState([]);
   const [featuredEvents, setFeaturedEvents] = useState([]);
-  const [filters, setFilters] = useState({
-    showAvailable: true,
-    date: '',
-    location: '',
-    distance: '',
-    status: ''
-  });
+  const [filters, setFilters] = useState({ date: '' });
 
   // Admin event management state
-  const [eventFormOpen, setEventFormOpen] = useState(false);
-  const [formData, setFormData] = useState(initialFormData);
-  const [editingEventId, setEditingEventId] = useState(null);
-  const [hadRecurrenceRule, setHadRecurrenceRule] = useState(false);
+  const [composerOpen, setComposerOpen] = useState(false);
+  const [composerEvent, setComposerEvent] = useState(null);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [eventToDelete, setEventToDelete] = useState(null);
   const [loading, setLoading] = useState(false);
   const [snackbar, setSnackbar] = useState({ open: false, message: '', severity: 'success' });
 
-  // Image upload state
-  const [imageFile, setImageFile] = useState(null);
-  const [imagePreview, setImagePreview] = useState('');
-  const [uploadingImage, setUploadingImage] = useState(false);
-  const fileInputRef = useRef(null);
+  // Single fetch/transform used by the initial load, EventComposer's onSaved
+  // and the post-delete refresh. Keeps the camelCase projection that
+  // EventDetailModal (and the deep-link lookup) rely on.
+  const fetchEvents = useCallback(async () => {
+    try {
+      const events = await getEventsByStatus('Upcoming');
+      const currentYear = new Date().getFullYear();
 
-  // Quick QR upload state
-  const [quickQrEventId, setQuickQrEventId] = useState(null);
-  const [quickQrFile, setQuickQrFile] = useState(null);
-  const [quickQrPreview, setQuickQrPreview] = useState('');
-  const [quickQrDialogOpen, setQuickQrDialogOpen] = useState(false);
-  const [quickQrUploading, setQuickQrUploading] = useState(false);
-  const quickQrFileInputRef = useRef(null);
+      const transformedEvents = events
+        .filter(event => {
+          // Only include events from the current year
+          const eventYear = parseInt((event.date || '').split('-')[0], 10);
+          return eventYear === currentYear;
+        })
+        .map(event => {
+          // Parse the event date and time for the date filter
+          const [year, month, day] = (event.date || '').split('-').map(Number);
+          const timeStr = event.time || '';
+          const timeParts = timeStr ? timeStr.split(':').map(Number) : [0, 0];
+          const isPM = timeStr ? timeStr.toLowerCase().includes('pm') : false;
+          const hours = Math.min(Math.max(timeParts[0] || 0, 0), 23);
+          const minutes = Math.min(Math.max(timeParts[1] || 0, 0), 59);
+          const parsedDate = new Date(year, month - 1, day, isPM ? hours + 12 : hours, minutes);
 
-  // Default values for Tab auto-fill
-  const eventDefaultValues = {
-    name: 'New Event',
-    chinese_name: '新活动',
-    time: '8:00 AM',
-    location: 'Central Park',
-    chinese_location: '中央公园',
-    description: 'Event description goes here.',
-    chinese_description: '活动描述在此。',
-    signup_link: 'https://newbeerunningclub.org/signup'
-  };
+          return {
+            id: event.id,
+            name: event.name,
+            chineseName: event.chinese_name,
+            date: event.date,
+            time: event.time,
+            location: event.location,
+            chineseLocation: event.chinese_location,
+            description: event.description,
+            chineseDescription: event.chinese_description,
+            image: event.image,
+            image_position: event.image_position,
+            signupLink: event.signup_link,
+            status: event.status,
+            eventType: event.event_type || 'standard',
+            heyloEmbed: event.heylo_embed || '',
+            wechatQrCode: event.wechat_qr_code || '',
+            parsedDate,
+          };
+        })
+        .sort((a, b) => a.date.localeCompare(b.date)); // Chronological order
 
-  const handleAutoFill = useAutoFillOnTab({
-    setValue: (field, value) => setFormData(prev => ({ ...prev, [field]: value })),
-    defaultValues: eventDefaultValues
-  });
-
-  // Translation auto-fill for bilingual fields
-  const {
-    handleKeyDown: handleTranslationKeyDown,
-    handleBlur: handleTranslationBlur,
-    translations,
-    isTranslating
-  } = useTranslationAutoFill({
-    setValue: (field, value) => setFormData(prev => ({ ...prev, [field]: value })),
-    getValue: (field) => formData[field],
-    fieldPairs: [
-      ['name', 'chinese_name'],
-      ['location', 'chinese_location'],
-      ['description', 'chinese_description']
-    ]
-  });
-
-  // Combined key down handler for both auto-fill and translation
-  const handleFieldKeyDown = (event) => {
-    handleAutoFill(event);
-    handleTranslationKeyDown(event);
-  };
-
-  const handleImageError = (e) => {
-    console.error('Image failed to load:', e.target.src);
-    e.target.src = '/images/placeholder-event.jpg';
-  };
+      setUpcomingEvents(transformedEvents);
+      setFeaturedEvents(transformedEvents.slice(0, 3));
+    } catch (error) {
+      console.error('Error loading events:', error);
+      setSnackbar({ open: true, message: 'Failed to load events / 加载活动失败', severity: 'error' });
+    }
+  }, []);
 
   useEffect(() => {
-    // Fetch events from API
-    const fetchEvents = async () => {
-      try {
-        const events = await getEventsByStatus('Upcoming');
-        console.log('Fetched events from API:', events);
-
-        // Get current year
-        const currentYear = new Date().getFullYear();
-
-        // Transform API response to match expected format and filter for current year
-        const transformedEvents = events
-          .filter(event => {
-            // Only include events from the current year
-            const eventYear = parseInt((event.date || '').split('-')[0], 10);
-            return eventYear === currentYear;
-          })
-          .map(event => {
-            // Parse the event date and time for filtering
-            const [year, month, day] = (event.date || '').split('-').map(Number);
-            const timeStr = event.time || '';
-            const timeParts = timeStr ? timeStr.split(':').map(Number) : [0, 0];
-            const isPM = timeStr ? timeStr.toLowerCase().includes('pm') : false;
-            const hours = Math.min(Math.max(timeParts[0] || 0, 0), 23);
-            const minutes = Math.min(Math.max(timeParts[1] || 0, 0), 59);
-            const eventDate = new Date(year, month - 1, day, isPM ? hours + 12 : hours, minutes);
-
-            return {
-              id: event.id,
-              name: event.name,
-              chineseName: event.chinese_name,
-              date: event.date,
-              time: event.time,
-              location: event.location,
-              chineseLocation: event.chinese_location,
-              description: event.description,
-              chineseDescription: event.chinese_description,
-              image: event.image,
-              image_position: event.image_position,
-              signupLink: event.signup_link,
-              status: event.status,
-              eventType: event.event_type || 'standard',
-              heyloEmbed: event.heylo_embed || '',
-              wechatQrCode: event.wechat_qr_code || '',
-              parsedDate: eventDate
-            };
-          }).sort((a, b) => a.date.localeCompare(b.date)); // Sort in chronological order
-
-        console.log('Transformed upcoming events:', transformedEvents);
-
-        // Set upcoming events
-        setUpcomingEvents(transformedEvents);
-
-        // Set featured events (first 3 events)
-        setFeaturedEvents(transformedEvents.slice(0, 3).map(event => ({
-          id: event.id,
-          title: event.name,
-          chineseTitle: event.chineseName,
-          image: event.image,
-          image_position: event.image_position,
-          description: event.description,
-          date: event.date,
-          time: event.time,
-          location: event.location,
-          chineseLocation: event.chineseLocation,
-          chineseDescription: event.chineseDescription,
-          signupLink: event.signupLink,
-          status: event.status,
-          eventType: event.eventType,
-          heyloEmbed: event.heyloEmbed,
-          wechatQrCode: event.wechatQrCode
-        })));
-      } catch (error) {
-        console.error('Error loading events:', error);
-        setSnackbar({ open: true, message: 'Failed to load events / 加载活动失败', severity: 'error' });
-      }
-    };
-
     fetchEvents();
-  }, []);
+  }, [fetchEvents]);
 
   // Deep-link: auto-open event modal from ?event=ID
   useEffect(() => {
@@ -260,8 +125,7 @@ export default function CalendarPage() {
     setSearchParams({});
   };
 
-  const handleShareEvent = (e, event) => {
-    e.stopPropagation();
+  const handleShareEvent = (event) => {
     const url = `${window.location.origin}/calendar?event=${event.id}`;
     navigator.clipboard.writeText(url).then(() => {
       setSnackbar({ open: true, message: 'Link copied / 链接已复制', severity: 'success' });
@@ -277,226 +141,35 @@ export default function CalendarPage() {
     });
   };
 
-  const handleEditEvent = (e, event) => {
-    e.stopPropagation();
-    // Pre-fill form with event data — legacy 'Highlight' status maps to Past + is_highlight
-    const rawStatus = event.status || 'Upcoming';
-    const normalizedStatus = rawStatus === 'Highlight' ? 'Past' : rawStatus;
-    const isHighlight = event.is_highlight === true || rawStatus === 'Highlight';
-    setFormData({
-      ...initialFormData,
-      name: event.name || event.title || '',
-      chinese_name: event.chineseName || event.chineseTitle || '',
-      date: event.date || '',
-      time: event.time || '',
-      location: event.location || '',
-      chinese_location: event.chineseLocation || '',
-      description: event.description || '',
-      chinese_description: event.chineseDescription || '',
-      image: event.image || '',
-      signup_link: event.signupLink || '',
-      status: normalizedStatus,
-      is_highlight: isHighlight,
-      event_type: event.eventType || event.event_type || 'standard',
-      heylo_embed: event.heyloEmbed || event.heylo_embed || ''
-    });
-    setEditingEventId(event.id);
-    setHadRecurrenceRule(false);
-    setImageFile(null);
-    setImagePreview(event.image || '');
-    if (fileInputRef.current) {
-      fileInputRef.current.value = '';
-    }
-    setEventFormOpen(true);
-    // Load the recurrence rule (if any) to populate the recurrence section
-    getEventWithRecurrence(event.id)
-      .then((full) => {
-        const rule = full?.recurrence;
-        if (!rule) return;
-        setHadRecurrenceRule(true);
-        setFormData(prev => ({
-          ...prev,
-          is_recurring: true,
-          recurrence_type: rule.recurrence_type || 'weekly',
-          days_of_week: rule.days_of_week || '',
-          day_of_month: rule.day_of_month != null ? String(rule.day_of_month) : '',
-          week_of_month: rule.week_of_month != null ? String(rule.week_of_month) : '',
-          month_of_year: rule.month_of_year != null ? String(rule.month_of_year) : '',
-          recurrence_end_date: rule.end_date || ''
-        }));
-      })
-      .catch((error) => {
-        console.error('Error loading recurrence rule:', error);
-      });
+  const handleAddEvent = () => {
+    setComposerEvent(null);
+    setComposerOpen(true);
   };
 
-  const handleDeleteEvent = (e, event) => {
-    e.stopPropagation();
+  const handleEditEvent = (event) => {
+    setComposerEvent(event);
+    setComposerOpen(true);
+  };
+
+  const handleDeleteEvent = (event) => {
     setEventToDelete(event);
     setDeleteDialogOpen(true);
   };
 
-  const handleMoveToHighlights = async (e, event) => {
-    e.stopPropagation();
+  const handleMoveToMemories = async (event) => {
     if (!currentUser?.uid) {
       setSnackbar({ open: true, message: 'You must be logged in / 您必须登录', severity: 'error' });
       return;
     }
     try {
       // Move from Upcoming -> Past (Memories). Highlight curation is a
-      // separate toggle in the event edit dialog and is preserved here.
+      // separate toggle in the event composer and is preserved here.
       await updateEvent(event.id, { status: 'Past' }, currentUser.uid);
       setUpcomingEvents(prev => prev.filter(ev => ev.id !== event.id));
       setSnackbar({ open: true, message: 'Event moved to Memories / 活动已移至回忆', severity: 'success' });
     } catch (error) {
       console.error('Error moving event to memories:', error);
       setSnackbar({ open: true, message: 'Failed to move event / 移动活动失败', severity: 'error' });
-    }
-  };
-
-  const handleAddEvent = () => {
-    setFormData(initialFormData);
-    setEditingEventId(null);
-    setHadRecurrenceRule(false);
-    setImageFile(null);
-    setImagePreview('');
-    if (fileInputRef.current) {
-      fileInputRef.current.value = '';
-    }
-    setEventFormOpen(true);
-  };
-
-  const handleFormChange = (field) => (e) => {
-    setFormData(prev => ({
-      ...prev,
-      [field]: e.target.value
-    }));
-  };
-
-  const syncRecurrenceRule = async (eventId) => {
-    if (formData.is_recurring) {
-      const rulePayload = {
-        recurrence_type: formData.recurrence_type,
-        days_of_week: formData.days_of_week || null,
-        day_of_month: formData.day_of_month ? Number(formData.day_of_month) : null,
-        week_of_month: formData.week_of_month ? Number(formData.week_of_month) : null,
-        month_of_year: formData.month_of_year ? Number(formData.month_of_year) : null,
-        end_date: formData.recurrence_end_date || null
-      };
-      if (hadRecurrenceRule) {
-        await updateEventRecurrence(eventId, rulePayload, currentUser.uid);
-      } else {
-        try {
-          await createEventRecurrence(eventId, rulePayload, currentUser.uid);
-        } catch (error) {
-          // A rule already exists (stale local state) — update it instead
-          if (error.status === 400) {
-            await updateEventRecurrence(eventId, rulePayload, currentUser.uid);
-          } else {
-            throw error;
-          }
-        }
-      }
-    } else if (hadRecurrenceRule) {
-      await deleteEventRecurrence(eventId, currentUser.uid);
-    }
-  };
-
-  const handleFormSubmit = async () => {
-    // Validate required fields
-    if (!formData.name || !formData.date) {
-      setSnackbar({ open: true, message: 'Name and date are required / 名称和日期为必填项', severity: 'error' });
-      return;
-    }
-
-    if (!currentUser?.uid) {
-      setSnackbar({ open: true, message: 'You must be logged in to manage events / 您必须登录才能管理活动', severity: 'error' });
-      return;
-    }
-
-    setLoading(true);
-    try {
-      // Upload image if a new file was selected
-      let imageUrl = formData.image;
-      if (imageFile) {
-        imageUrl = await handleImageUpload();
-      }
-
-      // Recurrence is managed via the dedicated rule endpoints below,
-      // not the event payload
-      const {
-        is_recurring, recurrence_type, days_of_week, day_of_month,
-        week_of_month, month_of_year, recurrence_end_date,
-        ...eventFields
-      } = { ...formData, image: imageUrl };
-
-      // Convert empty strings to null for backend validation
-      const cleanedEventData = Object.fromEntries(
-        Object.entries(eventFields).map(([key, value]) => [key, value === '' ? null : value])
-      );
-
-      let eventId = editingEventId;
-      if (editingEventId) {
-        // Update existing event
-        await updateEvent(editingEventId, cleanedEventData, currentUser.uid);
-        setSnackbar({ open: true, message: 'Event updated successfully / 活动已更新', severity: 'success' });
-      } else {
-        // Create new event
-        const createdEvent = await createEvent(cleanedEventData, currentUser.uid);
-        eventId = createdEvent.id;
-        setSnackbar({ open: true, message: 'Event created successfully / 活动已创建', severity: 'success' });
-      }
-
-      await syncRecurrenceRule(eventId);
-      setEventFormOpen(false);
-      setFormData(initialFormData);
-      setEditingEventId(null);
-      setImageFile(null);
-      setImagePreview('');
-      // Refresh events
-      const events = await getEventsByStatus('Upcoming');
-      const transformedEvents = events.map(event => ({
-        id: event.id,
-        name: event.name,
-        chineseName: event.chinese_name,
-        date: event.date,
-        time: event.time,
-        location: event.location,
-        chineseLocation: event.chinese_location,
-        description: event.description,
-        chineseDescription: event.chinese_description,
-        image: event.image,
-        image_position: event.image_position,
-        signupLink: event.signup_link,
-        status: event.status,
-        eventType: event.event_type || 'standard',
-        heyloEmbed: event.heylo_embed || '',
-        wechatQrCode: event.wechat_qr_code || ''
-      })).sort((a, b) => a.date.localeCompare(b.date));
-      setUpcomingEvents(transformedEvents);
-      setFeaturedEvents(transformedEvents.slice(0, 3).map(event => ({
-        id: event.id,
-        title: event.name,
-        chineseTitle: event.chineseName,
-        image: event.image,
-        image_position: event.image_position,
-        description: event.description,
-        date: event.date,
-        time: event.time,
-        location: event.location,
-        chineseLocation: event.chineseLocation,
-        chineseDescription: event.chineseDescription,
-        signupLink: event.signupLink,
-        status: event.status,
-        eventType: event.eventType,
-        heyloEmbed: event.heyloEmbed,
-        wechatQrCode: event.wechatQrCode
-      })));
-    } catch (error) {
-      console.error('Error saving event:', error);
-      setSnackbar({ open: true, message: `Error: ${error.message || 'Failed to save event'}`, severity: 'error' });
-    } finally {
-      setLoading(false);
     }
   };
 
@@ -512,45 +185,7 @@ export default function CalendarPage() {
       setSnackbar({ open: true, message: 'Event deleted successfully / 活动已删除', severity: 'success' });
       setDeleteDialogOpen(false);
       setEventToDelete(null);
-      // Refresh events
-      const events = await getEventsByStatus('Upcoming');
-      const transformedEvents = events.map(event => ({
-        id: event.id,
-        name: event.name,
-        chineseName: event.chinese_name,
-        date: event.date,
-        time: event.time,
-        location: event.location,
-        chineseLocation: event.chinese_location,
-        description: event.description,
-        chineseDescription: event.chinese_description,
-        image: event.image,
-        image_position: event.image_position,
-        signupLink: event.signup_link,
-        status: event.status,
-        eventType: event.event_type || 'standard',
-        heyloEmbed: event.heylo_embed || '',
-        wechatQrCode: event.wechat_qr_code || ''
-      })).sort((a, b) => a.date.localeCompare(b.date));
-      setUpcomingEvents(transformedEvents);
-      setFeaturedEvents(transformedEvents.slice(0, 3).map(event => ({
-        id: event.id,
-        title: event.name,
-        chineseTitle: event.chineseName,
-        image: event.image,
-        image_position: event.image_position,
-        description: event.description,
-        date: event.date,
-        time: event.time,
-        location: event.location,
-        chineseLocation: event.chineseLocation,
-        chineseDescription: event.chineseDescription,
-        signupLink: event.signupLink,
-        status: event.status,
-        eventType: event.eventType,
-        heyloEmbed: event.heyloEmbed,
-        wechatQrCode: event.wechatQrCode
-      })));
+      await fetchEvents();
     } catch (error) {
       console.error('Error deleting event:', error);
       setSnackbar({ open: true, message: `Error: ${error.message || 'Failed to delete event'}`, severity: 'error' });
@@ -563,117 +198,29 @@ export default function CalendarPage() {
     setSnackbar(prev => ({ ...prev, open: false }));
   };
 
-  const handleImageSelect = (e) => {
-    const file = e.target.files[0];
-    if (file) {
-      // Validate file type
-      if (!file.type.startsWith('image/')) {
-        setSnackbar({ open: true, message: 'Please select an image file / 请选择图片文件', severity: 'error' });
-        return;
-      }
-      // Validate file size (max 5MB)
-      if (file.size > 5 * 1024 * 1024) {
-        setSnackbar({ open: true, message: 'Image must be less than 5MB / 图片必须小于5MB', severity: 'error' });
-        return;
-      }
-      setImageFile(file);
-      // Create preview URL
-      const previewUrl = URL.createObjectURL(file);
-      setImagePreview(previewUrl);
-    }
-  };
+  // Small icon cluster passed into EventCard's top-right slot (the card
+  // wrapper already stopPropagation's clicks, so plain handlers suffice)
+  const renderAdminActions = (event) => (
+    <>
+      <Tooltip title="Edit event / 编辑活动">
+        <IconButton size="small" aria-label="edit event" onClick={() => handleEditEvent(event)}>
+          <EditIcon sx={{ fontSize: 16 }} color="primary" />
+        </IconButton>
+      </Tooltip>
+      <Tooltip title="Delete event / 删除活动">
+        <IconButton size="small" aria-label="delete event" onClick={() => handleDeleteEvent(event)}>
+          <DeleteIcon sx={{ fontSize: 16 }} color="error" />
+        </IconButton>
+      </Tooltip>
+      <Tooltip title="Move to Memories / 移至回忆">
+        <IconButton size="small" aria-label="move to memories" onClick={() => handleMoveToMemories(event)}>
+          <StarIcon sx={{ fontSize: 16, color: '#FFB84D' }} />
+        </IconButton>
+      </Tooltip>
+    </>
+  );
 
-  const handleImageUpload = async () => {
-    if (!imageFile) return formData.image;
-
-    setUploadingImage(true);
-    try {
-      // Upload to S3 via the backend (Firebase Storage quota is exceeded)
-      const { url } = await uploadImage(imageFile, currentUser.uid);
-      return url;
-    } catch (error) {
-      console.error('Error uploading image:', error);
-      throw new Error('Failed to upload image / 图片上传失败');
-    } finally {
-      setUploadingImage(false);
-    }
-  };
-
-  const handleRemoveImage = () => {
-    setImageFile(null);
-    setImagePreview('');
-    setFormData(prev => ({ ...prev, image: '' }));
-    if (fileInputRef.current) {
-      fileInputRef.current.value = '';
-    }
-  };
-
-  // Quick QR upload handlers
-  const getEventQrCode = (eventId) => {
-    const event = [...featuredEvents, ...upcomingEvents].find(ev => ev.id === eventId);
-    return event?.wechatQrCode || '';
-  };
-
-  const handleQuickQrOpen = (e, event) => {
-    e.stopPropagation();
-    setQuickQrEventId(event.id);
-    setQuickQrFile(null);
-    setQuickQrPreview('');
-    if (quickQrFileInputRef.current) quickQrFileInputRef.current.value = '';
-    setQuickQrDialogOpen(true);
-  };
-
-  const handleQuickQrSelect = (e) => {
-    const file = e.target.files[0];
-    if (file) {
-      if (!file.type.startsWith('image/')) {
-        setSnackbar({ open: true, message: 'Please select an image file / 请选择图片文件', severity: 'error' });
-        return;
-      }
-      if (file.size > 5 * 1024 * 1024) {
-        setSnackbar({ open: true, message: 'Image must be less than 5MB / 图片必须小于5MB', severity: 'error' });
-        return;
-      }
-      setQuickQrFile(file);
-      setQuickQrPreview(URL.createObjectURL(file));
-    }
-  };
-
-  const handleQuickQrSubmit = async () => {
-    if (!quickQrFile || !quickQrEventId) return;
-    setQuickQrUploading(true);
-    try {
-      const { url } = await uploadImage(quickQrFile, currentUser.uid);
-      await updateEvent(quickQrEventId, { wechat_qr_code: url }, currentUser.uid);
-      const updateList = (list) => list.map(ev => ev.id === quickQrEventId ? { ...ev, wechatQrCode: url } : ev);
-      setFeaturedEvents(updateList);
-      setUpcomingEvents(updateList);
-      setQuickQrDialogOpen(false);
-      setSnackbar({ open: true, message: 'QR code uploaded / 二维码已上传', severity: 'success' });
-    } catch (error) {
-      console.error('Error uploading QR code:', error);
-      setSnackbar({ open: true, message: 'Failed to upload QR code / 二维码上传失败', severity: 'error' });
-    } finally {
-      setQuickQrUploading(false);
-    }
-  };
-
-  const handleQuickQrRemove = async () => {
-    if (!quickQrEventId) return;
-    try {
-      await updateEvent(quickQrEventId, { wechat_qr_code: '' }, currentUser.uid);
-      const updateList = (list) => list.map(ev => ev.id === quickQrEventId ? { ...ev, wechatQrCode: '' } : ev);
-      setFeaturedEvents(updateList);
-      setUpcomingEvents(updateList);
-      setQuickQrDialogOpen(false);
-      setSnackbar({ open: true, message: 'QR code removed / 二维码已移除', severity: 'success' });
-    } catch (error) {
-      console.error('Error removing QR code:', error);
-      setSnackbar({ open: true, message: 'Failed to remove QR code / 移除二维码失败', severity: 'error' });
-    }
-  };
-
-  // Filter events based on selected filters
+  // Filter events based on the selected date range
   const filteredEvents = upcomingEvents.filter(event => {
     if (filters.date) {
       const referenceDate = new Date();
@@ -697,14 +244,6 @@ export default function CalendarPage() {
       }
     }
 
-    if (filters.location && event.location.toLowerCase() !== filters.location.toLowerCase()) {
-      return false;
-    }
-
-    if (filters.status && event.status.toLowerCase() !== filters.status.toLowerCase()) {
-      return false;
-    }
-
     return true;
   });
 
@@ -722,14 +261,14 @@ export default function CalendarPage() {
         </Container>
       )}
 
-      {/* Upcoming Events Section */}
+      {/* Featured Upcoming Events */}
       <Container maxWidth="xl" sx={{ px: { xs: 1, sm: 2 }, mt: 3 }}>
         <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 1.25, mb: 1.75 }}>
           <Typography sx={{ fontSize: '1.25rem', fontWeight: 700, color: INK }}>
             Upcoming Events
           </Typography>
           <Typography sx={{ fontSize: '0.875rem', color: MUTED }}>
-            即将举行的活动
+            近期活动
           </Typography>
         </Box>
 
@@ -760,482 +299,63 @@ export default function CalendarPage() {
         <Grid container spacing={3}>
           {featuredEvents.map((event) => (
             <Grid item xs={12} md={4} key={event.id}>
-              <Card
-                elevation={0}
-                sx={{
-                  height: '100%',
-                  display: 'flex',
-                  flexDirection: 'column',
-                  cursor: 'pointer',
-                  position: 'relative',
-                  backgroundColor: 'white',
-                  border: `1px solid ${LINE}`,
-                  borderRadius: '12px',
-                  boxShadow: '0 2px 4px rgba(0,0,0,0.08)',
-                  transition: 'all 0.2s ease',
-                  '&:hover': {
-                    transform: 'translateY(-3px)',
-                    boxShadow: '0 8px 24px rgba(255,165,0,0.35)'
-                  }
-                }}
-                onClick={() => handleEventClick(event)}
-              >
-                {/* Admin Edit/Delete Buttons */}
-                {adminModeEnabled && (
-                  <Box
-                    sx={{
-                      position: 'absolute',
-                      top: 8,
-                      right: 8,
-                      zIndex: 10,
-                      display: 'flex',
-                      gap: 0.5
-                    }}
-                  >
-                    <Tooltip title="Edit event / 编辑活动">
-                      <IconButton
-                        size="small"
-                        onClick={(e) => handleEditEvent(e, event)}
-                        sx={{
-                          backgroundColor: 'rgba(255, 255, 255, 0.9)',
-                          '&:hover': { backgroundColor: 'white' }
-                        }}
-                      >
-                        <EditIcon fontSize="small" color="primary" />
-                      </IconButton>
-                    </Tooltip>
-                    <Tooltip title="Delete event / 删除活动">
-                      <IconButton
-                        size="small"
-                        onClick={(e) => handleDeleteEvent(e, event)}
-                        sx={{
-                          backgroundColor: 'rgba(255, 255, 255, 0.9)',
-                          '&:hover': { backgroundColor: 'white' }
-                        }}
-                      >
-                        <DeleteIcon fontSize="small" color="error" />
-                      </IconButton>
-                    </Tooltip>
-                    <Tooltip title="Move to Memories / 移至回忆">
-                      <IconButton
-                        size="small"
-                        onClick={(e) => handleMoveToHighlights(e, event)}
-                        sx={{
-                          backgroundColor: 'rgba(255, 255, 255, 0.9)',
-                          '&:hover': { backgroundColor: 'white' }
-                        }}
-                      >
-                        <StarIcon fontSize="small" sx={{ color: '#FFB84D' }} />
-                      </IconButton>
-                    </Tooltip>
-                    <Tooltip title="Upload WeChat QR / 上传微信二维码">
-                      <IconButton
-                        size="small"
-                        onClick={(e) => handleQuickQrOpen(e, event)}
-                        sx={{
-                          backgroundColor: 'rgba(255, 255, 255, 0.9)',
-                          '&:hover': { backgroundColor: 'white' }
-                        }}
-                      >
-                        <QrCode2Icon fontSize="small" sx={{ color: event.wechatQrCode ? '#07C160' : 'action.active' }} />
-                      </IconButton>
-                    </Tooltip>
-                  </Box>
-                )}
-                <Box sx={{ position: 'relative' }}>
-                  <EventCardImage event={event} height="200" onError={handleImageError} />
-                  {!adminModeEnabled && (
-                    <IconButton
-                      size="small"
-                      onClick={(e) => handleShareEvent(e, event)}
-                      sx={{
-                        position: 'absolute',
-                        top: 8,
-                        right: 8,
-                        backgroundColor: 'rgba(255, 255, 255, 0.9)',
-                        '&:hover': { backgroundColor: 'rgba(255, 255, 255, 1)' },
-                      }}
-                    >
-                      <ShareIcon fontSize="small" />
-                    </IconButton>
-                  )}
-                </Box>
-                <CardContent sx={{ flexGrow: 1, display: 'flex', flexDirection: 'column' }}>
-                  <Typography gutterBottom variant="h6" component="div" sx={{
-                    overflow: 'hidden',
-                    display: '-webkit-box',
-                    WebkitLineClamp: 1,
-                    WebkitBoxOrient: 'vertical',
-                  }}>
-                    {event.title}
-                  </Typography>
-                  <Typography gutterBottom variant="subtitle1" color="text.secondary" sx={{
-                    overflow: 'hidden',
-                    display: '-webkit-box',
-                    WebkitLineClamp: 1,
-                    WebkitBoxOrient: 'vertical',
-                    minHeight: '1.75em',
-                  }}>
-                    {event.chineseTitle || '\u00A0'}
-                  </Typography>
-                  <Typography variant="body2" color="text.secondary" sx={{
-                    mb: 2,
-                    overflow: 'hidden',
-                    display: '-webkit-box',
-                    WebkitLineClamp: 3,
-                    WebkitBoxOrient: 'vertical',
-                    minHeight: '3.6em',
-                  }}>
-                    {event.description}
-                  </Typography>
-                  <Button
-                    variant="contained"
-                    disableElevation
-                    sx={{
-                      backgroundColor: ORANGE,
-                      color: 'white',
-                      textTransform: 'none',
-                      fontWeight: 600,
-                      fontSize: '0.9375rem',
-                      px: 2.5,
-                      py: 1.1,
-                      borderRadius: '99px',
-                      mt: 'auto',
-                      '&:hover': {
-                        backgroundColor: ORANGE_DARK,
-                      },
-                      '&:active': {
-                        transform: 'scale(0.98)',
-                      }
-                    }}
-                  >
-                    Learn More & Sign Up 了解更多并报名
-                  </Button>
-                </CardContent>
-              </Card>
+              <EventCard
+                event={event}
+                density="grid"
+                showDescription
+                onClick={handleEventClick}
+                onShare={handleShareEvent}
+                adminActions={adminModeEnabled ? renderAdminActions(event) : null}
+              />
             </Grid>
           ))}
         </Grid>
       </Container>
 
-      {/* Event Calendar Section */}
+      {/* All Upcoming Events */}
       <Container maxWidth="xl" sx={{ px: { xs: 1, sm: 2 }, mt: 5 }}>
         <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 1.25, mb: 1.75 }}>
           <Typography sx={{ fontSize: '1.05rem', fontWeight: 700, color: INK }}>
-            Upcoming
+            All Upcoming
           </Typography>
           <Typography sx={{ fontSize: '0.875rem', color: MUTED }}>
-            即将到来
+            全部活动
           </Typography>
         </Box>
 
         {/* Filters */}
         <Box sx={{ display: 'flex', mb: 3 }}>
           <Grid container spacing={2} sx={{ maxWidth: 1000 }}>
-          <Grid item xs={12} sm={6} md={3}>
-            <TextField
-              select
-              fullWidth
-              size="small"
-              sx={filterPillSx}
-              label="Date"
-              value={filters.date}
-              onChange={handleFilterChange('date')}
-            >
-              <MenuItem value="">All Dates</MenuItem>
-              <MenuItem value="this-week">This Week</MenuItem>
-              <MenuItem value="this-month">This Month</MenuItem>
-              <MenuItem value="next-month">Next Month</MenuItem>
-            </TextField>
-          </Grid>
-          <Grid item xs={12} sm={6} md={3}>
-            <TextField
-              select
-              fullWidth
-              size="small"
-              sx={filterPillSx}
-              label="Location"
-              value={filters.location}
-              onChange={handleFilterChange('location')}
-            >
-              <MenuItem value="">All Locations</MenuItem>
-              <MenuItem value="central-park">Central Park</MenuItem>
-              <MenuItem value="track-field">Track Field</MenuItem>
-              <MenuItem value="brooklyn">Brooklyn</MenuItem>
-            </TextField>
-          </Grid>
-          <Grid item xs={12} sm={6} md={3}>
-            <TextField
-              select
-              fullWidth
-              size="small"
-              sx={filterPillSx}
-              label="Distance"
-              value={filters.distance}
-              onChange={handleFilterChange('distance')}
-            >
-              <MenuItem value="">All Distances</MenuItem>
-              <MenuItem value="5k">5K</MenuItem>
-              <MenuItem value="10k">10K</MenuItem>
-              <MenuItem value="half-marathon">Half Marathon</MenuItem>
-              <MenuItem value="marathon">Marathon</MenuItem>
-            </TextField>
-          </Grid>
-          <Grid item xs={12} sm={6} md={3}>
-            <TextField
-              select
-              fullWidth
-              size="small"
-              sx={filterPillSx}
-              label="Status"
-              value={filters.status}
-              onChange={handleFilterChange('status')}
-            >
-              <MenuItem value="">All Status</MenuItem>
-              <MenuItem value="open">Open</MenuItem>
-              <MenuItem value="closed">Closed</MenuItem>
-              <MenuItem value="upcoming">Upcoming</MenuItem>
-            </TextField>
-          </Grid>
+            <Grid item xs={12} sm={6} md={3}>
+              <TextField
+                select
+                fullWidth
+                size="small"
+                sx={filterPillSx}
+                label="Date"
+                value={filters.date}
+                onChange={handleFilterChange('date')}
+              >
+                <MenuItem value="">All Dates</MenuItem>
+                <MenuItem value="this-week">This Week</MenuItem>
+                <MenuItem value="this-month">This Month</MenuItem>
+                <MenuItem value="next-month">Next Month</MenuItem>
+              </TextField>
+            </Grid>
           </Grid>
         </Box>
 
         {/* Events List */}
         <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
           {filteredEvents.map((event) => (
-            <Card
+            <EventCard
               key={event.id}
-              elevation={0}
-              sx={{
-                display: 'flex',
-                flexDirection: { xs: 'column', sm: 'row' },
-                height: { xs: 'auto', sm: '200px' },
-                overflow: 'hidden',
-                cursor: 'pointer',
-                position: 'relative',
-                backgroundColor: 'white',
-                border: `1px solid ${LINE}`,
-                borderRadius: '12px',
-                boxShadow: '0 2px 4px rgba(0,0,0,0.08)',
-                transition: 'all 0.2s ease',
-                '&:hover': {
-                  transform: 'translateY(-3px)',
-                  boxShadow: '0 8px 24px rgba(255,165,0,0.35)'
-                }
-              }}
-              onClick={() => handleEventClick(event)}
-            >
-              {/* Admin Edit/Delete Buttons for list view */}
-              {adminModeEnabled && (
-                <Box
-                  sx={{
-                    position: 'absolute',
-                    top: 8,
-                    right: 8,
-                    zIndex: 10,
-                    display: 'flex',
-                    gap: 0.5
-                  }}
-                >
-                  <Tooltip title="Edit event / 编辑活动">
-                    <IconButton
-                      size="small"
-                      onClick={(e) => handleEditEvent(e, event)}
-                      sx={{
-                        backgroundColor: 'rgba(255, 255, 255, 0.9)',
-                        '&:hover': { backgroundColor: 'white' }
-                      }}
-                    >
-                      <EditIcon fontSize="small" color="primary" />
-                    </IconButton>
-                  </Tooltip>
-                  <Tooltip title="Delete event / 删除活动">
-                    <IconButton
-                      size="small"
-                      onClick={(e) => handleDeleteEvent(e, event)}
-                      sx={{
-                        backgroundColor: 'rgba(255, 255, 255, 0.9)',
-                        '&:hover': { backgroundColor: 'white' }
-                      }}
-                    >
-                      <DeleteIcon fontSize="small" color="error" />
-                    </IconButton>
-                  </Tooltip>
-                  <Tooltip title="Move to Memories / 移至回忆">
-                    <IconButton
-                      size="small"
-                      onClick={(e) => handleMoveToHighlights(e, event)}
-                      sx={{
-                        backgroundColor: 'rgba(255, 255, 255, 0.9)',
-                        '&:hover': { backgroundColor: 'white' }
-                      }}
-                    >
-                      <StarIcon fontSize="small" sx={{ color: '#FFB84D' }} />
-                    </IconButton>
-                  </Tooltip>
-                  <Tooltip title="Upload WeChat QR / 上传微信二维码">
-                    <IconButton
-                      size="small"
-                      onClick={(e) => handleQuickQrOpen(e, event)}
-                      sx={{
-                        backgroundColor: 'rgba(255, 255, 255, 0.9)',
-                        '&:hover': { backgroundColor: 'white' }
-                      }}
-                    >
-                      <QrCode2Icon fontSize="small" sx={{ color: event.wechatQrCode ? '#07C160' : 'action.active' }} />
-                    </IconButton>
-                  </Tooltip>
-                </Box>
-              )}
-
-              {/* Mobile: Image at top */}
-              <Box
-                sx={{
-                  display: { xs: 'block', sm: 'none' },
-                  width: '100%',
-                  height: '150px'
-                }}
-              >
-                <EventCardImage event={event} onError={handleImageError} sx={{ height: '100%', width: '100%' }} />
-              </Box>
-
-              {/* Date/Time Column - hidden on mobile, shown on sm+ */}
-              <Box
-                sx={{
-                  display: { xs: 'none', sm: 'flex' },
-                  width: '120px',
-                  flexDirection: 'column',
-                  justifyContent: 'center',
-                  alignItems: 'center',
-                  gap: 0.75,
-                  backgroundColor: 'white',
-                  p: 2,
-                  borderRight: `1px solid ${LINE}`,
-                  whiteSpace: 'nowrap'
-                }}
-              >
-                {(() => {
-                  const bubbleDate = parseBubbleDate(event.date);
-                  return bubbleDate ? (
-                    <Box
-                      sx={{
-                        width: 46,
-                        height: 46,
-                        borderRadius: '12px',
-                        backgroundColor: ORANGE_BG,
-                        display: 'flex',
-                        flexDirection: 'column',
-                        alignItems: 'center',
-                        justifyContent: 'center',
-                      }}
-                    >
-                      <Typography sx={{ fontSize: '1rem', fontWeight: 700, color: ORANGE, lineHeight: 1.1 }}>
-                        {bubbleDate.day}
-                      </Typography>
-                      <Typography sx={{ fontSize: '0.59rem', fontWeight: 700, letterSpacing: '0.1em', color: MUTED, textTransform: 'uppercase' }}>
-                        {bubbleDate.month}
-                      </Typography>
-                    </Box>
-                  ) : (
-                    <Typography variant="body2" sx={{ color: MUTED, whiteSpace: 'nowrap' }}>
-                      {event.date}
-                    </Typography>
-                  );
-                })()}
-                <Typography sx={{ fontSize: '0.8rem', fontWeight: 600, color: ORANGE, whiteSpace: 'nowrap' }}>
-                  {event.time}
-                </Typography>
-              </Box>
-
-              {/* Image Column - hidden on mobile, shown on sm+ */}
-              <Box
-                sx={{
-                  display: { xs: 'none', sm: 'block' },
-                  width: '200px',
-                  flexShrink: 0
-                }}
-              >
-                <EventCardImage event={event} onError={handleImageError} sx={{ height: '100%', width: '100%' }} />
-              </Box>
-
-              {/* Content Column */}
-              <Box
-                sx={{
-                  flex: 1,
-                  p: 2,
-                  display: 'flex',
-                  flexDirection: 'column',
-                  position: 'relative'
-                }}
-              >
-                {/* Share button */}
-                <Box sx={{ position: 'absolute', top: 8, right: 8, zIndex: 10 }}>
-                  <IconButton
-                    size="small"
-                    onClick={(e) => handleShareEvent(e, event)}
-                    sx={{
-                      backgroundColor: 'rgba(255, 255, 255, 0.9)',
-                      '&:hover': { backgroundColor: 'rgba(255, 255, 255, 1)' },
-                    }}
-                  >
-                    <ShareIcon fontSize="small" />
-                  </IconButton>
-                </Box>
-                {/* Mobile: Show date/time at top of content */}
-                <Box sx={{ display: { xs: 'flex', sm: 'none' }, gap: 2, mb: 1, color: ORANGE }}>
-                  <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
-                    {event.time}
-                  </Typography>
-                  <Typography variant="subtitle1" color="text.secondary">
-                    {event.date}
-                  </Typography>
-                </Box>
-
-                <Box sx={{ display: 'flex', flexDirection: { xs: 'column', sm: 'row' }, justifyContent: 'space-between', alignItems: { xs: 'flex-start', sm: 'flex-start' }, mb: 1, gap: 1 }}>
-                  <Box>
-                    <Typography variant="h6" gutterBottom sx={{ fontSize: { xs: '1rem', sm: '1.25rem' } }}>
-                      {event.name}
-                    </Typography>
-                    <Typography variant="subtitle1" color="text.secondary" gutterBottom sx={{ fontSize: { xs: '0.875rem', sm: '1rem' } }}>
-                      {event.chineseName}
-                    </Typography>
-                  </Box>
-                  <Button
-                    variant="contained"
-                    disableElevation
-                    sx={{
-                      backgroundColor: ORANGE,
-                      color: 'white',
-                      textTransform: 'none',
-                      fontWeight: 600,
-                      fontSize: { xs: '0.8125rem', sm: '0.9375rem' },
-                      px: { xs: 2, sm: 2.5 },
-                      py: { xs: 0.75, sm: 1 },
-                      borderRadius: '99px',
-                      flexShrink: 0,
-                      '&:hover': {
-                        backgroundColor: ORANGE_DARK,
-                      },
-                      '&:active': {
-                        transform: 'scale(0.98)',
-                      }
-                    }}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      handleEventClick(event);
-                    }}
-                  >
-                    Learn More & Sign Up 了解更多并报名
-                  </Button>
-                </Box>
-                <Typography variant="body2" color="text.secondary" gutterBottom>
-                  {event.location}
-                </Typography>
-                <Typography variant="body2" color="text.secondary" gutterBottom>
-                  {event.chineseLocation}
-                </Typography>
-              </Box>
-            </Card>
+              event={event}
+              density="row"
+              onClick={handleEventClick}
+              onShare={handleShareEvent}
+              adminActions={adminModeEnabled ? renderAdminActions(event) : null}
+            />
           ))}
         </Box>
       </Container>
@@ -1251,427 +371,18 @@ export default function CalendarPage() {
               ev.id === updatedEvent.id ? { ...ev, ...updatedEvent } : ev
             );
             setUpcomingEvents(updateList);
-            setFeaturedEvents(prev => prev.map(ev =>
-              ev.id === updatedEvent.id ? { ...ev, ...updatedEvent } : ev
-            ));
+            setFeaturedEvents(updateList);
           }}
         />
       )}
 
-      {/* Event Form Dialog */}
-      <Dialog open={eventFormOpen} onClose={() => setEventFormOpen(false)} maxWidth="md" fullWidth>
-        <DialogTitle>
-          {editingEventId ? 'Edit Event / 编辑活动' : 'Add Event / 添加活动'}
-        </DialogTitle>
-        <DialogContent>
-          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, pt: 1 }}>
-            <TextField
-              name="name"
-              label="Event Name / 活动名称 *"
-              value={formData.name}
-              onChange={handleFormChange('name')}
-              onKeyDown={handleFieldKeyDown}
-              onBlur={handleTranslationBlur}
-              placeholder={eventDefaultValues.name}
-              fullWidth
-              required
-            />
-            <TextField
-              name="chinese_name"
-              label="Chinese Name / 中文名称"
-              value={formData.chinese_name}
-              onChange={handleFormChange('chinese_name')}
-              onKeyDown={handleFieldKeyDown}
-              onBlur={handleTranslationBlur}
-              placeholder={translations.chinese_name || eventDefaultValues.chinese_name}
-              fullWidth
-              InputProps={{
-                endAdornment: isTranslating && !formData.chinese_name && (
-                  <CircularProgress size={16} sx={{ mr: 1 }} />
-                )
-              }}
-              helperText={translations.chinese_name && !formData.chinese_name ? 'Press Tab to auto-fill translation' : ''}
-            />
-            <Box sx={{ display: 'flex', gap: 2 }}>
-              <TextField
-                label="Date / 日期 *"
-                type="date"
-                value={formData.date}
-                onChange={handleFormChange('date')}
-                fullWidth
-                required
-                InputLabelProps={{ shrink: true }}
-              />
-              <TextField
-                name="time"
-                label="Time / 时间"
-                value={formData.time}
-                onChange={handleFormChange('time')}
-                onKeyDown={handleFieldKeyDown}
-                fullWidth
-                placeholder={eventDefaultValues.time}
-              />
-            </Box>
-            <Box sx={{ display: 'flex', gap: 2 }}>
-              <TextField
-                name="location"
-                label="Location / 地点"
-                value={formData.location}
-                onChange={handleFormChange('location')}
-                onKeyDown={handleFieldKeyDown}
-                onBlur={handleTranslationBlur}
-                placeholder={eventDefaultValues.location}
-                fullWidth
-              />
-              <TextField
-                name="chinese_location"
-                label="Chinese Location / 中文地点"
-                value={formData.chinese_location}
-                onChange={handleFormChange('chinese_location')}
-                onKeyDown={handleFieldKeyDown}
-                onBlur={handleTranslationBlur}
-                placeholder={translations.chinese_location || eventDefaultValues.chinese_location}
-                fullWidth
-                InputProps={{
-                  endAdornment: isTranslating && !formData.chinese_location && (
-                    <CircularProgress size={16} sx={{ mr: 1 }} />
-                  )
-                }}
-                helperText={translations.chinese_location && !formData.chinese_location ? 'Press Tab to auto-fill translation' : ''}
-              />
-            </Box>
-            <TextField
-              name="description"
-              label="Description / 描述"
-              value={formData.description}
-              onChange={handleFormChange('description')}
-              onKeyDown={handleFieldKeyDown}
-              onBlur={handleTranslationBlur}
-              placeholder={eventDefaultValues.description}
-              fullWidth
-              multiline
-              rows={3}
-            />
-            <TextField
-              name="chinese_description"
-              label="Chinese Description / 中文描述"
-              value={formData.chinese_description}
-              onChange={handleFormChange('chinese_description')}
-              onKeyDown={handleFieldKeyDown}
-              onBlur={handleTranslationBlur}
-              placeholder={translations.chinese_description || eventDefaultValues.chinese_description}
-              fullWidth
-              multiline
-              rows={3}
-              InputProps={{
-                endAdornment: isTranslating && !formData.chinese_description && (
-                  <CircularProgress size={16} sx={{ mr: 1 }} />
-                )
-              }}
-              helperText={translations.chinese_description && !formData.chinese_description ? 'Press Tab to auto-fill translation' : ''}
-            />
-            {/* Image Upload */}
-            <Box sx={{ border: '1px dashed #ccc', borderRadius: 1, p: 2 }}>
-              <Typography variant="subtitle2" gutterBottom>
-                Event Image / 活动图片
-              </Typography>
-              <input
-                type="file"
-                accept="image/*"
-                onChange={handleImageSelect}
-                ref={fileInputRef}
-                style={{ display: 'none' }}
-                id="event-image-upload"
-              />
-              <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, flexWrap: 'wrap' }}>
-                <label htmlFor="event-image-upload">
-                  <Button
-                    variant="outlined"
-                    component="span"
-                    startIcon={uploadingImage ? <CircularProgress size={20} /> : <CloudUploadIcon />}
-                    disabled={uploadingImage}
-                    sx={{
-                      borderColor: '#FFB84D',
-                      color: '#FFB84D',
-                      '&:hover': { borderColor: '#FFA833', backgroundColor: 'rgba(255, 184, 77, 0.04)' }
-                    }}
-                  >
-                    {uploadingImage ? 'Uploading...' : 'Choose Image / 选择图片'}
-                  </Button>
-                </label>
-                {(imagePreview || formData.image) && (
-                  <Button
-                    variant="text"
-                    color="error"
-                    size="small"
-                    onClick={handleRemoveImage}
-                  >
-                    Remove / 移除
-                  </Button>
-                )}
-              </Box>
-              {(imagePreview || formData.image) && (
-                <Box sx={{ mt: 2 }}>
-                  <img
-                    src={imagePreview || formData.image}
-                    alt="Preview"
-                    style={{
-                      maxWidth: '100%',
-                      maxHeight: 200,
-                      borderRadius: 4,
-                      objectFit: 'cover'
-                    }}
-                    onError={(e) => {
-                      e.target.style.display = 'none';
-                    }}
-                  />
-                </Box>
-              )}
-              <Typography variant="caption" color="text.secondary" sx={{ mt: 1, display: 'block' }}>
-                Max size: 5MB. Supported: JPG, PNG, GIF / 最大5MB，支持JPG、PNG、GIF格式
-              </Typography>
-            </Box>
-            <TextField
-              name="signup_link"
-              label="Signup Link / 报名链接"
-              value={formData.signup_link}
-              onChange={handleFormChange('signup_link')}
-              onKeyDown={handleFieldKeyDown}
-              fullWidth
-              placeholder={eventDefaultValues.signup_link}
-            />
-            <TextField
-              select
-              label="Status / 状态 *"
-              value={formData.status}
-              onChange={handleFormChange('status')}
-              fullWidth
-              required
-            >
-              <MenuItem value="Upcoming">Upcoming / 即将举行</MenuItem>
-              <MenuItem value="Past">Past (Memories) / 已结束（回忆）</MenuItem>
-              <MenuItem value="Cancelled">Cancelled / 已取消</MenuItem>
-            </TextField>
-            <FormControlLabel
-              control={
-                <Switch
-                  checked={!!formData.is_highlight}
-                  onChange={(e) =>
-                    setFormData(prev => ({ ...prev, is_highlight: e.target.checked }))
-                  }
-                  color="warning"
-                />
-              }
-              label="Highlight (featured) / 精选"
-            />
-
-            <TextField
-              select
-              label="Event Type / 活动类型"
-              value={formData.event_type}
-              onChange={handleFormChange('event_type')}
-              fullWidth
-            >
-              <MenuItem value="standard">Standard / 标准</MenuItem>
-              <MenuItem value="heylo">Heylo (Weekly Run) / Heylo周跑</MenuItem>
-              <MenuItem value="race">Race / 比赛</MenuItem>
-            </TextField>
-            {formData.event_type === 'heylo' && (
-              <TextField
-                label="Heylo Embed Code / Heylo嵌入代码"
-                value={formData.heylo_embed}
-                onChange={handleFormChange('heylo_embed')}
-                fullWidth
-                multiline
-                rows={4}
-                placeholder="Paste Heylo embed code here... / 在此粘贴Heylo嵌入代码..."
-                helperText="Paste the embed code from Heylo Pro admin panel. The event details will auto-display. / 从Heylo Pro管理面板粘贴嵌入代码，活动详情将自动显示。"
-              />
-            )}
-
-            {/* Recurrence Section */}
-            <Box sx={{ mt: 2, p: 2, border: '1px solid', borderColor: 'divider', borderRadius: 1 }}>
-              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
-                <RepeatIcon color="action" />
-                <Typography variant="subtitle1" fontWeight={600}>
-                  Recurring Event / 重复活动
-                </Typography>
-              </Box>
-              <FormControlLabel
-                control={
-                  <Switch
-                    checked={formData.is_recurring}
-                    onChange={(e) => setFormData({ ...formData, is_recurring: e.target.checked })}
-                  />
-                }
-                label="Enable recurrence / 启用重复"
-              />
-
-              {formData.is_recurring && (
-                <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 2 }}>
-                  <TextField
-                    select
-                    label="Recurrence Type / 重复类型"
-                    value={formData.recurrence_type}
-                    onChange={handleFormChange('recurrence_type')}
-                    fullWidth
-                  >
-                    <MenuItem value="weekly">Weekly / 每周</MenuItem>
-                    <MenuItem value="biweekly">Biweekly / 每两周</MenuItem>
-                    <MenuItem value="monthly">Monthly / 每月</MenuItem>
-                    <MenuItem value="yearly">Yearly / 每年</MenuItem>
-                    <MenuItem value="custom">Custom / 自定义</MenuItem>
-                  </TextField>
-
-                  {/* Days of Week selector for weekly/biweekly */}
-                  {(formData.recurrence_type === 'weekly' || formData.recurrence_type === 'biweekly') && (
-                    <Box>
-                      <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
-                        Days of Week / 每周哪几天
-                      </Typography>
-                      <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap' }}>
-                        {['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'].map((day, index) => {
-                          const days = formData.days_of_week ? formData.days_of_week.split(',').map(Number) : [];
-                          const isSelected = days.includes(index);
-                          return (
-                            <Chip
-                              key={day}
-                              label={day}
-                              size="small"
-                              color={isSelected ? 'primary' : 'default'}
-                              onClick={() => {
-                                let newDays;
-                                if (isSelected) {
-                                  newDays = days.filter(d => d !== index);
-                                } else {
-                                  newDays = [...days, index].sort();
-                                }
-                                setFormData({ ...formData, days_of_week: newDays.join(',') });
-                              }}
-                              sx={{ cursor: 'pointer' }}
-                            />
-                          );
-                        })}
-                      </Box>
-                    </Box>
-                  )}
-
-                  {/* Day of Month selector for monthly */}
-                  {formData.recurrence_type === 'monthly' && (
-                    <Box sx={{ display: 'flex', gap: 2 }}>
-                      <TextField
-                        type="number"
-                        label="Day of Month / 每月几号"
-                        value={formData.day_of_month}
-                        onChange={handleFormChange('day_of_month')}
-                        inputProps={{ min: 1, max: 31 }}
-                        sx={{ flex: 1 }}
-                        helperText="1-31 (or leave empty for week-based)"
-                      />
-                      <TextField
-                        select
-                        label="Week of Month / 每月第几周"
-                        value={formData.week_of_month}
-                        onChange={handleFormChange('week_of_month')}
-                        sx={{ flex: 1 }}
-                      >
-                        <MenuItem value="">None</MenuItem>
-                        <MenuItem value="1">1st / 第一周</MenuItem>
-                        <MenuItem value="2">2nd / 第二周</MenuItem>
-                        <MenuItem value="3">3rd / 第三周</MenuItem>
-                        <MenuItem value="4">4th / 第四周</MenuItem>
-                        <MenuItem value="5">Last / 最后一周</MenuItem>
-                      </TextField>
-                    </Box>
-                  )}
-
-                  {/* Yearly recurrence: Month, Week, Day selectors */}
-                  {formData.recurrence_type === 'yearly' && (
-                    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-                      <TextField
-                        select
-                        label="Month / 月份"
-                        value={formData.month_of_year}
-                        onChange={handleFormChange('month_of_year')}
-                        fullWidth
-                      >
-                        <MenuItem value="1">January / 一月</MenuItem>
-                        <MenuItem value="2">February / 二月</MenuItem>
-                        <MenuItem value="3">March / 三月</MenuItem>
-                        <MenuItem value="4">April / 四月</MenuItem>
-                        <MenuItem value="5">May / 五月</MenuItem>
-                        <MenuItem value="6">June / 六月</MenuItem>
-                        <MenuItem value="7">July / 七月</MenuItem>
-                        <MenuItem value="8">August / 八月</MenuItem>
-                        <MenuItem value="9">September / 九月</MenuItem>
-                        <MenuItem value="10">October / 十月</MenuItem>
-                        <MenuItem value="11">November / 十一月</MenuItem>
-                        <MenuItem value="12">December / 十二月</MenuItem>
-                      </TextField>
-                      <Box sx={{ display: 'flex', gap: 2 }}>
-                        <TextField
-                          select
-                          label="Week / 第几周"
-                          value={formData.week_of_month}
-                          onChange={handleFormChange('week_of_month')}
-                          sx={{ flex: 1 }}
-                        >
-                          <MenuItem value="1">1st / 第一</MenuItem>
-                          <MenuItem value="2">2nd / 第二</MenuItem>
-                          <MenuItem value="3">3rd / 第三</MenuItem>
-                          <MenuItem value="4">4th / 第四</MenuItem>
-                          <MenuItem value="5">Last / 最后</MenuItem>
-                        </TextField>
-                        <TextField
-                          select
-                          label="Day / 星期几"
-                          value={formData.days_of_week}
-                          onChange={handleFormChange('days_of_week')}
-                          sx={{ flex: 1 }}
-                        >
-                          <MenuItem value="0">Sunday / 周日</MenuItem>
-                          <MenuItem value="1">Monday / 周一</MenuItem>
-                          <MenuItem value="2">Tuesday / 周二</MenuItem>
-                          <MenuItem value="3">Wednesday / 周三</MenuItem>
-                          <MenuItem value="4">Thursday / 周四</MenuItem>
-                          <MenuItem value="5">Friday / 周五</MenuItem>
-                          <MenuItem value="6">Saturday / 周六</MenuItem>
-                        </TextField>
-                      </Box>
-                    </Box>
-                  )}
-
-                  <TextField
-                    type="date"
-                    label="End Date (optional) / 结束日期"
-                    value={formData.recurrence_end_date}
-                    onChange={handleFormChange('recurrence_end_date')}
-                    fullWidth
-                    InputLabelProps={{ shrink: true }}
-                    helperText="Leave empty for no end date / 留空表示无结束日期"
-                  />
-                </Box>
-              )}
-            </Box>
-          </Box>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={() => setEventFormOpen(false)} disabled={loading}>
-            Cancel / 取消
-          </Button>
-          <Button
-            variant="contained"
-            onClick={handleFormSubmit}
-            disabled={loading}
-            sx={{
-              backgroundColor: '#FFB84D',
-              '&:hover': { backgroundColor: '#FFA833' }
-            }}
-          >
-            {loading ? <CircularProgress size={24} /> : (editingEventId ? 'Update / 更新' : 'Create / 创建')}
-          </Button>
-        </DialogActions>
-      </Dialog>
+      {/* Create/Edit Composer */}
+      <EventComposer
+        open={composerOpen}
+        onClose={() => setComposerOpen(false)}
+        event={composerEvent}
+        onSaved={fetchEvents}
+      />
 
       {/* Delete Confirmation Dialog */}
       <Dialog open={deleteDialogOpen} onClose={() => setDeleteDialogOpen(false)}>
@@ -1700,82 +411,6 @@ export default function CalendarPage() {
             disabled={loading}
           >
             {loading ? <CircularProgress size={24} /> : 'Delete / 删除'}
-          </Button>
-        </DialogActions>
-      </Dialog>
-
-      {/* Quick QR Upload Dialog */}
-      <Dialog
-        open={quickQrDialogOpen}
-        onClose={() => setQuickQrDialogOpen(false)}
-        maxWidth="xs"
-        fullWidth
-      >
-        <DialogTitle sx={{ textAlign: 'center' }}>
-          WeChat QR Code / 微信二维码
-        </DialogTitle>
-        <DialogContent sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 2 }}>
-          {getEventQrCode(quickQrEventId) && !quickQrPreview && (
-            <Box sx={{ textAlign: 'center' }}>
-              <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
-                Current QR Code / 当前二维码
-              </Typography>
-              <img
-                src={getEventQrCode(quickQrEventId)}
-                alt="Current QR Code"
-                style={{ width: 200, height: 200, objectFit: 'contain' }}
-              />
-              <Box sx={{ mt: 1 }}>
-                <Button size="small" color="error" onClick={handleQuickQrRemove}>
-                  Remove / 移除
-                </Button>
-              </Box>
-            </Box>
-          )}
-          <input
-            type="file"
-            accept="image/*"
-            onChange={handleQuickQrSelect}
-            ref={quickQrFileInputRef}
-            style={{ display: 'none' }}
-            id="quick-qr-upload"
-          />
-          <label htmlFor="quick-qr-upload">
-            <Button
-              variant="outlined"
-              component="span"
-              startIcon={<CloudUploadIcon />}
-              sx={{
-                borderColor: '#FFB84D',
-                color: '#FFB84D',
-                '&:hover': { borderColor: '#FFA833', backgroundColor: 'rgba(255, 184, 77, 0.04)' }
-              }}
-            >
-              {getEventQrCode(quickQrEventId) ? 'Replace QR / 替换二维码' : 'Choose QR Code / 选择二维码'}
-            </Button>
-          </label>
-          {quickQrPreview && (
-            <Box sx={{ textAlign: 'center' }}>
-              <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
-                New QR Code / 新二维码
-              </Typography>
-              <img
-                src={quickQrPreview}
-                alt="QR Preview"
-                style={{ width: 200, height: 200, objectFit: 'contain' }}
-              />
-            </Box>
-          )}
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={() => setQuickQrDialogOpen(false)}>Cancel / 取消</Button>
-          <Button
-            onClick={handleQuickQrSubmit}
-            variant="contained"
-            disabled={!quickQrFile || quickQrUploading}
-            sx={{ backgroundColor: '#07C160', '&:hover': { backgroundColor: '#06AD56' } }}
-          >
-            {quickQrUploading ? <CircularProgress size={20} /> : 'Upload / 上传'}
           </Button>
         </DialogActions>
       </Dialog>

--- a/ProjectCode/client/src/pages/CalendarPage.test.js
+++ b/ProjectCode/client/src/pages/CalendarPage.test.js
@@ -1,38 +1,17 @@
-import { render, screen, fireEvent, waitFor, within, act } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import CalendarPage from './CalendarPage';
 import { useAdmin, useAuth } from '../context';
-import {
-  getEventsByStatus, createEvent, updateEvent, deleteEvent,
-  getEventWithRecurrence, createEventRecurrence, updateEventRecurrence, deleteEventRecurrence,
-} from '../api';
-import { uploadImage } from '../api/homepageSections';
+import { getEventsByStatus, updateEvent, deleteEvent } from '../api';
 
 jest.mock('../context', () => ({
   useAdmin: jest.fn(),
   useAuth: jest.fn(),
 }));
-jest.mock('../hooks', () => ({
-  useAutoFillOnTab: () => jest.fn(),
-  useTranslationAutoFill: () => ({
-    handleKeyDown: jest.fn(),
-    handleBlur: jest.fn(),
-    translations: {},
-    isTranslating: false,
-  }),
-}));
 jest.mock('../api', () => ({
   getEventsByStatus: jest.fn(),
-  createEvent: jest.fn(),
   updateEvent: jest.fn(),
   deleteEvent: jest.fn(),
-  getEventWithRecurrence: jest.fn(),
-  createEventRecurrence: jest.fn(),
-  updateEventRecurrence: jest.fn(),
-  deleteEventRecurrence: jest.fn(),
-}));
-jest.mock('../api/homepageSections', () => ({
-  uploadImage: jest.fn(),
 }));
 // Probes for heavy children
 jest.mock('../components/EventDetailModal', () => {
@@ -51,6 +30,24 @@ jest.mock('../components/EventDetailModal', () => {
     );
   };
 });
+// EventComposer has its own test suite — stub it and probe the wiring
+jest.mock('../components/EventComposer', () => {
+  const React = require('react');
+  return function MockEventComposer({ open, onClose, event, onSaved }) {
+    if (!open) return null;
+    return React.createElement(
+      'div',
+      { 'data-testid': 'event-composer' },
+      React.createElement(
+        'span',
+        null,
+        event ? `composer-edit:${event.name || event.title}` : 'composer-create'
+      ),
+      React.createElement('button', { onClick: () => onSaved && onSaved() }, 'probe-composer-save'),
+      React.createElement('button', { onClick: onClose }, 'probe-composer-close')
+    );
+  };
+});
 jest.mock('../components/EventCardImage', () => {
   const React = require('react');
   return function MockEventCardImage({ event, onError }) {
@@ -64,6 +61,13 @@ jest.mock('../components/EventCardImage', () => {
         'probe-img-error'
       )
     );
+  };
+});
+// EventEngagementBar fetches /engagement — keep the real EventCard but stub the bar
+jest.mock('../components/EventEngagementBar', () => {
+  const React = require('react');
+  return function MockEventEngagementBar({ eventId }) {
+    return React.createElement('div', { 'data-testid': 'engagement-bar' }, `engagement:${eventId}`);
   };
 });
 
@@ -94,7 +98,7 @@ const apiEvents = [
     chinese_description: '', image: '', signup_link: '', status: 'Upcoming',
     event_type: 'standard', heylo_embed: '', wechat_qr_code: '',
   },
-  // Malformed date exercises the date-bubble fallback
+  // Malformed date exercises the missing-date-bubble path
   {
     id: 5, name: 'Broken Date Run', chinese_name: '', date: `${YEAR}-13-40`, time: '10:00 AM',
     location: 'Brooklyn', chinese_location: '', description: 'Bad date',
@@ -118,104 +122,95 @@ const renderPage = (route = '/calendar') =>
   );
 
 beforeEach(() => {
-  jest.clearAllMocks();
   useAdmin.mockReturnValue({ adminModeEnabled: false });
   useAuth.mockReturnValue({ currentUser: { uid: 'admin-uid' } });
   getEventsByStatus.mockResolvedValue(apiEvents);
-  createEvent.mockResolvedValue({ id: 42 });
   updateEvent.mockResolvedValue({});
   deleteEvent.mockResolvedValue({});
-  getEventWithRecurrence.mockResolvedValue({ recurrence: null });
-  createEventRecurrence.mockResolvedValue({});
-  updateEventRecurrence.mockResolvedValue({});
-  deleteEventRecurrence.mockResolvedValue({});
-  uploadImage.mockResolvedValue({ url: 'https://s3/uploaded.png' });
   Object.defineProperty(navigator, 'clipboard', {
     value: { writeText: jest.fn().mockResolvedValue() },
     configurable: true,
   });
-  jest.spyOn(console, 'log').mockImplementation(() => {});
-});
-
-afterEach(() => {
-  console.log.mockRestore();
 });
 
 describe('event rendering', () => {
   test('renders featured cards (first 3 by date) and the full list, excluding other years', async () => {
     renderPage();
     // Featured card + list entry for the first three events
-    expect(await screen.findAllByText('Summer 5K')).toHaveLength(2);
-    expect(screen.getAllByText('Track Night')).toHaveLength(2);
-    expect(screen.getAllByText('Fall Marathon')).toHaveLength(2);
+    expect(await screen.findAllByText(/Summer 5K/)).toHaveLength(2);
+    expect(screen.getAllByText(/Track Night/)).toHaveLength(2);
+    expect(screen.getAllByText(/Fall Marathon/)).toHaveLength(2);
     // 4th+ events only appear in the list
     expect(screen.getAllByText('Winter Run')).toHaveLength(1);
     expect(screen.getAllByText('Broken Date Run')).toHaveLength(1);
     // Previous-year event filtered out entirely
     expect(screen.queryByText('Old Event')).not.toBeInTheDocument();
-    // Featured card content (chinese name shows on featured card and list row)
+    // 3 featured + 5 list rows, each an EventCard with an engagement bar
+    expect(screen.getAllByTestId('event-card')).toHaveLength(8);
+    expect(screen.getAllByTestId('engagement-bar')).toHaveLength(8);
+    // Chinese names render inline in the card titles
     expect(screen.getAllByText('夏日五公里').length).toBeGreaterThan(0);
-    expect(screen.getAllByText('Fast summer race').length).toBeGreaterThan(0);
-    expect(screen.getAllByText(/Learn More & Sign Up/).length).toBeGreaterThan(0);
+    // Description only shows on featured (grid) cards
+    expect(screen.getAllByText('Fast summer race')).toHaveLength(1);
   });
 
-  test('renders date bubbles for valid dates and raw text fallback for invalid dates', async () => {
+  test('featured cards show date, time and location meta rows', async () => {
     renderPage();
-    await screen.findAllByText('Summer 5K');
-    // Bubble for Aug 15: day + month abbreviation
-    expect(screen.getByText('15')).toBeInTheDocument();
-    expect(screen.getByText('AUG')).toBeInTheDocument();
-    expect(screen.getByText('SEP')).toBeInTheDocument();
-    expect(screen.getByText('NOV')).toBeInTheDocument();
-    expect(screen.getByText('DEC')).toBeInTheDocument();
-    // Invalid date falls back to the raw string (desktop bubble + mobile line)
-    expect(screen.getAllByText(`${YEAR}-13-40`).length).toBeGreaterThan(0);
+    await screen.findAllByText(/Summer 5K/);
+    const featured = screen.getAllByTestId('event-card')[0]; // Summer 5K featured card
+    expect(within(featured).getByText(`${YEAR}-08-15 · 8:00 AM`)).toBeInTheDocument();
+    expect(within(featured).getByText('Brooklyn 布鲁克林')).toBeInTheDocument();
+    expect(within(featured).getByText('Fast summer race')).toBeInTheDocument();
+  });
+
+  test('renders date bubbles for valid dates and omits the bubble for invalid dates', async () => {
+    renderPage();
+    await screen.findAllByText(/Summer 5K/);
+    // Bubble for Aug 15 appears on both the featured card and the list row
+    expect(screen.getAllByText('15')).toHaveLength(2);
+    expect(screen.getAllByText('AUG')).toHaveLength(2);
+    expect(screen.getAllByText('SEP')).toHaveLength(2);
+    expect(screen.getAllByText('NOV')).toHaveLength(2);
+    expect(screen.getAllByText('DEC')).toHaveLength(1); // Winter Run, list only
+    // Invalid date: no bubble, but the raw date still shows in the meta row
+    expect(screen.getByText(`${YEAR}-13-40 · 10:00 AM`)).toBeInTheDocument();
+  });
+
+  test('signup CTA appears for upcoming events with a signup link, others get View Details', async () => {
+    renderPage();
+    await screen.findAllByText(/Summer 5K/);
+    // Summer 5K (featured + list) is the only event with a signup link
+    expect(screen.getAllByText('Sign Up 报名')).toHaveLength(2);
+    expect(screen.getAllByText('View Details 查看详情')).toHaveLength(6);
   });
 
   test('shows empty sections when the api returns no events', async () => {
     getEventsByStatus.mockResolvedValue([]);
     renderPage();
     await waitFor(() => expect(getEventsByStatus).toHaveBeenCalledWith('Upcoming'));
-    expect(screen.queryByText(/Learn More & Sign Up/)).not.toBeInTheDocument();
+    expect(screen.queryAllByTestId('event-card')).toHaveLength(0);
     expect(screen.getByText('Upcoming Events')).toBeInTheDocument();
+    expect(screen.getByText('All Upcoming')).toBeInTheDocument();
   });
 
   test('shows an error snackbar when the events fetch fails', async () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
     getEventsByStatus.mockRejectedValue(new Error('down'));
     renderPage();
     expect(await screen.findByText(/Failed to load events/)).toBeInTheDocument();
+    errorSpy.mockRestore();
+  });
+
+  test('card image error handler swaps to the placeholder image without crashing', async () => {
+    renderPage();
+    await screen.findAllByText(/Summer 5K/);
+    fireEvent.click(screen.getAllByText('probe-img-error')[0]);
+    expect(screen.getAllByText(/Summer 5K/).length).toBeGreaterThan(0);
   });
 });
 
-describe('filters', () => {
-  const openFilter = async (label) => {
-    fireEvent.mouseDown(screen.getByRole('combobox', { name: new RegExp(`^${label}`) }));
-    return screen.findByRole('listbox');
-  };
-
-  test('status filter keeps only matching events', async () => {
-    renderPage();
-    await screen.findAllByText('Summer 5K');
-    const listbox = await openFilter('Status');
-    fireEvent.click(within(listbox).getByText('Open'));
-    await waitFor(() => expect(screen.queryByText('Winter Run')).not.toBeInTheDocument());
-    // Track Night (status Open) stays in the list (1 list entry + 1 featured card)
-    expect(screen.getAllByText('Track Night')).toHaveLength(2);
-    // Featured cards are unaffected by list filters
-    expect(screen.getAllByText('Summer 5K')).toHaveLength(1);
-  });
-
-  test('location filter matches case-insensitively', async () => {
-    renderPage();
-    await screen.findAllByText('Summer 5K');
-    const listbox = await openFilter('Location');
-    fireEvent.click(within(listbox).getByText('Brooklyn'));
-    await waitFor(() => expect(screen.getAllByText('Fall Marathon')).toHaveLength(1)); // featured only
-    expect(screen.getAllByText('Summer 5K')).toHaveLength(2);
-    expect(screen.getByText('Winter Run')).toBeInTheDocument();
-  });
-
-  test('date filters restrict by parsed event date', async () => {
+describe('date filter', () => {
+  test('date filters restrict the list by parsed event date, featured cards unaffected', async () => {
     // The filter uses today as its reference date; compute the same bounds it
     // does so this test holds no matter when it runs. Summer 5K is Aug 15.
     const ref = new Date();
@@ -230,38 +225,39 @@ describe('filters', () => {
     const inNextMonth = summer <= nextMonthEnd && summer >= ref ? 2 : 1;
 
     renderPage();
-    await screen.findAllByText('Summer 5K');
-    const listbox = await openFilter('Date');
-    fireEvent.click(within(listbox).getByText('This Week'));
-    await waitFor(() => expect(screen.getAllByText('Summer 5K')).toHaveLength(inThisWeek));
+    await screen.findAllByText(/Summer 5K/);
+    const openFilter = async () => {
+      fireEvent.mouseDown(screen.getByRole('combobox', { name: /^Date/ }));
+      return screen.findByRole('listbox');
+    };
+
+    fireEvent.click(within(await openFilter()).getByText('This Week'));
+    await waitFor(() => expect(screen.getAllByText(/Summer 5K/)).toHaveLength(inThisWeek));
 
     // Switch to All Dates restores the list
-    const listbox2 = await openFilter('Date');
-    fireEvent.click(within(listbox2).getByText('All Dates'));
-    await waitFor(() => expect(screen.getAllByText('Summer 5K')).toHaveLength(2));
+    fireEvent.click(within(await openFilter()).getByText('All Dates'));
+    await waitFor(() => expect(screen.getAllByText(/Summer 5K/)).toHaveLength(2));
 
     // this-month / next-month branches
-    const listbox3 = await openFilter('Date');
-    fireEvent.click(within(listbox3).getByText('This Month'));
-    await waitFor(() => expect(screen.getAllByText('Summer 5K')).toHaveLength(inThisMonth));
-    const listbox4 = await openFilter('Date');
-    fireEvent.click(within(listbox4).getByText('Next Month'));
-    await waitFor(() => expect(screen.getAllByText('Summer 5K')).toHaveLength(inNextMonth));
+    fireEvent.click(within(await openFilter()).getByText('This Month'));
+    await waitFor(() => expect(screen.getAllByText(/Summer 5K/)).toHaveLength(inThisMonth));
+    fireEvent.click(within(await openFilter()).getByText('Next Month'));
+    await waitFor(() => expect(screen.getAllByText(/Summer 5K/)).toHaveLength(inNextMonth));
   });
 
-  test('distance filter changes value without affecting the list', async () => {
+  test('the dead Location/Distance/Status filters are gone', async () => {
     renderPage();
-    await screen.findAllByText('Summer 5K');
-    const listbox = await openFilter('Distance');
-    fireEvent.click(within(listbox).getByText('Half Marathon'));
-    await waitFor(() => expect(screen.getAllByText('Summer 5K')).toHaveLength(2));
+    await screen.findAllByText(/Summer 5K/);
+    expect(screen.queryByRole('combobox', { name: /Location/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole('combobox', { name: /Distance/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole('combobox', { name: /Status/ })).not.toBeInTheDocument();
   });
 });
 
 describe('event modal and deep links', () => {
-  test('clicking an event opens the detail modal and close dismisses it', async () => {
+  test('clicking an event card opens the detail modal and close dismisses it', async () => {
     renderPage();
-    const cards = await screen.findAllByText('Summer 5K');
+    const cards = await screen.findAllByText(/Summer 5K/);
     fireEvent.click(cards[0]);
     expect(await screen.findByTestId('event-detail-modal')).toBeInTheDocument();
     expect(screen.getByText('modal:Summer 5K')).toBeInTheDocument();
@@ -269,6 +265,26 @@ describe('event modal and deep links', () => {
     await waitFor(() =>
       expect(screen.queryByTestId('event-detail-modal')).not.toBeInTheDocument()
     );
+  });
+
+  test('the View Details CTA opens the modal', async () => {
+    renderPage();
+    await screen.findAllByText(/Summer 5K/);
+    const winterCard = screen
+      .getAllByTestId('event-card')
+      .find((card) => within(card).queryByText('Winter Run'));
+    fireEvent.click(within(winterCard).getByText('View Details 查看详情'));
+    expect(await screen.findByText('modal:Winter Run')).toBeInTheDocument();
+  });
+
+  test('the Sign Up CTA opens the signup link instead of the modal', async () => {
+    const openSpy = jest.spyOn(window, 'open').mockImplementation(() => {});
+    renderPage();
+    await screen.findAllByText(/Summer 5K/);
+    fireEvent.click(screen.getAllByText('Sign Up 报名')[0]);
+    expect(openSpy).toHaveBeenCalledWith('https://signup/summer', '_blank', 'noopener,noreferrer');
+    expect(screen.queryByTestId('event-detail-modal')).not.toBeInTheDocument();
+    openSpy.mockRestore();
   });
 
   test('deep link ?event=id opens the matching event automatically', async () => {
@@ -282,31 +298,17 @@ describe('event modal and deep links', () => {
     fireEvent.click(screen.getByText('probe-update-event'));
     expect(await screen.findByText('modal:Updated Name')).toBeInTheDocument();
     // Both featured card and list entry renamed
-    await waitFor(() => expect(screen.getAllByText('Updated Name').length).toBeGreaterThanOrEqual(2));
-  });
-
-  test('list "Learn More" button opens the modal without triggering card click twice', async () => {
-    renderPage();
-    await screen.findAllByText('Summer 5K');
-    const buttons = screen.getAllByText(/Learn More & Sign Up/);
-    fireEvent.click(buttons[buttons.length - 1]); // a list-row button
-    expect(await screen.findByTestId('event-detail-modal')).toBeInTheDocument();
-    fireEvent.click(screen.getByText('probe-close-modal'));
     await waitFor(() =>
-      expect(screen.queryByTestId('event-detail-modal')).not.toBeInTheDocument()
+      expect(screen.getAllByText(/Updated Name/).length).toBeGreaterThanOrEqual(2)
     );
-
-    // Clicking the list card body (not the button) also opens the modal
-    fireEvent.click(screen.getByText('Winter Run'));
-    expect(await screen.findByText('modal:Winter Run')).toBeInTheDocument();
   });
 });
 
 describe('sharing', () => {
   test('share button copies the event deep link and shows a snackbar', async () => {
     renderPage();
-    await screen.findAllByText('Summer 5K');
-    fireEvent.click(screen.getAllByTestId('ShareIcon')[0].closest('button'));
+    await screen.findAllByText(/Summer 5K/);
+    fireEvent.click(screen.getAllByLabelText('share event')[0]);
     await waitFor(() =>
       expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
         expect.stringContaining('/calendar?event=1')
@@ -318,419 +320,106 @@ describe('sharing', () => {
   test('clipboard failure shows an error snackbar', async () => {
     navigator.clipboard.writeText.mockRejectedValue(new Error('denied'));
     renderPage();
-    await screen.findAllByText('Summer 5K');
-    fireEvent.click(screen.getAllByTestId('ShareIcon')[0].closest('button'));
+    await screen.findAllByText(/Summer 5K/);
+    fireEvent.click(screen.getAllByLabelText('share event')[0]);
     expect(await screen.findByText(/Failed to copy link/)).toBeInTheDocument();
+  });
+
+  test('list-row share button copies the deep link', async () => {
+    renderPage();
+    await screen.findAllByText(/Summer 5K/);
+    const shareButtons = screen.getAllByLabelText('share event');
+    fireEvent.click(shareButtons[shareButtons.length - 1]);
+    await waitFor(() => expect(navigator.clipboard.writeText).toHaveBeenCalled());
+    expect(await screen.findByText(/Link copied/)).toBeInTheDocument();
   });
 });
 
 describe('admin gating', () => {
   test('non-admin sees no add button, admin alert, or admin card actions', async () => {
     renderPage();
-    await screen.findAllByText('Summer 5K');
+    await screen.findAllByText(/Summer 5K/);
     expect(screen.queryByText('Add Event / 添加活动')).not.toBeInTheDocument();
     expect(screen.queryByText(/Admin mode enabled/)).not.toBeInTheDocument();
-    expect(screen.queryByTestId('EditIcon')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('StarIcon')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('QrCode2Icon')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('edit event')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('delete event')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('move to memories')).not.toBeInTheDocument();
+    // Share stays available to everyone
+    expect(screen.getAllByLabelText('share event')).toHaveLength(8);
   });
 
-  test('admin sees add button, alert, and per-event admin actions', async () => {
+  test('admin sees add button, alert, and per-event admin actions on every card', async () => {
     useAdmin.mockReturnValue({ adminModeEnabled: true });
     renderPage();
-    await screen.findAllByText('Summer 5K');
+    await screen.findAllByText(/Summer 5K/);
     expect(screen.getByText('Add Event / 添加活动')).toBeInTheDocument();
     expect(screen.getByText(/Admin mode enabled/)).toBeInTheDocument();
-    // 3 featured + 5 list entries each get edit/delete/star/qr buttons
-    expect(screen.getAllByTestId('EditIcon')).toHaveLength(8);
-    expect(screen.getAllByTestId('DeleteIcon')).toHaveLength(8);
-    expect(screen.getAllByTestId('StarIcon')).toHaveLength(8);
-    expect(screen.getAllByTestId('QrCode2Icon')).toHaveLength(8);
-    // Share buttons hidden on featured cards in admin mode but present in list rows
-    expect(screen.getAllByTestId('ShareIcon')).toHaveLength(5);
+    // 3 featured + 5 list entries each get edit/delete/star buttons
+    expect(screen.getAllByLabelText('edit event')).toHaveLength(8);
+    expect(screen.getAllByLabelText('delete event')).toHaveLength(8);
+    expect(screen.getAllByLabelText('move to memories')).toHaveLength(8);
+    // The quick-QR dialog is gone — QR upload lives in the composer now
+    expect(screen.queryByTestId('QrCode2Icon')).not.toBeInTheDocument();
   });
 });
 
-describe('admin event form', () => {
+describe('event composer wiring', () => {
   beforeEach(() => {
     useAdmin.mockReturnValue({ adminModeEnabled: true });
   });
 
-  const openAddForm = async () => {
+  test('Add Event opens the composer in create mode', async () => {
+    renderPage();
+    await screen.findAllByText(/Summer 5K/);
+    expect(screen.queryByTestId('event-composer')).not.toBeInTheDocument();
     fireEvent.click(screen.getByText('Add Event / 添加活动'));
-    return screen.findByRole('dialog');
-  };
-
-  test('create flow validates required fields then saves with nulls for empty strings', async () => {
-    renderPage();
-    await screen.findAllByText('Summer 5K');
-    const dialog = await openAddForm();
-    expect(within(dialog).getByText('Add Event / 添加活动')).toBeInTheDocument();
-
-    // Missing name/date
-    fireEvent.click(within(dialog).getByText('Create / 创建'));
-    expect(await screen.findByText(/Name and date are required/)).toBeInTheDocument();
-    expect(createEvent).not.toHaveBeenCalled();
-
-    fireEvent.change(within(dialog).getByLabelText(/Event Name/), { target: { value: 'New Race' } });
-    fireEvent.change(within(dialog).getByLabelText(/Date \/ 日期/), { target: { value: `${YEAR}-10-10` } });
-    fireEvent.click(within(dialog).getByText('Create / 创建'));
-
-    await waitFor(() =>
-      expect(createEvent).toHaveBeenCalledWith(
-        expect.objectContaining({
-          name: 'New Race',
-          date: `${YEAR}-10-10`,
-          status: 'Upcoming',
-          time: null, // empty strings converted to null
-          location: null,
-        }),
-        'admin-uid'
-      )
-    );
-    expect(await screen.findByText(/Event created successfully/)).toBeInTheDocument();
-    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
-    // Events refetched after save
-    expect(getEventsByStatus).toHaveBeenCalledTimes(2);
+    expect(await screen.findByTestId('event-composer')).toBeInTheDocument();
+    expect(screen.getByText('composer-create')).toBeInTheDocument();
   });
 
-  test('submit while logged out shows a login error', async () => {
-    useAuth.mockReturnValue({ currentUser: null });
+  test('per-card edit button opens the composer with that event', async () => {
     renderPage();
-    await screen.findAllByText('Summer 5K');
-    const dialog = await openAddForm();
-    fireEvent.change(within(dialog).getByLabelText(/Event Name/), { target: { value: 'X' } });
-    fireEvent.change(within(dialog).getByLabelText(/Date \/ 日期/), { target: { value: `${YEAR}-10-10` } });
-    fireEvent.click(within(dialog).getByText('Create / 创建'));
-    expect(await screen.findByText(/You must be logged in to manage events/)).toBeInTheDocument();
-    expect(createEvent).not.toHaveBeenCalled();
-  });
-
-  test('create failure surfaces the api error in a snackbar', async () => {
-    createEvent.mockRejectedValue(new Error('backend rejected'));
-    renderPage();
-    await screen.findAllByText('Summer 5K');
-    const dialog = await openAddForm();
-    fireEvent.change(within(dialog).getByLabelText(/Event Name/), { target: { value: 'X' } });
-    fireEvent.change(within(dialog).getByLabelText(/Date \/ 日期/), { target: { value: `${YEAR}-10-10` } });
-    fireEvent.click(within(dialog).getByText('Create / 创建'));
-    expect(await screen.findByText(/Error: backend rejected/)).toBeInTheDocument();
-  });
-
-  test('edit flow pre-fills the form and updates the event', async () => {
-    renderPage();
-    await screen.findAllByText('Summer 5K');
+    await screen.findAllByText(/Summer 5K/);
     // First edit icon belongs to the first featured card (Summer 5K)
-    fireEvent.click(screen.getAllByTestId('EditIcon')[0].closest('button'));
-    const dialog = await screen.findByRole('dialog');
-    expect(within(dialog).getByText('Edit Event / 编辑活动')).toBeInTheDocument();
-    expect(within(dialog).getByLabelText(/Event Name/)).toHaveValue('Summer 5K');
-    expect(within(dialog).getByLabelText(/Chinese Name/)).toHaveValue('夏日五公里');
-    expect(within(dialog).getByLabelText(/Date \/ 日期/)).toHaveValue(`${YEAR}-08-15`);
-
-    fireEvent.change(within(dialog).getByLabelText(/Event Name/), { target: { value: 'Summer 5K v2' } });
-    fireEvent.click(within(dialog).getByText('Update / 更新'));
-    await waitFor(() =>
-      expect(updateEvent).toHaveBeenCalledWith(
-        1,
-        expect.objectContaining({ name: 'Summer 5K v2', signup_link: 'https://signup/summer' }),
-        'admin-uid'
-      )
-    );
-    expect(await screen.findByText(/Event updated successfully/)).toBeInTheDocument();
+    fireEvent.click(screen.getAllByLabelText('edit event')[0]);
+    expect(await screen.findByText('composer-edit:Summer 5K')).toBeInTheDocument();
   });
 
-  test('cancel closes the form without saving', async () => {
+  test('list-row edit button opens the composer for the same event', async () => {
     renderPage();
-    await screen.findAllByText('Summer 5K');
-    const dialog = await openAddForm();
-    fireEvent.click(within(dialog).getByText('Cancel / 取消'));
-    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
-    expect(createEvent).not.toHaveBeenCalled();
+    await screen.findAllByText(/Summer 5K/);
+    // Index 3 = first list row (indices 0-2 are the featured cards)
+    fireEvent.click(screen.getAllByLabelText('edit event')[3]);
+    expect(await screen.findByText('composer-edit:Summer 5K')).toBeInTheDocument();
   });
 
-  test('status, highlight, event type and heylo embed controls work', async () => {
+  test('onSaved refetches the events', async () => {
     renderPage();
-    await screen.findAllByText('Summer 5K');
-    const dialog = await openAddForm();
+    await screen.findAllByText(/Summer 5K/);
+    expect(getEventsByStatus).toHaveBeenCalledTimes(1);
+    fireEvent.click(screen.getByText('Add Event / 添加活动'));
+    fireEvent.click(await screen.findByText('probe-composer-save'));
+    await waitFor(() => expect(getEventsByStatus).toHaveBeenCalledTimes(2));
+  });
 
-    // Status select
-    fireEvent.mouseDown(within(dialog).getByLabelText(/Status \/ 状态/));
-    fireEvent.click(within(await screen.findByRole('listbox')).getByText('Past (Memories) / 已结束（回忆）'));
-    // Highlight switch
-    fireEvent.click(within(dialog).getByLabelText(/Highlight \(featured\)/));
-    // Event type -> heylo reveals the embed field
-    fireEvent.mouseDown(within(dialog).getByLabelText(/Event Type/));
-    fireEvent.click(within(await screen.findByRole('listbox')).getByText('Heylo (Weekly Run) / Heylo周跑'));
-    const embed = await within(dialog).findByLabelText(/Heylo Embed Code/);
-    fireEvent.change(embed, { target: { value: '<div>embed</div>' } });
-
-    fireEvent.change(within(dialog).getByLabelText(/Event Name/), { target: { value: 'Heylo Run' } });
-    fireEvent.change(within(dialog).getByLabelText(/Date \/ 日期/), { target: { value: `${YEAR}-10-11` } });
-    fireEvent.click(within(dialog).getByText('Create / 创建'));
+  test('onClose hides the composer', async () => {
+    renderPage();
+    await screen.findAllByText(/Summer 5K/);
+    fireEvent.click(screen.getByText('Add Event / 添加活动'));
+    fireEvent.click(await screen.findByText('probe-composer-close'));
     await waitFor(() =>
-      expect(createEvent).toHaveBeenCalledWith(
-        expect.objectContaining({
-          status: 'Past',
-          is_highlight: true,
-          event_type: 'heylo',
-          heylo_embed: '<div>embed</div>',
-        }),
-        'admin-uid'
-      )
+      expect(screen.queryByTestId('event-composer')).not.toBeInTheDocument()
     );
   });
 
-  test('recurrence controls: weekly days, monthly, yearly and end date', async () => {
+  test('editing after creating passes the newly selected event', async () => {
     renderPage();
-    await screen.findAllByText('Summer 5K');
-    const dialog = await openAddForm();
-
-    fireEvent.click(within(dialog).getByLabelText(/Enable recurrence/));
-    // Weekly day chips toggle on and off
-    fireEvent.click(within(dialog).getByText('Mon'));
-    fireEvent.click(within(dialog).getByText('Wed'));
-    fireEvent.click(within(dialog).getByText('Mon')); // deselect
-
-    // Monthly reveals day-of-month + week-of-month
-    fireEvent.mouseDown(within(dialog).getByLabelText(/Recurrence Type/));
-    fireEvent.click(within(await screen.findByRole('listbox')).getByText('Monthly / 每月'));
-    fireEvent.change(await within(dialog).findByLabelText(/Day of Month/), { target: { value: '15' } });
-    fireEvent.mouseDown(within(dialog).getByLabelText(/Week of Month/));
-    fireEvent.click(within(await screen.findByRole('listbox')).getByText('2nd / 第二周'));
-
-    // Yearly reveals month/week/day selectors
-    fireEvent.mouseDown(within(dialog).getByLabelText(/Recurrence Type/));
-    fireEvent.click(within(await screen.findByRole('listbox')).getByText('Yearly / 每年'));
-    fireEvent.mouseDown(await within(dialog).findByLabelText(/Month \/ 月份/));
-    fireEvent.click(within(await screen.findByRole('listbox')).getByText('November / 十一月'));
-    fireEvent.mouseDown(within(dialog).getByLabelText(/Day \/ 星期几/));
-    fireEvent.click(within(await screen.findByRole('listbox')).getByText('Sunday / 周日'));
-
-    fireEvent.change(within(dialog).getByLabelText(/End Date/), { target: { value: `${YEAR}-12-31` } });
-
-    fireEvent.change(within(dialog).getByLabelText(/Event Name/), { target: { value: 'Yearly Race' } });
-    fireEvent.change(within(dialog).getByLabelText(/Date \/ 日期/), { target: { value: `${YEAR}-11-01` } });
-    fireEvent.click(within(dialog).getByText('Create / 创建'));
-
-    // Recurrence fields are stripped from the event payload and sent to the
-    // dedicated rule endpoint instead (numeric fields coerced, end_date mapped)
-    await waitFor(() => expect(createEvent).toHaveBeenCalled());
-    const eventPayload = createEvent.mock.calls[0][0];
-    expect(eventPayload).toEqual(expect.objectContaining({ name: 'Yearly Race' }));
-    expect(eventPayload).not.toHaveProperty('is_recurring');
-    expect(eventPayload).not.toHaveProperty('recurrence_type');
-    expect(eventPayload).not.toHaveProperty('recurrence_end_date');
-    await waitFor(() =>
-      expect(createEventRecurrence).toHaveBeenCalledWith(
-        42,
-        {
-          recurrence_type: 'yearly',
-          days_of_week: '0',
-          day_of_month: 15,
-          week_of_month: 2,
-          month_of_year: 11,
-          end_date: `${YEAR}-12-31`,
-        },
-        'admin-uid'
-      )
-    );
-  });
-
-  test('create without recurrence never touches the rule endpoints', async () => {
-    renderPage();
-    await screen.findAllByText('Summer 5K');
-    const dialog = await openAddForm();
-    fireEvent.change(within(dialog).getByLabelText(/Event Name/), { target: { value: 'Plain Race' } });
-    fireEvent.change(within(dialog).getByLabelText(/Date \/ 日期/), { target: { value: `${YEAR}-10-10` } });
-    fireEvent.click(within(dialog).getByText('Create / 创建'));
-    await waitFor(() => expect(createEvent).toHaveBeenCalled());
-    expect(createEventRecurrence).not.toHaveBeenCalled();
-    expect(updateEventRecurrence).not.toHaveBeenCalled();
-    expect(deleteEventRecurrence).not.toHaveBeenCalled();
-  });
-
-  test('create falls back to updating the rule when one already exists (400)', async () => {
-    createEventRecurrence.mockRejectedValue(Object.assign(new Error('exists'), { status: 400 }));
-    renderPage();
-    await screen.findAllByText('Summer 5K');
-    const dialog = await openAddForm();
-    fireEvent.click(within(dialog).getByLabelText(/Enable recurrence/));
-    fireEvent.change(within(dialog).getByLabelText(/Event Name/), { target: { value: 'Weekly Race' } });
-    fireEvent.change(within(dialog).getByLabelText(/Date \/ 日期/), { target: { value: `${YEAR}-10-10` } });
-    fireEvent.click(within(dialog).getByText('Create / 创建'));
-    await waitFor(() =>
-      expect(updateEventRecurrence).toHaveBeenCalledWith(
-        42,
-        expect.objectContaining({ recurrence_type: 'weekly' }),
-        'admin-uid'
-      )
-    );
-  });
-
-  test('edit pre-fills an existing recurrence rule and updates it on save', async () => {
-    getEventWithRecurrence.mockResolvedValue({
-      recurrence: {
-        recurrence_type: 'yearly', days_of_week: '6', day_of_month: null,
-        week_of_month: 3, month_of_year: 11, end_date: null,
-      },
-    });
-    renderPage();
-    await screen.findAllByText('Summer 5K');
-    fireEvent.click(screen.getAllByTestId('EditIcon')[0].closest('button'));
-    const dialog = await screen.findByRole('dialog');
-    expect(getEventWithRecurrence).toHaveBeenCalledWith(1);
-    // Rule loads asynchronously and enables the recurrence section
-    expect(await within(dialog).findByLabelText(/Month \/ 月份/)).toBeInTheDocument();
-    expect(within(dialog).getByLabelText(/Enable recurrence/)).toBeChecked();
-
-    fireEvent.click(within(dialog).getByText('Update / 更新'));
-    await waitFor(() =>
-      expect(updateEventRecurrence).toHaveBeenCalledWith(
-        1,
-        {
-          recurrence_type: 'yearly',
-          days_of_week: '6',
-          day_of_month: null,
-          week_of_month: 3,
-          month_of_year: 11,
-          end_date: null,
-        },
-        'admin-uid'
-      )
-    );
-    expect(createEventRecurrence).not.toHaveBeenCalled();
-  });
-
-  test('edit that disables recurrence deletes the existing rule', async () => {
-    getEventWithRecurrence.mockResolvedValue({
-      recurrence: { recurrence_type: 'weekly', days_of_week: '0' },
-    });
-    renderPage();
-    await screen.findAllByText('Summer 5K');
-    fireEvent.click(screen.getAllByTestId('EditIcon')[0].closest('button'));
-    const dialog = await screen.findByRole('dialog');
-    const toggle = await within(dialog).findByLabelText(/Enable recurrence/);
-    await waitFor(() => expect(toggle).toBeChecked());
-
-    fireEvent.click(toggle); // turn recurrence off
-    fireEvent.click(within(dialog).getByText('Update / 更新'));
-    await waitFor(() => expect(deleteEventRecurrence).toHaveBeenCalledWith(1, 'admin-uid'));
-    expect(updateEventRecurrence).not.toHaveBeenCalled();
-  });
-
-  test('edit tolerates a failed recurrence rule fetch', async () => {
-    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-    getEventWithRecurrence.mockRejectedValue(new Error('rule fetch down'));
-    renderPage();
-    await screen.findAllByText('Summer 5K');
-    fireEvent.click(screen.getAllByTestId('EditIcon')[0].closest('button'));
-    const dialog = await screen.findByRole('dialog');
-    await waitFor(() =>
-      expect(errorSpy).toHaveBeenCalledWith('Error loading recurrence rule:', expect.any(Error))
-    );
-    // Form still opens with recurrence off
-    expect(within(dialog).getByLabelText(/Enable recurrence/)).not.toBeChecked();
-    errorSpy.mockRestore();
-  });
-
-  test('non-400 recurrence save failure surfaces the error and does not retry as update', async () => {
-    createEventRecurrence.mockRejectedValue(Object.assign(new Error('rule boom'), { status: 500 }));
-    renderPage();
-    await screen.findAllByText('Summer 5K');
-    const dialog = await openAddForm();
-    fireEvent.click(within(dialog).getByLabelText(/Enable recurrence/));
-    fireEvent.change(within(dialog).getByLabelText(/Event Name/), { target: { value: 'X' } });
-    fireEvent.change(within(dialog).getByLabelText(/Date \/ 日期/), { target: { value: `${YEAR}-10-10` } });
-    fireEvent.click(within(dialog).getByText('Create / 创建'));
-    expect(await screen.findByText(/Error: rule boom/)).toBeInTheDocument();
-    expect(updateEventRecurrence).not.toHaveBeenCalled();
-  });
-
-  test('edit pre-fills a day-of-month rule including its end date', async () => {
-    getEventWithRecurrence.mockResolvedValue({
-      recurrence: {
-        recurrence_type: 'monthly', days_of_week: null, day_of_month: 15,
-        week_of_month: null, month_of_year: null, end_date: '2027-01-31',
-      },
-    });
-    renderPage();
-    await screen.findAllByText('Summer 5K');
-    fireEvent.click(screen.getAllByTestId('EditIcon')[0].closest('button'));
-    const dialog = await screen.findByRole('dialog');
-    expect(await within(dialog).findByLabelText(/Day of Month/)).toHaveValue(15);
-    expect(within(dialog).getByLabelText(/End Date/)).toHaveValue('2027-01-31');
-  });
-
-  test('edit defaults a rule without a type to weekly', async () => {
-    getEventWithRecurrence.mockResolvedValue({
-      recurrence: { recurrence_type: null, days_of_week: '0,6' },
-    });
-    renderPage();
-    await screen.findAllByText('Summer 5K');
-    fireEvent.click(screen.getAllByTestId('EditIcon')[0].closest('button'));
-    const dialog = await screen.findByRole('dialog');
-    const toggle = await within(dialog).findByLabelText(/Enable recurrence/);
-    await waitFor(() => expect(toggle).toBeChecked());
-    expect(within(dialog).getByText('Weekly / 每周')).toBeInTheDocument();
-  });
-
-  test('image selection previews, uploads on save, and can be removed', async () => {
-    renderPage();
-    await screen.findAllByText('Summer 5K');
-    const dialog = await openAddForm();
-
-    const fileInput = dialog.querySelector('#event-image-upload');
-    // Non-image file rejected
-    fireEvent.change(fileInput, {
-      target: { files: [new File(['x'], 'doc.pdf', { type: 'application/pdf' })] },
-    });
-    expect(await screen.findByText(/Please select an image file/)).toBeInTheDocument();
-
-    // Oversize file rejected
-    const bigFile = new File(['x'], 'big.png', { type: 'image/png' });
-    Object.defineProperty(bigFile, 'size', { value: 6 * 1024 * 1024 });
-    fireEvent.change(fileInput, { target: { files: [bigFile] } });
-    expect(await screen.findByText(/Image must be less than 5MB/)).toBeInTheDocument();
-
-    // Valid image previews
-    const goodFile = new File(['x'], 'photo.png', { type: 'image/png' });
-    fireEvent.change(fileInput, { target: { files: [goodFile] } });
-    const preview = await within(dialog).findByAltText('Preview');
-    expect(preview).toBeInTheDocument();
-
-    // Remove clears the preview
-    fireEvent.click(within(dialog).getByText('Remove / 移除'));
-    expect(within(dialog).queryByAltText('Preview')).not.toBeInTheDocument();
-
-    // Re-select and save: image uploads first, url stored on the event
-    fireEvent.change(fileInput, { target: { files: [goodFile] } });
-    await within(dialog).findByAltText('Preview');
-    fireEvent.change(within(dialog).getByLabelText(/Event Name/), { target: { value: 'Pic Race' } });
-    fireEvent.change(within(dialog).getByLabelText(/Date \/ 日期/), { target: { value: `${YEAR}-10-12` } });
-    fireEvent.click(within(dialog).getByText('Create / 创建'));
-    await waitFor(() => expect(uploadImage).toHaveBeenCalledWith(goodFile, 'admin-uid'));
-    await waitFor(() =>
-      expect(createEvent).toHaveBeenCalledWith(
-        expect.objectContaining({ image: 'https://s3/uploaded.png' }),
-        'admin-uid'
-      )
-    );
-  });
-
-  test('image upload failure aborts the save with an error snackbar', async () => {
-    uploadImage.mockRejectedValue(new Error('s3 down'));
-    renderPage();
-    await screen.findAllByText('Summer 5K');
-    const dialog = await openAddForm();
-    fireEvent.change(dialog.querySelector('#event-image-upload'), {
-      target: { files: [new File(['x'], 'p.png', { type: 'image/png' })] },
-    });
-    fireEvent.change(within(dialog).getByLabelText(/Event Name/), { target: { value: 'X' } });
-    fireEvent.change(within(dialog).getByLabelText(/Date \/ 日期/), { target: { value: `${YEAR}-10-12` } });
-    fireEvent.click(within(dialog).getByText('Create / 创建'));
-    expect(await screen.findByText(/Failed to upload image/)).toBeInTheDocument();
-    expect(createEvent).not.toHaveBeenCalled();
+    await screen.findAllByText(/Summer 5K/);
+    fireEvent.click(screen.getByText('Add Event / 添加活动'));
+    expect(await screen.findByText('composer-create')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('probe-composer-close'));
+    fireEvent.click(screen.getAllByLabelText('edit event')[1]); // Track Night featured card
+    expect(await screen.findByText('composer-edit:Track Night')).toBeInTheDocument();
   });
 });
 
@@ -741,8 +430,8 @@ describe('admin delete and move-to-memories', () => {
 
   test('delete flow confirms then deletes and refreshes', async () => {
     renderPage();
-    await screen.findAllByText('Summer 5K');
-    fireEvent.click(screen.getAllByTestId('DeleteIcon')[0].closest('button'));
+    await screen.findAllByText(/Summer 5K/);
+    fireEvent.click(screen.getAllByLabelText('delete event')[0]);
     const dialog = await screen.findByRole('dialog');
     expect(within(dialog).getByText(/Are you sure you want to delete "Summer 5K"\?/)).toBeInTheDocument();
     fireEvent.click(within(dialog).getByText('Delete / 删除'));
@@ -753,8 +442,8 @@ describe('admin delete and move-to-memories', () => {
 
   test('delete cancel keeps the event', async () => {
     renderPage();
-    await screen.findAllByText('Summer 5K');
-    fireEvent.click(screen.getAllByTestId('DeleteIcon')[0].closest('button'));
+    await screen.findAllByText(/Summer 5K/);
+    fireEvent.click(screen.getAllByLabelText('delete event')[0]);
     const dialog = await screen.findByRole('dialog');
     fireEvent.click(within(dialog).getByText('Cancel / 取消'));
     await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
@@ -762,191 +451,73 @@ describe('admin delete and move-to-memories', () => {
   });
 
   test('delete failure shows an error snackbar', async () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
     deleteEvent.mockRejectedValue(new Error('locked'));
     renderPage();
-    await screen.findAllByText('Summer 5K');
-    fireEvent.click(screen.getAllByTestId('DeleteIcon')[0].closest('button'));
+    await screen.findAllByText(/Summer 5K/);
+    fireEvent.click(screen.getAllByLabelText('delete event')[0]);
     const dialog = await screen.findByRole('dialog');
     fireEvent.click(within(dialog).getByText('Delete / 删除'));
     expect(await screen.findByText(/Error: locked/)).toBeInTheDocument();
-  });
-
-  test('star button moves the event to memories and drops it from the list', async () => {
-    renderPage();
-    await screen.findAllByText('Summer 5K');
-    fireEvent.click(screen.getAllByTestId('StarIcon')[0].closest('button'));
-    await waitFor(() =>
-      expect(updateEvent).toHaveBeenCalledWith(1, { status: 'Past' }, 'admin-uid')
-    );
-    expect(await screen.findByText(/Event moved to Memories/)).toBeInTheDocument();
-    // Removed from the list section (featured cards are left untouched)
-    await waitFor(() => expect(screen.getAllByText('Summer 5K')).toHaveLength(1));
-  });
-
-  test('move to memories fails gracefully', async () => {
-    updateEvent.mockRejectedValue(new Error('nope'));
-    renderPage();
-    await screen.findAllByText('Summer 5K');
-    fireEvent.click(screen.getAllByTestId('StarIcon')[0].closest('button'));
-    expect(await screen.findByText(/Failed to move event/)).toBeInTheDocument();
-  });
-
-  test('move to memories requires login', async () => {
-    useAuth.mockReturnValue({ currentUser: null });
-    renderPage();
-    await screen.findAllByText('Summer 5K');
-    fireEvent.click(screen.getAllByTestId('StarIcon')[0].closest('button'));
-    expect(await screen.findByText(/You must be logged in/)).toBeInTheDocument();
-    expect(updateEvent).not.toHaveBeenCalled();
-  });
-});
-
-describe('quick QR upload', () => {
-  beforeEach(() => {
-    useAdmin.mockReturnValue({ adminModeEnabled: true });
-  });
-
-  test('uploads a QR code for an event without one', async () => {
-    renderPage();
-    await screen.findAllByText('Summer 5K');
-    // First QR icon = first featured card (Summer 5K, no QR yet)
-    fireEvent.click(screen.getAllByTestId('QrCode2Icon')[0].closest('button'));
-    const dialog = await screen.findByRole('dialog');
-    expect(within(dialog).getByText('WeChat QR Code / 微信二维码')).toBeInTheDocument();
-    expect(within(dialog).getByText('Choose QR Code / 选择二维码')).toBeInTheDocument();
-
-    const uploadBtn = within(dialog).getByText('Upload / 上传').closest('button');
-    expect(uploadBtn).toBeDisabled();
-
-    const qrFile = new File(['x'], 'qr.png', { type: 'image/png' });
-    fireEvent.change(dialog.querySelector('#quick-qr-upload'), { target: { files: [qrFile] } });
-    expect(await within(dialog).findByAltText('QR Preview')).toBeInTheDocument();
-
-    fireEvent.click(uploadBtn);
-    await waitFor(() => expect(uploadImage).toHaveBeenCalledWith(qrFile, 'admin-uid'));
-    await waitFor(() =>
-      expect(updateEvent).toHaveBeenCalledWith(1, { wechat_qr_code: 'https://s3/uploaded.png' }, 'admin-uid')
-    );
-    expect(await screen.findByText(/QR code uploaded/)).toBeInTheDocument();
-  });
-
-  test('validates QR file type and size', async () => {
-    renderPage();
-    await screen.findAllByText('Summer 5K');
-    fireEvent.click(screen.getAllByTestId('QrCode2Icon')[0].closest('button'));
-    const dialog = await screen.findByRole('dialog');
-    fireEvent.change(dialog.querySelector('#quick-qr-upload'), {
-      target: { files: [new File(['x'], 'doc.txt', { type: 'text/plain' })] },
-    });
-    expect(await screen.findByText(/Please select an image file/)).toBeInTheDocument();
-
-    const big = new File(['x'], 'big.png', { type: 'image/png' });
-    Object.defineProperty(big, 'size', { value: 6 * 1024 * 1024 });
-    fireEvent.change(dialog.querySelector('#quick-qr-upload'), { target: { files: [big] } });
-    expect(await screen.findByText(/Image must be less than 5MB/)).toBeInTheDocument();
-  });
-
-  test('shows the existing QR with replace/remove options and removes it', async () => {
-    renderPage();
-    await screen.findAllByText('Summer 5K');
-    // Second featured card is Track Night (id 2) which has a QR code
-    fireEvent.click(screen.getAllByTestId('QrCode2Icon')[1].closest('button'));
-    const dialog = await screen.findByRole('dialog');
-    expect(within(dialog).getByAltText('Current QR Code')).toHaveAttribute('src', 'https://qr/track.png');
-    expect(within(dialog).getByText('Replace QR / 替换二维码')).toBeInTheDocument();
-
-    fireEvent.click(within(dialog).getByText('Remove / 移除'));
-    await waitFor(() =>
-      expect(updateEvent).toHaveBeenCalledWith(2, { wechat_qr_code: '' }, 'admin-uid')
-    );
-    expect(await screen.findByText(/QR code removed/)).toBeInTheDocument();
-  });
-
-  test('QR upload failure shows an error snackbar', async () => {
-    uploadImage.mockRejectedValue(new Error('s3 down'));
-    renderPage();
-    await screen.findAllByText('Summer 5K');
-    fireEvent.click(screen.getAllByTestId('QrCode2Icon')[0].closest('button'));
-    const dialog = await screen.findByRole('dialog');
-    fireEvent.change(dialog.querySelector('#quick-qr-upload'), {
-      target: { files: [new File(['x'], 'qr.png', { type: 'image/png' })] },
-    });
-    fireEvent.click(within(dialog).getByText('Upload / 上传'));
-    expect(await screen.findByText(/Failed to upload QR code/)).toBeInTheDocument();
-  });
-
-  test('QR remove failure shows an error snackbar', async () => {
-    updateEvent.mockRejectedValue(new Error('nope'));
-    renderPage();
-    await screen.findAllByText('Summer 5K');
-    fireEvent.click(screen.getAllByTestId('QrCode2Icon')[1].closest('button'));
-    const dialog = await screen.findByRole('dialog');
-    fireEvent.click(within(dialog).getByText('Remove / 移除'));
-    expect(await screen.findByText(/Failed to remove QR code/)).toBeInTheDocument();
-  });
-
-  test('cancel closes the QR dialog', async () => {
-    renderPage();
-    await screen.findAllByText('Summer 5K');
-    fireEvent.click(screen.getAllByTestId('QrCode2Icon')[0].closest('button'));
-    const dialog = await screen.findByRole('dialog');
-    fireEvent.click(within(dialog).getByText('Cancel / 取消'));
-    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
-  });
-});
-
-describe('remaining interaction wiring', () => {
-  test('list-row admin actions use the same handlers and dialogs close on Escape', async () => {
-    useAdmin.mockReturnValue({ adminModeEnabled: true });
-    renderPage();
-    await screen.findAllByText('Summer 5K');
-    // Icon index 3 = first list row (indices 0-2 are the featured cards)
-    fireEvent.click(screen.getAllByTestId('EditIcon')[3].closest('button'));
-    let dialog = await screen.findByRole('dialog');
-    expect(within(dialog).getByLabelText(/Event Name/)).toHaveValue('Summer 5K');
-    fireEvent.keyDown(dialog, { key: 'Escape' });
-    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
-
-    fireEvent.click(screen.getAllByTestId('DeleteIcon')[3].closest('button'));
-    dialog = await screen.findByRole('dialog');
-    expect(within(dialog).getByText(/Summer 5K/)).toBeInTheDocument();
-    fireEvent.keyDown(dialog, { key: 'Escape' });
-    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
-
-    fireEvent.click(screen.getAllByTestId('QrCode2Icon')[3].closest('button'));
-    dialog = await screen.findByRole('dialog');
-    expect(within(dialog).getByText('WeChat QR Code / 微信二维码')).toBeInTheDocument();
-    fireEvent.keyDown(dialog, { key: 'Escape' });
-    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
-
-    fireEvent.click(screen.getAllByTestId('StarIcon')[3].closest('button'));
-    await waitFor(() =>
-      expect(updateEvent).toHaveBeenCalledWith(1, { status: 'Past' }, 'admin-uid')
-    );
-  });
-
-  test('list-row share button copies the deep link', async () => {
-    renderPage();
-    await screen.findAllByText('Summer 5K');
-    const shareButtons = screen.getAllByTestId('ShareIcon');
-    fireEvent.click(shareButtons[shareButtons.length - 1].closest('button'));
-    await waitFor(() => expect(navigator.clipboard.writeText).toHaveBeenCalled());
-    expect(await screen.findByText(/Link copied/)).toBeInTheDocument();
+    errorSpy.mockRestore();
   });
 
   test('delete confirm without a logged-in user shows an error', async () => {
-    useAdmin.mockReturnValue({ adminModeEnabled: true });
     useAuth.mockReturnValue({ currentUser: null });
     renderPage();
-    await screen.findAllByText('Summer 5K');
-    fireEvent.click(screen.getAllByTestId('DeleteIcon')[0].closest('button'));
+    await screen.findAllByText(/Summer 5K/);
+    fireEvent.click(screen.getAllByLabelText('delete event')[0]);
     const dialog = await screen.findByRole('dialog');
     fireEvent.click(within(dialog).getByText('Delete / 删除'));
     expect(await screen.findByText(/Unable to delete event/)).toBeInTheDocument();
     expect(deleteEvent).not.toHaveBeenCalled();
   });
 
+  test('list-row delete button targets the same event as the featured card', async () => {
+    renderPage();
+    await screen.findAllByText(/Summer 5K/);
+    // Index 3 = first list row (Summer 5K)
+    fireEvent.click(screen.getAllByLabelText('delete event')[3]);
+    const dialog = await screen.findByRole('dialog');
+    fireEvent.click(within(dialog).getByText('Delete / 删除'));
+    await waitFor(() => expect(deleteEvent).toHaveBeenCalledWith(1, 'admin-uid'));
+  });
+
+  test('star button moves the event to memories and drops it from the list', async () => {
+    renderPage();
+    await screen.findAllByText(/Summer 5K/);
+    fireEvent.click(screen.getAllByLabelText('move to memories')[0]);
+    await waitFor(() =>
+      expect(updateEvent).toHaveBeenCalledWith(1, { status: 'Past' }, 'admin-uid')
+    );
+    expect(await screen.findByText(/Event moved to Memories/)).toBeInTheDocument();
+    // Removed from the list section (featured cards are left untouched)
+    await waitFor(() => expect(screen.getAllByText(/Summer 5K/)).toHaveLength(1));
+  });
+
+  test('move to memories fails gracefully', async () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    updateEvent.mockRejectedValue(new Error('nope'));
+    renderPage();
+    await screen.findAllByText(/Summer 5K/);
+    fireEvent.click(screen.getAllByLabelText('move to memories')[0]);
+    expect(await screen.findByText(/Failed to move event/)).toBeInTheDocument();
+    errorSpy.mockRestore();
+  });
+
+  test('move to memories requires login', async () => {
+    useAuth.mockReturnValue({ currentUser: null });
+    renderPage();
+    await screen.findAllByText(/Summer 5K/);
+    fireEvent.click(screen.getAllByLabelText('move to memories')[0]);
+    expect(await screen.findByText(/You must be logged in/)).toBeInTheDocument();
+    expect(updateEvent).not.toHaveBeenCalled();
+  });
+});
+
+describe('snackbar', () => {
   test('snackbar close button dismisses the snackbar', async () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
     getEventsByStatus.mockRejectedValue(new Error('down'));
     renderPage();
     await screen.findByText(/Failed to load events/);
@@ -954,34 +525,6 @@ describe('remaining interaction wiring', () => {
     await waitFor(() =>
       expect(screen.queryByText(/Failed to load events/)).not.toBeInTheDocument()
     );
-  });
-
-  test('card image error handler swaps to the placeholder image', async () => {
-    renderPage();
-    await screen.findAllByText('Summer 5K');
-    fireEvent.click(screen.getAllByText('probe-img-error')[0]);
-    // Handler mutates the event target — no crash and page still renders
-    expect(screen.getAllByText('Summer 5K').length).toBeGreaterThan(0);
-  });
-
-  test('form field keydown runs the combined autofill/translation handler and empty file selection is a no-op', async () => {
-    useAdmin.mockReturnValue({ adminModeEnabled: true });
-    renderPage();
-    await screen.findAllByText('Summer 5K');
-    fireEvent.click(screen.getByText('Add Event / 添加活动'));
-    const dialog = await screen.findByRole('dialog');
-    fireEvent.keyDown(within(dialog).getByLabelText(/Event Name/), { key: 'Tab' });
-
-    // Selecting no file leaves the form untouched
-    fireEvent.change(dialog.querySelector('#event-image-upload'), { target: { files: [] } });
-    expect(within(dialog).queryByAltText('Preview')).not.toBeInTheDocument();
-
-    // Broken preview image hides itself via its inline error handler
-    fireEvent.change(dialog.querySelector('#event-image-upload'), {
-      target: { files: [new File(['x'], 'p.png', { type: 'image/png' })] },
-    });
-    const preview = await within(dialog).findByAltText('Preview');
-    fireEvent.error(preview);
-    expect(preview.style.display).toBe('none');
+    errorSpy.mockRestore();
   });
 });

--- a/ProjectCode/client/src/pages/HighlightsPage.js
+++ b/ProjectCode/client/src/pages/HighlightsPage.js
@@ -1,17 +1,14 @@
 import MoreVertIcon from '@mui/icons-material/MoreVert';
 import PlaylistAddIcon from '@mui/icons-material/PlaylistAdd';
 import DragIndicatorIcon from '@mui/icons-material/DragIndicator';
-import ShareIcon from '@mui/icons-material/Share';
 import DeleteIcon from '@mui/icons-material/Delete';
 import AddIcon from '@mui/icons-material/Add';
-import { Alert, Box, Button, Card, CardContent, Chip, CircularProgress, Container, Dialog, DialogActions, DialogContent, DialogTitle, Grid, IconButton, Menu, MenuItem, Snackbar, TextField, Typography } from '@mui/material';
+import { Alert, Box, Button, Card, CircularProgress, Container, Dialog, DialogActions, DialogContent, DialogTitle, Grid, IconButton, Menu, MenuItem, Snackbar, TextField, Typography } from '@mui/material';
 import { useEffect, useState, useCallback } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { DndContext, DragOverlay, useSensor, useSensors, TouchSensor, MouseSensor, closestCenter } from '@dnd-kit/core';
 import { useDraggable, useDroppable } from '@dnd-kit/core';
-import EventCardImage from '../components/EventCardImage';
-import EventEngagementBar from '../components/EventEngagementBar';
-import EventGalleryPreview from '../components/EventGalleryPreview';
+import EventCard from '../components/EventCard';
 import EventDetailModal from '../components/EventDetailModal';
 import EventGroupCard from '../components/EventGroupCard';
 import EventGroupGalleryModal from '../components/EventGroupGalleryModal';
@@ -19,24 +16,10 @@ import UndoSnackbar from '../components/UndoSnackbar';
 import { getBatchEngagement, toggleSeriesParent, getHighlightsGrouped, mergeEventsToGroup, removeEventFromGroup, undoGroupMerge, deleteEvent, createEvent } from '../api';
 import { useAuth } from '../context/AuthContext';
 import { useAdmin } from '../context/AdminContext';
-
-// Design tokens — match the redesigned HomePage / NavBar
-const ORANGE = '#FFA500';
-const ORANGE_DARK = '#F29400';
-const ORANGE_BG = '#FFF6E8';
-const LINE = '#EEE7DC';
-const INK = '#212121';
-const MUTED = '#757575';
-
-const MONTHS = ['JAN', 'FEB', 'MAR', 'APR', 'MAY', 'JUN', 'JUL', 'AUG', 'SEP', 'OCT', 'NOV', 'DEC'];
-
-// Parse an event date (YYYY-MM-DD) into { day, month } for the date bubble
-function parseBubbleDate(dateStr) {
-  if (!dateStr) return null;
-  const d = new Date(`${dateStr}T00:00:00`);
-  if (isNaN(d.getTime())) return null;
-  return { day: d.getDate(), month: MONTHS[d.getMonth()] };
-}
+import {
+  ORANGE, ORANGE_DARK, ORANGE_BG, LINE, INK, MUTED,
+  CARD_SHADOW, CARD_HOVER_SHADOW, FALLBACK_EVENT_IMAGE,
+} from '../theme/tokens';
 
 // Pill styling for the filter selects
 const filterPillSx = {
@@ -277,7 +260,7 @@ export default function HighlightsPage() {
           chineseLocation: event.chinese_location,
           description: event.description,
           chineseDescription: event.chinese_description,
-          image: event.image || '/images/2025/20250517_bk_half.jpg',
+          image: event.image || FALLBACK_EVENT_IMAGE,
           image_position: event.image_position,
           signupLink: event.signup_link,
           status: event.status,
@@ -304,8 +287,9 @@ export default function HighlightsPage() {
           time: e.time,
           location: e.location,
           chineseLocation: e.chinese_location,
-          image: e.image || '/images/2025/20250517_bk_half.jpg',
+          image: e.image || FALLBACK_EVENT_IMAGE,
           image_position: e.image_position,
+          status: e.status,
           is_highlight: !!e.is_highlight,
         })))
       ];
@@ -324,7 +308,9 @@ export default function HighlightsPage() {
           time: e.time,
           location: e.location,
           chineseLocation: e.chineseLocation,
-          chineseDescription: e.chineseDescription
+          chineseDescription: e.chineseDescription,
+          // Featured cards are memories — never let EventCard default to Upcoming
+          status: e.status || 'Past'
         }));
       setFeaturedEvents(featured);
 
@@ -524,13 +510,7 @@ export default function HighlightsPage() {
     handleMenuClose();
   };
 
-  const handleImageError = (e) => {
-    console.error('Image failed to load:', e.target.src);
-    e.target.src = '/images/2025/20250517_bk_half.jpg';
-  };
-
-  const handleShare = async (e, eventId, eventName) => {
-    e.stopPropagation();
+  const handleShare = async (eventId) => {
     const shareUrl = `${window.location.origin}/highlights?event=${eventId}`;
     try {
       await navigator.clipboard.writeText(shareUrl);
@@ -661,93 +641,13 @@ export default function HighlightsPage() {
         <Grid container spacing={3}>
           {featuredEvents.map((event) => (
             <Grid item xs={12} md={4} key={event.id}>
-              <Card
-                elevation={0}
-                sx={{
-                  height: '100%',
-                  display: 'flex',
-                  flexDirection: 'column',
-                  cursor: 'pointer',
-                  backgroundColor: 'white',
-                  border: `1px solid ${LINE}`,
-                  borderRadius: '12px',
-                  boxShadow: '0 2px 4px rgba(0,0,0,0.08)',
-                  transition: 'all 0.2s ease',
-                  '&:hover': {
-                    transform: 'translateY(-3px)',
-                    boxShadow: '0 8px 24px rgba(255,165,0,0.35)'
-                  }
-                }}
-                onClick={() => handleEventClick(event)}
-              >
-                <Box sx={{ position: 'relative' }}>
-                  <EventCardImage event={event} height="200" onError={handleImageError} />
-                  <IconButton
-                    size="small"
-                    onClick={(e) => handleShare(e, event.id, event.title)}
-                    sx={{
-                      position: 'absolute',
-                      top: 8,
-                      right: 8,
-                      backgroundColor: 'rgba(255, 255, 255, 0.9)',
-                      '&:hover': { backgroundColor: 'rgba(255, 255, 255, 1)' },
-                    }}
-                  >
-                    <ShareIcon fontSize="small" />
-                  </IconButton>
-                </Box>
-                <CardContent sx={{ flexGrow: 1, display: 'flex', flexDirection: 'column' }}>
-                  <Typography gutterBottom variant="h6" component="div" sx={{
-                    overflow: 'hidden',
-                    display: '-webkit-box',
-                    WebkitLineClamp: 1,
-                    WebkitBoxOrient: 'vertical',
-                  }}>
-                    {event.title}
-                  </Typography>
-                  <Typography gutterBottom variant="subtitle1" color="text.secondary" sx={{
-                    overflow: 'hidden',
-                    display: '-webkit-box',
-                    WebkitLineClamp: 1,
-                    WebkitBoxOrient: 'vertical',
-                    minHeight: '1.75em',
-                  }}>
-                    {event.chineseTitle || '\u00A0'}
-                  </Typography>
-                  <Box sx={{ mb: 1 }}>
-                    <EventGalleryPreview eventId={event.id} maxImages={4} size={40} />
-                  </Box>
-                  <Box sx={{ mb: 1 }}>
-                    <EventEngagementBar
-                      eventId={event.id}
-                      initialData={engagementData[event.id]}
-                    />
-                  </Box>
-                  <Button
-                    variant="contained"
-                    disableElevation
-                    sx={{
-                      mt: 'auto',
-                      backgroundColor: ORANGE,
-                      color: 'white',
-                      textTransform: 'none',
-                      fontWeight: 600,
-                      fontSize: '0.9375rem',
-                      px: 2.5,
-                      py: 1.1,
-                      borderRadius: '99px',
-                      '&:hover': {
-                        backgroundColor: ORANGE_DARK,
-                      },
-                      '&:active': {
-                        transform: 'scale(0.98)',
-                      }
-                    }}
-                  >
-                    View Details 查看详情
-                  </Button>
-                </CardContent>
-              </Card>
+              <EventCard
+                event={event}
+                density="grid"
+                showGalleryPreview
+                onClick={handleEventClick}
+                onShare={(ev) => handleShare(ev.id)}
+              />
             </Grid>
           ))}
         </Grid>
@@ -888,255 +788,47 @@ export default function HighlightsPage() {
               {({ isOver }) => (
                 <DraggableEventCard id={event.id} disabled={!adminModeEnabled}>
                   {({ dragHandleProps, isDragging }) => (
-                    <Card
-                      elevation={0}
+                    <EventCard
+                      event={event}
+                      density="row"
+                      showGalleryPreview
+                      onClick={(ev) => !isDragging && handleEventClick(ev)}
+                      onShare={(ev) => handleShare(ev.id)}
+                      adminActions={adminModeEnabled ? (
+                        <>
+                          {/* Drag handle: hold (touch) or press-and-move (mouse) to merge */}
+                          <Box
+                            {...dragHandleProps}
+                            aria-label="drag to merge"
+                            sx={{
+                              display: 'inline-flex',
+                              alignItems: 'center',
+                              cursor: 'grab',
+                              p: 0.5,
+                              borderRadius: '4px',
+                              '&:hover': { backgroundColor: ORANGE_BG },
+                            }}
+                          >
+                            <DragIndicatorIcon sx={{ color: ORANGE, fontSize: 20 }} />
+                          </Box>
+                          <IconButton
+                            size="small"
+                            onClick={(e) => handleMenuOpen(e, event.id)}
+                            aria-label="event admin menu"
+                            sx={{ color: MUTED, '&:hover': { color: ORANGE, backgroundColor: ORANGE_BG } }}
+                          >
+                            <MoreVertIcon fontSize="small" />
+                          </IconButton>
+                        </>
+                      ) : null}
                       sx={{
-                        display: 'flex',
-                        flexDirection: { xs: 'column', sm: 'row' },
-                        minHeight: { xs: 'auto', sm: '200px' },
-                        overflow: 'hidden',
-                        cursor: 'pointer',
-                        backgroundColor: 'white',
-                        borderRadius: '12px',
-                        boxShadow: '0 2px 4px rgba(0,0,0,0.08)',
-                        transition: 'all 0.2s ease',
                         opacity: isDragging ? 0.5 : 1,
                         border: isOver ? `3px dashed ${ORANGE}` : `1px solid ${LINE}`,
-                        '&:hover': {
-                          transform: isDragging ? 'none' : 'translateY(-3px)',
-                          boxShadow: '0 8px 24px rgba(255,165,0,0.35)'
-                        },
+                        ...(isDragging && {
+                          '&:hover': { transform: 'none', boxShadow: CARD_SHADOW },
+                        }),
                       }}
-                      onClick={() => !isDragging && handleEventClick(event)}
-                    >
-                      {/* Mobile: Image at top */}
-                      <Box
-                        sx={{
-                          display: { xs: 'block', sm: 'none' },
-                          width: '100%',
-                          height: '150px',
-                          position: 'relative'
-                        }}
-                      >
-                        <EventCardImage
-                          event={event}
-                          onError={handleImageError}
-                          sx={{ height: '100%', width: '100%' }}
-                        />
-                        {/* Mobile drag handle - long press to drag */}
-                        {adminModeEnabled && (
-                          <Box
-                            {...dragHandleProps}
-                            onClick={(e) => e.stopPropagation()}
-                            sx={{
-                              position: 'absolute',
-                              top: 8,
-                              left: 8,
-                              zIndex: 10,
-                              cursor: 'grab',
-                            }}
-                          >
-                            <Chip
-                              icon={<DragIndicatorIcon sx={{ fontSize: 16 }} />}
-                              label="Hold to drag"
-                              size="small"
-                              sx={{
-                                backgroundColor: 'rgba(255, 165, 0, 0.95)',
-                                color: 'white',
-                                fontWeight: 600,
-                                fontSize: '0.75rem',
-                              }}
-                            />
-                          </Box>
-                        )}
-                      </Box>
-
-                      {/* Date/Time Column - hidden on mobile, shown on sm+ */}
-                      <Box
-                        sx={{
-                          display: { xs: 'none', sm: 'flex' },
-                          width: '120px',
-                          flexDirection: 'column',
-                          justifyContent: 'center',
-                          alignItems: 'center',
-                          gap: 0.75,
-                          backgroundColor: 'white',
-                          p: 2,
-                          borderRight: `1px solid ${LINE}`,
-                          whiteSpace: 'nowrap',
-                          position: 'relative'
-                        }}
-                      >
-                        {/* Desktop drag handle */}
-                        {adminModeEnabled && (
-                          <Box
-                            {...dragHandleProps}
-                            onClick={(e) => e.stopPropagation()}
-                            sx={{
-                              position: 'absolute',
-                              top: 8,
-                              left: '50%',
-                              transform: 'translateX(-50%)',
-                              cursor: 'grab',
-                              padding: '4px',
-                              borderRadius: '4px',
-                              '&:hover': {
-                                backgroundColor: 'rgba(255, 165, 0, 0.2)',
-                              },
-                            }}
-                          >
-                            <DragIndicatorIcon
-                              sx={{
-                                color: '#FFA500',
-                                fontSize: 20,
-                              }}
-                            />
-                          </Box>
-                        )}
-                {(() => {
-                  const bubbleDate = parseBubbleDate(event.date);
-                  return bubbleDate ? (
-                    <Box
-                      sx={{
-                        width: 46,
-                        height: 46,
-                        borderRadius: '12px',
-                        backgroundColor: ORANGE_BG,
-                        display: 'flex',
-                        flexDirection: 'column',
-                        alignItems: 'center',
-                        justifyContent: 'center',
-                      }}
-                    >
-                      <Typography sx={{ fontSize: '1rem', fontWeight: 700, color: ORANGE, lineHeight: 1.1 }}>
-                        {bubbleDate.day}
-                      </Typography>
-                      <Typography sx={{ fontSize: '0.59rem', fontWeight: 700, letterSpacing: '0.1em', color: MUTED, textTransform: 'uppercase' }}>
-                        {bubbleDate.month}
-                      </Typography>
-                    </Box>
-                  ) : (
-                    <Typography variant="body2" sx={{ color: MUTED, whiteSpace: 'nowrap' }}>
-                      {event.date}
-                    </Typography>
-                  );
-                })()}
-                <Typography sx={{ fontSize: '0.7rem', fontWeight: 700, letterSpacing: '0.06em', color: MUTED, whiteSpace: 'nowrap' }}>
-                  {(event.date || '').split('-')[0]}
-                </Typography>
-                <Typography sx={{ fontSize: '0.8rem', fontWeight: 600, color: ORANGE, whiteSpace: 'nowrap' }}>
-                  {event.time}
-                </Typography>
-              </Box>
-
-              {/* Image Column - hidden on mobile, shown on sm+ */}
-              <Box
-                sx={{
-                  display: { xs: 'none', sm: 'block' },
-                  width: '200px',
-                  flexShrink: 0
-                }}
-              >
-                <EventCardImage event={event} onError={handleImageError} sx={{ height: '100%', width: '100%' }} />
-              </Box>
-
-              {/* Content Column */}
-              <Box
-                sx={{
-                  flex: 1,
-                  p: 2,
-                  display: 'flex',
-                  flexDirection: 'column',
-                  position: 'relative'
-                }}
-              >
-                {/* Share and admin buttons */}
-                <Box sx={{ position: 'absolute', top: 8, right: 8, zIndex: 10, display: 'flex', gap: 0.5 }}>
-                  <IconButton
-                    size="small"
-                    onClick={(e) => handleShare(e, event.id, event.name)}
-                    sx={{
-                      backgroundColor: 'rgba(255, 255, 255, 0.9)',
-                      '&:hover': { backgroundColor: 'rgba(255, 255, 255, 1)' },
-                    }}
-                  >
-                    <ShareIcon fontSize="small" />
-                  </IconButton>
-                  {adminModeEnabled && (
-                    <IconButton
-                      size="small"
-                      onClick={(e) => handleMenuOpen(e, event.id)}
-                      sx={{
-                        backgroundColor: 'rgba(255, 255, 255, 0.9)',
-                        '&:hover': { backgroundColor: 'rgba(255, 165, 0, 0.2)' }
-                      }}
-                    >
-                      <MoreVertIcon fontSize="small" />
-                    </IconButton>
-                  )}
-                </Box>
-                {/* Mobile: Show date/time at top of content */}
-                <Box sx={{ display: { xs: 'flex', sm: 'none' }, gap: 2, mb: 1, color: ORANGE }}>
-                  <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
-                    {event.time}
-                  </Typography>
-                  <Typography variant="subtitle1" color="text.secondary">
-                    {event.date}
-                  </Typography>
-                </Box>
-
-                <Box sx={{ display: 'flex', flexDirection: { xs: 'column', sm: 'row' }, justifyContent: 'space-between', alignItems: { xs: 'flex-start', sm: 'flex-start' }, mb: 1, gap: 1 }}>
-                  <Box>
-                    <Typography variant="h6" gutterBottom sx={{ fontSize: { xs: '1rem', sm: '1.25rem' } }}>
-                      {event.name}
-                    </Typography>
-                    <Typography variant="subtitle1" color="text.secondary" gutterBottom sx={{ fontSize: { xs: '0.875rem', sm: '1rem' } }}>
-                      {event.chineseName}
-                    </Typography>
-                  </Box>
-                  <Button
-                    variant="contained"
-                    disableElevation
-                    sx={{
-                      backgroundColor: ORANGE,
-                      color: 'white',
-                      textTransform: 'none',
-                      fontWeight: 600,
-                      fontSize: { xs: '0.8125rem', sm: '0.9375rem' },
-                      px: { xs: 2, sm: 2.5 },
-                      py: { xs: 0.75, sm: 1 },
-                      borderRadius: '99px',
-                      flexShrink: 0,
-                      '&:hover': {
-                        backgroundColor: ORANGE_DARK,
-                      },
-                      '&:active': {
-                        transform: 'scale(0.98)',
-                      }
-                    }}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      handleEventClick(event);
-                    }}
-                  >
-                    View Details 查看详情
-                  </Button>
-                </Box>
-                <Typography variant="body2" color="text.secondary" gutterBottom>
-                  {event.location}
-                </Typography>
-                <Typography variant="body2" color="text.secondary" gutterBottom>
-                  {event.chineseLocation}
-                </Typography>
-                <EventGalleryPreview eventId={event.id} maxImages={5} size={36} />
-                <Box sx={{ mt: 'auto' }}>
-                  <EventEngagementBar
-                    eventId={event.id}
-                    initialData={engagementData[event.id]}
-                  />
-                </Box>
-              </Box>
-                    </Card>
+                    />
                   )}
                 </DraggableEventCard>
               )}
@@ -1155,7 +847,7 @@ export default function HighlightsPage() {
                 p: 2,
                 border: `1px solid ${LINE}`,
                 borderRadius: '12px',
-                boxShadow: '0 8px 24px rgba(255,165,0,0.35)',
+                boxShadow: CARD_HOVER_SHADOW,
                 transform: 'rotate(3deg)',
                 opacity: 0.9,
               }}
@@ -1197,7 +889,7 @@ export default function HighlightsPage() {
         transformOrigin={{ vertical: 'top', horizontal: 'right' }}
       >
         <MenuItem onClick={handleToggleSeriesParent}>
-          <PlaylistAddIcon sx={{ mr: 1, color: '#FFA500' }} />
+          <PlaylistAddIcon sx={{ mr: 1, color: ORANGE }} />
           Mark as Series Parent 设为系列主活动
         </MenuItem>
         <MenuItem onClick={handleDeleteEvent}>
@@ -1337,7 +1029,7 @@ export default function HighlightsPage() {
             variant="contained"
             disabled={addEventLoading}
             startIcon={addEventLoading ? <CircularProgress size={20} color="inherit" /> : <AddIcon />}
-            sx={{ backgroundColor: '#FFA500', '&:hover': { backgroundColor: '#e69500' } }}
+            sx={{ backgroundColor: ORANGE, '&:hover': { backgroundColor: ORANGE_DARK } }}
           >
             {addEventLoading ? 'Creating...' : 'Create 创建'}
           </Button>

--- a/ProjectCode/client/src/pages/HighlightsPage.test.js
+++ b/ProjectCode/client/src/pages/HighlightsPage.test.js
@@ -404,20 +404,25 @@ describe('rendering', () => {
     expect(screen.getAllByText('Winter Marathon')).toHaveLength(1); // memories only
   });
 
-  test('renders memory cards with date bubbles, year, time and fallback for bad dates', async () => {
+  test('renders memory cards with date bubbles and a View Details CTA', async () => {
     await renderLoaded();
 
-    // Date bubble for Brooklyn Half: 17 / MAY
-    expect(screen.getByText('17')).toBeInTheDocument();
+    // Date bubble for Brooklyn Half: 17 / MAY (featured + memory card)
+    expect(screen.getAllByText('17').length).toBeGreaterThanOrEqual(1);
     expect(screen.getAllByText('MAY').length).toBeGreaterThanOrEqual(2); // May 17 + May 10
     expect(screen.getByText('JAN')).toBeInTheDocument(); // Jan 5
     expect(screen.getByText('APR')).toBeInTheDocument(); // Apr 1 (converted single group)
-    // Year row under the bubble
-    expect(screen.getAllByText('2025').length).toBeGreaterThanOrEqual(4);
-    // Unparseable date falls back to raw date text (no bubble)
-    expect(screen.getAllByText('not-a-date').length).toBeGreaterThanOrEqual(1);
-    // Time column rendered
-    expect(screen.getAllByText('7:00 am').length).toBeGreaterThanOrEqual(1);
+    // Date · time meta row
+    expect(screen.getAllByText('2025-05-17 · 7:00 am').length).toBeGreaterThanOrEqual(1);
+    // Unparseable date renders no bubble but still shows the raw date in the meta row
+    expect(screen.getAllByText(/not-a-date/).length).toBeGreaterThanOrEqual(1);
+    // Past events carry the MEMORY chip
+    expect(screen.getAllByText('MEMORY 回忆').length).toBeGreaterThanOrEqual(1);
+    // Standalone memory cards offer the outlined View Details CTA
+    const winterCard = screen.getByText('Winter Marathon').closest('[data-testid="event-card"]');
+    expect(
+      within(winterCard).getByRole('button', { name: 'View Details 查看详情' })
+    ).toBeInTheDocument();
   });
 
   test('renders multi-event group card and converts single-event groups to standalone', async () => {
@@ -432,14 +437,12 @@ describe('rendering', () => {
     expect(screen.getByText('Solo Group Event')).toBeInTheDocument();
   });
 
-  test('passes engagement data to standalone event cards', async () => {
+  test('renders engagement bars for standalone event cards', async () => {
     await renderLoaded();
-    // Event 1 is both featured and a memory card; both get engagement data
+    // Event 1 is both featured and a memory card; each EventCard renders an
+    // engagement bar (the bar fetches its own data via the API)
     const bars = screen.getAllByTestId('engagement-1');
-    expect(bars.length).toBeGreaterThanOrEqual(1);
-    bars.forEach((bar) =>
-      expect(bar.getAttribute('data-initial')).toContain('like_count')
-    );
+    expect(bars.length).toBeGreaterThanOrEqual(2);
   });
 
   test('renders nothing crashing when API returns empty payload and skips engagement fetch', async () => {
@@ -483,15 +486,11 @@ describe('rendering', () => {
     );
   });
 
-  test('image load errors swap in the fallback image', async () => {
+  test('image load errors swap in the shared fallback image', async () => {
     await renderLoaded();
     const img = screen.getAllByTestId('event-card-image')[0];
     fireEvent.error(img);
-    expect(img.src).toContain('/images/2025/20250517_bk_half.jpg');
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
-      'Image failed to load:',
-      expect.anything()
-    );
+    expect(img.src).toContain('/images/placeholder-event.jpg');
   });
 });
 
@@ -727,7 +726,6 @@ describe('admin gating', () => {
 
     expect(screen.getByRole('button', { name: /Add Event/ })).toBeInTheDocument();
     expect(screen.getAllByTestId('DragIndicatorIcon').length).toBeGreaterThan(0);
-    expect(screen.getAllByText('Hold to drag').length).toBeGreaterThan(0);
     expect(screen.getAllByTestId('MoreVertIcon').length).toBeGreaterThan(0);
     expect(
       screen.getByText('Long press the drag handle to move events')
@@ -741,10 +739,9 @@ describe('admin gating', () => {
     expect(screen.getByTestId('event-group-card')).toHaveAttribute('data-admin', 'true');
 
     // Clicking a drag handle does not open the event detail modal
-    // (stopPropagation on both the mobile chip handle and the desktop handle)
+    // (EventCard stops propagation from the whole admin-actions cluster)
     const icons = screen.getAllByTestId('DragIndicatorIcon');
     icons.forEach((icon) => fireEvent.click(icon));
-    fireEvent.click(screen.getAllByText('Hold to drag')[0]);
     expect(screen.queryByTestId('event-detail-modal')).not.toBeInTheDocument();
   });
 

--- a/ProjectCode/client/src/pages/HomePage.js
+++ b/ProjectCode/client/src/pages/HomePage.js
@@ -47,11 +47,8 @@ import { updateBanner } from '../api/banners';
 import { getActiveSections, updateSection, reorderSections, uploadImage } from '../api/homepageSections';
 import ImagePositionEditor from '../components/ImagePositionEditor';
 import { updateEvent, getEventsByStatus } from '../api';
-
-const ORANGE = '#FFA500';
-const ORANGE_BG = '#FFF6E8';
-const LINE = '#EEE7DC';
-const MUTED = '#757575';
+import { ORANGE, ORANGE_BG, LINE, MUTED } from '../theme/tokens';
+import { parseBubbleDate as parseEventDate } from '../helpers/eventDate';
 
 // Fallback carousel images if API fails
 const fallbackCarouselImages = [
@@ -85,16 +82,6 @@ const fallbackSections = [
   // Training With Us ('/training') hidden for now — restore an entry here (and
   // reactivate the DB section in admin mode) to bring it back
 ];
-
-const MONTHS = ['JAN', 'FEB', 'MAR', 'APR', 'MAY', 'JUN', 'JUL', 'AUG', 'SEP', 'OCT', 'NOV', 'DEC'];
-
-// Parse a banner's event_date (YYYY-MM-DD) into { day, month } for the date bubble
-function parseEventDate(dateStr) {
-  if (!dateStr) return null;
-  const d = new Date(`${dateStr}T00:00:00`);
-  if (isNaN(d.getTime())) return null;
-  return { day: d.getDate(), month: MONTHS[d.getMonth()] };
-}
 
 // Sortable Section Card — featured grid card with title overlaid on the image.
 // The first two sections render as large (span-2) cards.

--- a/ProjectCode/client/src/theme/tokens.js
+++ b/ProjectCode/client/src/theme/tokens.js
@@ -1,0 +1,24 @@
+// Shared design tokens for the 2F redesign. Import these instead of
+// redeclaring per-file constants — EventCard, CalendarPage, HomePage,
+// HighlightsPage and EventGroupCard must all stay on the same palette.
+
+export const ORANGE = '#FFA500';
+export const ORANGE_DARK = '#F29400';
+export const ORANGE_BG = '#FFF6E8';
+export const LINE = '#EEE7DC';
+export const INK = '#212121';
+export const MUTED = '#757575';
+
+// Chip palettes for event status/type badges
+export const GREEN = '#2e7d32';
+export const GREEN_BG = '#e8f5e9';
+export const RED = '#c62828';
+export const RED_BG = '#ffebee';
+export const BLUE = '#1565c0';
+export const BLUE_BG = '#e3f2fd';
+
+export const FALLBACK_EVENT_IMAGE = '/images/placeholder-event.jpg';
+
+// Card shell shared by every event surface
+export const CARD_SHADOW = '0 2px 4px rgba(0,0,0,0.08)';
+export const CARD_HOVER_SHADOW = '0 8px 24px rgba(255,165,0,0.35)';

--- a/design-mockups/events-a-consolidated.html
+++ b/design-mockups/events-a-consolidated.html
@@ -1,0 +1,261 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Events A — Consolidated (one card, three variants) · NewBee Running Club</title>
+<link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;600;700;900&family=Noto+Sans+SC:wght@400;500;700&display=swap" rel="stylesheet">
+<style>
+  /* PROPOSAL A: keep today's visual language, but ONE EventCard component
+     (variant: featured | row | group) + one shared token file + one editor.
+     Fixes folded in: featured cards get date/time/location, every CTA works,
+     group card uses the real orange tokens + bilingual label. */
+  :root{
+    --orange:#FFA500; --orange-dark:#F29400; --orange-bg:#FFF6E8;
+    --ink:#212121; --muted:#757575; --line:#EEE7DC;
+  }
+  *{margin:0;padding:0;box-sizing:border-box}
+  body{font-family:Roboto,'Noto Sans SC',sans-serif;background:#FFFDFA;color:var(--ink)}
+  a{text-decoration:none;color:inherit}
+  .container{max-width:1180px;margin:0 auto;padding:0 16px}
+
+  .explain{background:var(--orange-bg);border-bottom:1px solid var(--line);padding:14px 0}
+  .explain b{font-size:14px}
+  .explain p{font-size:12.5px;color:var(--muted);margin-top:3px}
+
+  .sechead{display:flex;align-items:baseline;gap:10px;margin:34px 2px 14px}
+  .sechead h2{font-size:20px;font-weight:700}
+  .sechead span{font-size:14px;color:var(--muted);font-family:'Noto Sans SC'}
+  .sechead .addbtn{margin-left:auto;background:var(--orange);color:#fff;font-weight:600;font-size:13px;
+      padding:9px 20px;border-radius:99px;box-shadow:0 2px 6px rgba(255,165,0,.3);cursor:pointer;border:none}
+  .sechead .addbtn:hover{background:var(--orange-dark)}
+
+  /* ---- the ONE card: shared shell ---- */
+  .ecard{background:#fff;border:1px solid var(--line);border-radius:12px;overflow:hidden;cursor:pointer;
+      box-shadow:0 2px 4px rgba(0,0,0,.08);transition:all .2s;position:relative}
+  .ecard:hover{transform:translateY(-3px);box-shadow:0 8px 24px rgba(255,165,0,.35)}
+
+  .pill{display:inline-block;background:var(--orange);color:#fff;font-weight:600;font-size:14px;
+      padding:10px 22px;border-radius:99px;border:none;cursor:pointer;text-align:center;transition:all .15s}
+  .pill:hover{background:var(--orange-dark)}
+  .pill:active{transform:scale(.98)}
+  .pill small{font-family:'Noto Sans SC';font-weight:500;margin-left:6px}
+
+  .bubble{width:46px;height:46px;border-radius:12px;background:var(--orange-bg);flex-shrink:0;
+      display:flex;flex-direction:column;align-items:center;justify-content:center}
+  .bubble b{font-size:16px;color:var(--orange);line-height:1.1}
+  .bubble span{font-size:9.5px;font-weight:700;letter-spacing:.1em;color:var(--muted)}
+
+  .meta{display:flex;flex-wrap:wrap;gap:6px 16px;font-size:12.5px;color:var(--muted)}
+  .meta i{font-style:normal;color:var(--orange);margin-right:4px}
+
+  /* variant: featured (vertical, image top) */
+  .fgrid{display:grid;grid-template-columns:repeat(3,1fr);gap:20px}
+  .ecard.featured{display:flex;flex-direction:column}
+  .ecard.featured .img{height:190px;position:relative}
+  .ecard.featured .img img{width:100%;height:100%;object-fit:cover;display:block}
+  .ecard.featured .body{padding:16px;display:flex;flex-direction:column;flex:1;gap:8px}
+  .ecard.featured h3{font-size:17px;font-weight:600;line-height:1.3}
+  .ecard.featured h3 small{display:block;font-size:13px;color:var(--muted);font-weight:400;font-family:'Noto Sans SC';margin-top:2px}
+  .ecard.featured p{font-size:13px;color:var(--muted);line-height:1.5;
+      display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden}
+  .ecard.featured .pill{margin-top:auto;width:100%}
+
+  /* variant: row (horizontal) */
+  .rowlist{display:flex;flex-direction:column;gap:20px}
+  .ecard.row{display:flex;min-height:180px}
+  .ecard.row .datecol{width:112px;flex-shrink:0;border-right:1px solid var(--line);
+      display:flex;flex-direction:column;align-items:center;justify-content:center;gap:6px;padding:16px 8px}
+  .ecard.row .datecol .time{font-size:12.5px;font-weight:600;color:var(--orange)}
+  .ecard.row .img{width:200px;flex-shrink:0}
+  .ecard.row .img img{width:100%;height:100%;object-fit:cover;display:block}
+  .ecard.row .body{flex:1;padding:16px 18px;display:flex;flex-direction:column;gap:8px;position:relative}
+  .ecard.row h3{font-size:17px;font-weight:600}
+  .ecard.row h3 small{font-size:13px;color:var(--muted);font-weight:400;font-family:'Noto Sans SC';margin-left:8px}
+  .ecard.row .pill{align-self:flex-start;margin-top:auto}
+
+  /* variant: group (row + stack effect) — now uses the SAME tokens & pill */
+  .groupwrap{position:relative;margin-top:26px}
+  .groupwrap::before,.groupwrap::after{content:'';position:absolute;left:8px;right:8px;height:100%;
+      border:1px solid var(--line);border-radius:12px;background:#fff;z-index:0}
+  .groupwrap::before{top:-5px;left:4px;right:4px;background:#f7f3ec}
+  .groupwrap::after{top:-10px;background:#efe9df}
+  .groupwrap .ecard{z-index:1}
+  .folder{display:inline-flex;align-items:center;gap:6px;background:var(--orange-bg);color:var(--orange);
+      font-size:12px;font-weight:700;padding:5px 12px;border-radius:99px}
+
+  .share{position:absolute;top:10px;right:10px;width:32px;height:32px;border-radius:50%;
+      background:rgba(255,255,255,.92);display:grid;place-items:center;font-size:14px;color:var(--muted);z-index:2}
+  .share:hover{color:var(--orange)}
+  .adminrow{position:absolute;top:10px;right:48px;display:flex;gap:6px;z-index:2}
+  .adminrow i{width:32px;height:32px;border-radius:50%;background:rgba(255,255,255,.92);
+      display:grid;place-items:center;font-size:14px;font-style:normal;color:var(--muted)}
+  .adminrow i:hover{color:var(--orange)}
+
+  /* ---- unified editor dialog (the ONE form, superset of all three) ---- */
+  .dlgdemo{margin:44px 0 60px}
+  .dialog{max-width:720px;margin:0 auto;background:#fff;border-radius:14px;border:1px solid var(--line);
+      box-shadow:0 18px 50px rgba(0,0,0,.18);overflow:hidden}
+  .dialog .dhead{padding:18px 24px;border-bottom:1px solid var(--line);display:flex;align-items:baseline;gap:10px}
+  .dialog .dhead h3{font-size:17px;font-weight:700}
+  .dialog .dhead span{font-size:13px;color:var(--muted);font-family:'Noto Sans SC'}
+  .dialog .dbody{padding:20px 24px;display:grid;grid-template-columns:1fr 1fr;gap:14px 16px}
+  .fld{display:flex;flex-direction:column;gap:5px}
+  .fld.full{grid-column:span 2}
+  .fld label{font-size:11.5px;font-weight:600;color:var(--muted);letter-spacing:.03em}
+  .fld label em{color:#d32f2f;font-style:normal}
+  .fld input,.fld select,.fld textarea{font:inherit;font-size:13.5px;padding:9px 12px;border:1px solid #d9d2c6;
+      border-radius:8px;background:#fff;color:var(--ink)}
+  .fld input:focus,.fld textarea:focus{outline:2px solid var(--orange);border-color:transparent}
+  .fld .hint{font-size:11px;color:var(--muted)}
+  .fset{grid-column:span 2;border:1px solid var(--line);border-radius:10px;padding:14px 16px;margin-top:4px}
+  .fset legend{font-size:12px;font-weight:700;color:var(--muted);padding:0 6px}
+  .fset .inner{display:flex;flex-wrap:wrap;gap:10px;align-items:center;margin-top:8px}
+  .daychip{font-size:12px;font-weight:600;padding:6px 12px;border-radius:99px;border:1px solid var(--line);color:var(--muted);cursor:pointer}
+  .daychip.on{background:var(--orange);border-color:var(--orange);color:#fff}
+  .upload{grid-column:span 2;border:1.5px dashed #d9d2c6;border-radius:10px;padding:18px;text-align:center;
+      color:var(--muted);font-size:13px;background:#fffdf8}
+  .upload b{color:var(--orange)}
+  .dfoot{padding:16px 24px;border-top:1px solid var(--line);display:flex;justify-content:flex-end;gap:10px}
+  .ghost{background:#fff;border:1px solid var(--line);color:var(--muted);font-weight:600;font-size:13px;
+      padding:9px 20px;border-radius:99px;cursor:pointer}
+  .note{max-width:720px;margin:10px auto 0;font-size:12px;color:var(--muted);text-align:center}
+
+  @media(max-width:860px){
+    .fgrid{grid-template-columns:1fr}
+    .ecard.row{flex-direction:column;min-height:0}
+    .ecard.row .datecol{display:none}
+    .ecard.row .img{width:100%;height:150px}
+    .dialog .dbody{grid-template-columns:1fr}
+    .fld.full,.fset,.upload{grid-column:span 1}
+  }
+</style>
+</head>
+<body>
+
+<div class="explain">
+  <div class="container">
+    <b>Proposal A — Consolidated · 统一现有样式</b>
+    <p>Same visual language as today, but one &lt;EventCard variant="featured|row|group"&gt; everywhere, shared tokens, and one editor dialog replacing the three divergent forms. Featured cards gain date/time/location; every CTA is clickable; the group card joins the token system.</p>
+  </div>
+</div>
+
+<div class="container">
+
+  <div class="sechead"><h2>Upcoming Events</h2><span>近期活动</span><button class="addbtn">+ Add Event 添加活动</button></div>
+
+  <div class="fgrid">
+    <div class="ecard featured">
+      <div class="img">
+        <img src="../ProjectCode/client/public/images/2025/20250727_team_champ.jpg" alt="">
+        <span class="share">⤴</span>
+        <span class="adminrow"><i>✎</i><i>🗑</i></span>
+      </div>
+      <div class="body">
+        <h3>Team Championship<small>团队锦标赛</small></h3>
+        <div class="meta"><span><i>⏰</i>Jul 27 · 7:30 AM</span><span><i>📍</i>Central Park</span></div>
+        <p>Race with the NewBee squad at the NYRR Team Championships — 5 miles, club scoring, post-race picnic.</p>
+        <button class="pill">Sign Up<small>报名</small></button>
+      </div>
+    </div>
+    <div class="ecard featured">
+      <div class="img">
+        <img src="../ProjectCode/client/public/images/2025/20250620_queens_10k.jpg" alt="">
+        <span class="share">⤴</span>
+      </div>
+      <div class="body">
+        <h3>Saturday Long Run<small>周六长跑</small></h3>
+        <div class="meta"><span><i>⏰</i>Jul 19 · 8:00 AM</span><span><i>📍</i>Central Park, Engineers' Gate</span></div>
+        <p>Weekly long run, 10–16 miles with paced groups. All levels welcome — bagels after.</p>
+        <button class="pill">View Details<small>查看详情</small></button>
+      </div>
+    </div>
+    <div class="ecard featured">
+      <div class="img">
+        <img src="../ProjectCode/client/public/images/2025/20250604_9th_anniversary_run.jpg" alt="">
+        <span class="share">⤴</span>
+      </div>
+      <div class="body">
+        <h3>Track Tuesday<small>周二田径场训练</small></h3>
+        <div class="meta"><span><i>⏰</i>Jul 15 · 6:30 PM</span><span><i>📍</i>East River Track</span></div>
+        <p>Coached interval session — 8×400m this week. Meet at the north gate.</p>
+        <button class="pill">View Details<small>查看详情</small></button>
+      </div>
+    </div>
+  </div>
+
+  <div class="sechead"><h2>All Upcoming</h2><span>全部活动</span></div>
+
+  <div class="rowlist">
+    <div class="ecard row">
+      <div class="datecol"><div class="bubble"><b>15</b><span>JUL</span></div><div class="time">6:30 PM</div></div>
+      <div class="img"><img src="../ProjectCode/client/public/images/2025/20250604_9th_anniversary_run.jpg" alt=""></div>
+      <div class="body">
+        <span class="share">⤴</span>
+        <h3>Track Tuesday<small>周二田径场训练</small></h3>
+        <div class="meta"><span><i>📍</i>East River Track 东河田径场</span></div>
+        <button class="pill">View Details<small>查看详情</small></button>
+      </div>
+    </div>
+    <div class="ecard row">
+      <div class="datecol"><div class="bubble"><b>27</b><span>JUL</span></div><div class="time">7:30 AM</div></div>
+      <div class="img"><img src="../ProjectCode/client/public/images/2025/20250727_team_champ.jpg" alt=""></div>
+      <div class="body">
+        <span class="share">⤴</span>
+        <h3>Team Championship<small>团队锦标赛</small></h3>
+        <div class="meta"><span><i>📍</i>Central Park 中央公园</span></div>
+        <button class="pill">Sign Up<small>报名</small></button>
+      </div>
+    </div>
+
+    <div class="groupwrap">
+      <div class="ecard row">
+        <div class="datecol">
+          <span class="folder">🗂 6 events</span>
+          <div class="meta" style="justify-content:center"><span>May 2024 – present</span></div>
+        </div>
+        <div class="img"><img src="../ProjectCode/client/public/images/2025/20250517_bk_half.jpg" alt=""></div>
+        <div class="body">
+          <span class="share">⤴</span>
+          <h3>Brooklyn Half Series<small>布鲁克林半马系列</small></h3>
+          <div class="meta"><span>6 events from 2024 to 2026</span></div>
+          <button class="pill">View All 6 Events<small>查看全部</small></button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- the ONE editor -->
+  <div class="dlgdemo">
+    <div class="sechead"><h2>One editor, three doors</h2><span>统一编辑表单</span></div>
+    <div class="dialog">
+      <div class="dhead"><h3>Add Event</h3><span>添加活动</span></div>
+      <div class="dbody">
+        <div class="fld"><label>EVENT NAME <em>*</em></label><input value="Saturday Long Run"></div>
+        <div class="fld"><label>中文名称</label><input value="周六长跑"><span class="hint">Press Tab to auto-fill 按 Tab 自动翻译</span></div>
+        <div class="fld"><label>DATE <em>*</em></label><input type="date" value="2026-07-19"></div>
+        <div class="fld"><label>TIME</label><input type="time" value="08:00"><span class="hint">Time picker — no more free-text "e.g. 8:00 AM"</span></div>
+        <div class="fld"><label>LOCATION</label><input value="Central Park, Engineers' Gate"></div>
+        <div class="fld"><label>中文地点</label><input value="中央公园"></div>
+        <div class="fld full"><label>DESCRIPTION</label><textarea rows="2">Weekly long run, 10–16 miles with paced groups.</textarea></div>
+        <div class="upload">📷 <b>Upload image</b> or drag &amp; drop — uploads immediately with progress (not deferred to Save)</div>
+        <div class="fld"><label>SIGNUP LINK</label><input placeholder="https://…"></div>
+        <div class="fld"><label>EVENT TYPE</label><select><option>Standard</option><option>Heylo</option><option>Race</option></select></div>
+        <div class="fld"><label>STATUS</label><select><option>Upcoming</option><option>Past</option><option>Cancelled</option></select></div>
+        <div class="fld"><label>WECHAT QR</label><input placeholder="Upload QR image…"><span class="hint">Now part of the same form, not a separate mini-dialog</span></div>
+        <fieldset class="fset"><legend>REPEATS · 重复</legend>
+          <div class="inner">
+            <select><option>Weekly</option><option>Biweekly</option><option>Monthly</option><option>Yearly</option></select>
+            <span class="daychip">Mon</span><span class="daychip on">Sat</span><span class="daychip">Sun</span>
+            <span class="hint">"Custom" option removed — it rendered no UI</span>
+          </div>
+        </fieldset>
+      </div>
+      <div class="dfoot"><button class="ghost">Cancel 取消</button><button class="pill">Save Event 保存</button></div>
+    </div>
+    <p class="note">This single dialog is mounted from CalendarPage, AdminPanel, and EventDetailModal — replacing three forms that each had different fields and different null-handling.</p>
+  </div>
+
+</div>
+</body>
+</html>

--- a/design-mockups/events-b-unified-card-composer.html
+++ b/design-mockups/events-b-unified-card-composer.html
@@ -1,0 +1,283 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Events B — Unified Card + Staged Composer (recommended) · NewBee Running Club</title>
+<link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;600;700;900&family=Noto+Sans+SC:wght@400;500;700&display=swap" rel="stylesheet">
+<style>
+  /* PROPOSAL B (recommended): one redesigned card with a real information
+     hierarchy — status/type chips, date+time+location always visible,
+     engagement bar on every card, context-aware CTA — plus a 3-step
+     composer with live card preview replacing the 15-field wall. */
+  :root{
+    --orange:#FFA500; --orange-dark:#F29400; --orange-bg:#FFF6E8;
+    --ink:#212121; --muted:#757575; --line:#EEE7DC;
+    --green:#2e7d32; --green-bg:#e8f5e9; --red:#c62828; --red-bg:#ffebee;
+    --blue:#1565c0; --blue-bg:#e3f2fd;
+  }
+  *{margin:0;padding:0;box-sizing:border-box}
+  body{font-family:Roboto,'Noto Sans SC',sans-serif;background:#FFFDFA;color:var(--ink)}
+  a{text-decoration:none;color:inherit}
+  .container{max-width:1180px;margin:0 auto;padding:0 16px}
+
+  .explain{background:var(--orange-bg);border-bottom:1px solid var(--line);padding:14px 0}
+  .explain b{font-size:14px}
+  .explain p{font-size:12.5px;color:var(--muted);margin-top:3px}
+
+  .sechead{display:flex;align-items:baseline;gap:10px;margin:34px 2px 14px}
+  .sechead h2{font-size:20px;font-weight:700}
+  .sechead span{font-size:14px;color:var(--muted);font-family:'Noto Sans SC'}
+  .sechead .addbtn{margin-left:auto;background:var(--orange);color:#fff;font-weight:600;font-size:13px;
+      padding:9px 20px;border-radius:99px;box-shadow:0 2px 6px rgba(255,165,0,.3);cursor:pointer;border:none}
+
+  /* ---- chips ---- */
+  .chip{display:inline-flex;align-items:center;gap:4px;font-size:11px;font-weight:700;
+      padding:3px 10px;border-radius:99px;letter-spacing:.02em}
+  .chip.upcoming{background:var(--green-bg);color:var(--green)}
+  .chip.race{background:var(--blue-bg);color:var(--blue)}
+  .chip.repeat{background:var(--orange-bg);color:var(--orange)}
+  .chip.cancelled{background:var(--red-bg);color:var(--red)}
+  .chip.past{background:#f0ede7;color:var(--muted)}
+
+  /* ---- the unified card ---- */
+  .ecard{background:#fff;border:1px solid var(--line);border-radius:12px;overflow:hidden;cursor:pointer;
+      box-shadow:0 2px 4px rgba(0,0,0,.08);transition:all .2s;position:relative;display:flex}
+  .ecard:hover{transform:translateY(-3px);box-shadow:0 8px 24px rgba(255,165,0,.35)}
+  .ecard.cancelled-card{opacity:.75}
+  .ecard .img{position:relative;flex-shrink:0}
+  .ecard .img img{width:100%;height:100%;object-fit:cover;display:block}
+  .ecard .img .bubble{position:absolute;left:10px;bottom:10px;width:48px;height:48px;border-radius:12px;
+      background:rgba(255,255,255,.95);box-shadow:0 2px 6px rgba(0,0,0,.18);
+      display:flex;flex-direction:column;align-items:center;justify-content:center}
+  .ecard .img .bubble b{font-size:17px;color:var(--orange);line-height:1.1}
+  .ecard .img .bubble span{font-size:9.5px;font-weight:700;letter-spacing:.1em;color:var(--muted)}
+  .ecard .body{padding:14px 16px;display:flex;flex-direction:column;gap:8px;flex:1;min-width:0}
+  .ecard .chiprow{display:flex;gap:6px;align-items:center}
+  .ecard .chiprow .icons{margin-left:auto;display:flex;gap:4px}
+  .ecard .chiprow .icons i{width:28px;height:28px;border-radius:50%;display:grid;place-items:center;
+      font-size:13px;font-style:normal;color:var(--muted)}
+  .ecard .chiprow .icons i:hover{background:var(--orange-bg);color:var(--orange)}
+  .ecard h3{font-size:16.5px;font-weight:600;line-height:1.3;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+  .ecard h3 small{font-size:13px;color:var(--muted);font-weight:400;font-family:'Noto Sans SC';margin-left:8px}
+  .meta{display:flex;flex-wrap:wrap;gap:4px 16px;font-size:12.5px;color:var(--muted)}
+  .meta i{font-style:normal;color:var(--orange);margin-right:4px}
+  .engage{display:flex;align-items:center;gap:14px;font-size:12.5px;color:var(--muted);margin-top:auto}
+  .engage .thumbs{display:flex;align-items:center;margin-left:auto}
+  .engage .thumbs img{width:26px;height:26px;border-radius:6px;object-fit:cover;border:2px solid #fff;margin-left:-8px}
+  .engage .thumbs img:first-child{margin-left:0}
+  .engage .thumbs .more{width:26px;height:26px;border-radius:6px;background:#f0ede7;color:var(--muted);
+      font-size:9.5px;font-weight:700;display:grid;place-items:center;margin-left:-8px;border:2px solid #fff}
+  .cta{display:flex;gap:10px;align-items:center;margin-top:2px}
+  .pill{display:inline-block;background:var(--orange);color:#fff;font-weight:600;font-size:13.5px;
+      padding:9px 22px;border-radius:99px;border:none;cursor:pointer;transition:all .15s}
+  .pill:hover{background:var(--orange-dark)}
+  .pill:active{transform:scale(.98)}
+  .pill.ghost{background:#fff;border:1.5px solid var(--orange);color:var(--orange)}
+  .pill.ghost:hover{background:var(--orange);color:#fff}
+  .pill small{font-family:'Noto Sans SC';font-weight:500;margin-left:6px}
+
+  /* grid density */
+  .fgrid{display:grid;grid-template-columns:repeat(3,1fr);gap:20px}
+  .fgrid .ecard{flex-direction:column}
+  .fgrid .ecard .img{height:180px}
+  /* row density */
+  .rowlist{display:flex;flex-direction:column;gap:18px;margin-bottom:8px}
+  .rowlist .ecard .img{width:220px}
+  .rowlist .ecard{min-height:172px}
+
+  /* ---- composer ---- */
+  .dlgdemo{margin:46px 0 64px}
+  .composer{max-width:1020px;margin:0 auto;background:#fff;border-radius:14px;border:1px solid var(--line);
+      box-shadow:0 18px 50px rgba(0,0,0,.18);overflow:hidden;display:grid;grid-template-columns:1.25fr 1fr}
+  .cform{padding:22px 26px;border-right:1px solid var(--line)}
+  .steps{display:flex;align-items:center;gap:8px;margin-bottom:20px}
+  .step{display:flex;align-items:center;gap:8px;font-size:12.5px;font-weight:600;color:var(--muted)}
+  .step .n{width:24px;height:24px;border-radius:50%;background:#f0ede7;display:grid;place-items:center;font-size:12px}
+  .step.done .n{background:var(--green-bg);color:var(--green)}
+  .step.on{color:var(--ink)}
+  .step.on .n{background:var(--orange);color:#fff}
+  .steps .bar{flex:1;height:2px;background:var(--line)}
+  .cform h3{font-size:16px;font-weight:700;margin-bottom:2px}
+  .cform .sub{font-size:12px;color:var(--muted);margin-bottom:16px}
+  .fgrid2{display:grid;grid-template-columns:1fr 1fr;gap:13px 14px}
+  .fld{display:flex;flex-direction:column;gap:5px}
+  .fld.full{grid-column:span 2}
+  .fld label{font-size:11.5px;font-weight:600;color:var(--muted);letter-spacing:.03em}
+  .fld label em{color:#d32f2f;font-style:normal}
+  .fld input,.fld select,.fld textarea{font:inherit;font-size:13.5px;padding:9px 12px;border:1px solid #d9d2c6;
+      border-radius:8px;background:#fff;color:var(--ink)}
+  .fld input:focus{outline:2px solid var(--orange);border-color:transparent}
+  .fld .hint{font-size:11px;color:var(--muted)}
+  .fld .err{font-size:11px;color:#d32f2f}
+  .fld input.bad{border-color:#d32f2f}
+  .upload{grid-column:span 2;border:1.5px dashed #d9d2c6;border-radius:10px;padding:14px;
+      color:var(--muted);font-size:12.5px;background:#fffdf8;display:flex;align-items:center;gap:12px}
+  .upload .prog{flex:1;height:6px;border-radius:3px;background:#f0ede7;overflow:hidden}
+  .upload .prog i{display:block;height:100%;width:72%;background:var(--orange)}
+  .cfoot{display:flex;justify-content:space-between;margin-top:20px}
+  .ghostbtn{background:#fff;border:1px solid var(--line);color:var(--muted);font-weight:600;font-size:13px;
+      padding:9px 20px;border-radius:99px;cursor:pointer}
+
+  .cpreview{padding:22px;background:#FFFDFA;display:flex;flex-direction:column}
+  .cpreview .cap{font-size:11.5px;font-weight:700;color:var(--muted);letter-spacing:.06em;margin-bottom:12px}
+  .cpreview .cap span{font-family:'Noto Sans SC';font-weight:500;margin-left:6px}
+  .cpreview .ecard{cursor:default}
+  .cpreview .ecard:hover{transform:none;box-shadow:0 2px 4px rgba(0,0,0,.08)}
+  .cpreview .devnote{margin-top:auto;font-size:11.5px;color:var(--muted);line-height:1.55;padding-top:16px}
+
+  .note{max-width:1020px;margin:10px auto 0;font-size:12px;color:var(--muted);text-align:center}
+
+  @media(max-width:900px){
+    .fgrid{grid-template-columns:1fr}
+    .rowlist .ecard{flex-direction:column}
+    .rowlist .ecard .img{width:100%;height:150px}
+    .composer{grid-template-columns:1fr}
+    .cform{border-right:none;border-bottom:1px solid var(--line)}
+  }
+</style>
+</head>
+<body>
+
+<div class="explain">
+  <div class="container">
+    <b>Proposal B — Unified Card + Staged Composer (recommended) · 统一卡片 + 分步创建</b>
+    <p>One card everywhere with a real hierarchy: status/type chips, date bubble on the image, time &amp; location always visible, engagement on every card, and a CTA that matches the event (Sign Up when a signup link exists, View Details otherwise, nothing decorative). Creation becomes a 3-step composer with live preview.</p>
+  </div>
+</div>
+
+<div class="container">
+
+  <div class="sechead"><h2>Upcoming Events</h2><span>近期活动</span><button class="addbtn">+ Add Event 添加活动</button></div>
+
+  <div class="fgrid">
+    <div class="ecard">
+      <div class="img">
+        <img src="../ProjectCode/client/public/images/2025/20250727_team_champ.jpg" alt="">
+        <div class="bubble"><b>27</b><span>JUL</span></div>
+      </div>
+      <div class="body">
+        <div class="chiprow">
+          <span class="chip upcoming">UPCOMING</span><span class="chip race">RACE</span>
+          <span class="icons"><i>⤴</i><i>✎</i></span>
+        </div>
+        <h3>Team Championship <small>团队锦标赛</small></h3>
+        <div class="meta"><span><i>⏰</i>Sat 7:30 AM</span><span><i>📍</i>Central Park</span></div>
+        <div class="engage">
+          <span>♥ 12</span><span>💬 4</span>
+          <span class="thumbs">
+            <img src="../ProjectCode/client/public/images/2025/20250727_team_champ.jpg"><img src="../ProjectCode/client/public/images/2025/20250620_queens_10k.jpg"><span class="more">+6</span>
+          </span>
+        </div>
+        <div class="cta"><button class="pill" style="width:100%">Sign Up<small>报名</small></button></div>
+      </div>
+    </div>
+
+    <div class="ecard">
+      <div class="img">
+        <img src="../ProjectCode/client/public/images/2025/20250620_queens_10k.jpg" alt="">
+        <div class="bubble"><b>19</b><span>JUL</span></div>
+      </div>
+      <div class="body">
+        <div class="chiprow">
+          <span class="chip upcoming">UPCOMING</span><span class="chip repeat">⟳ WEEKLY</span>
+          <span class="icons"><i>⤴</i></span>
+        </div>
+        <h3>Saturday Long Run <small>周六长跑</small></h3>
+        <div class="meta"><span><i>⏰</i>Sat 8:00 AM</span><span><i>📍</i>Engineers' Gate</span></div>
+        <div class="engage"><span>♥ 31</span><span>💬 9</span></div>
+        <div class="cta"><button class="pill ghost" style="width:100%">View Details<small>查看详情</small></button></div>
+      </div>
+    </div>
+
+    <div class="ecard cancelled-card">
+      <div class="img">
+        <img src="../ProjectCode/client/public/images/2025/20250604_9th_anniversary_run.jpg" alt="" style="filter:grayscale(.6)">
+        <div class="bubble"><b>15</b><span>JUL</span></div>
+      </div>
+      <div class="body">
+        <div class="chiprow">
+          <span class="chip cancelled">CANCELLED 已取消</span>
+          <span class="icons"><i>⤴</i></span>
+        </div>
+        <h3 style="text-decoration:line-through;color:var(--muted)">Track Tuesday <small>周二训练</small></h3>
+        <div class="meta"><span><i>⏰</i>Tue 6:30 PM</span><span><i>📍</i>East River Track</span></div>
+        <div class="engage"><span style="color:var(--red)">Cancelled due to heat advisory 因高温取消</span></div>
+        <div class="cta"><button class="pill ghost" style="width:100%;opacity:.6">View Details<small>查看详情</small></button></div>
+      </div>
+    </div>
+  </div>
+
+  <div class="sechead"><h2>All Upcoming</h2><span>全部活动</span></div>
+
+  <div class="rowlist">
+    <div class="ecard">
+      <div class="img">
+        <img src="../ProjectCode/client/public/images/2025/20250517_bk_half.jpg" alt="">
+        <div class="bubble"><b>02</b><span>AUG</span></div>
+      </div>
+      <div class="body">
+        <div class="chiprow">
+          <span class="chip upcoming">UPCOMING</span><span class="chip race">RACE</span><span class="chip repeat">⟳ YEARLY</span>
+          <span class="icons"><i>⤴</i><i>✎</i><i>⧉</i></span>
+        </div>
+        <h3>Bronx 10-Mile Team Outing <small>布朗克斯十英里</small></h3>
+        <div class="meta"><span><i>⏰</i>Sun 8:00 AM</span><span><i>📍</i>Van Cortlandt Park 范科特兰公园</span></div>
+        <div class="engage">
+          <span>♥ 18</span><span>💬 6</span>
+          <span class="thumbs"><img src="../ProjectCode/client/public/images/2025/20250503_bk_half_preview_run.jpg"><img src="../ProjectCode/client/public/images/2025/20250517_bk_half.jpg"><span class="more">+12</span></span>
+        </div>
+        <div class="cta"><button class="pill">Sign Up<small>报名</small></button><button class="pill ghost">Details<small>详情</small></button></div>
+      </div>
+    </div>
+  </div>
+  <p style="font-size:12px;color:var(--muted);margin:0 2px">Admin icons on hover: ✎ edit · ⧉ duplicate (fastest way to create next week's run) · same card component in both densities.</p>
+
+  <!-- composer -->
+  <div class="dlgdemo">
+    <div class="sechead"><h2>3-step composer with live preview</h2><span>分步创建 · 实时预览</span></div>
+
+    <div class="composer">
+      <div class="cform">
+        <div class="steps">
+          <span class="step done"><span class="n">✓</span>Basics 基本</span><span class="bar"></span>
+          <span class="step on"><span class="n">2</span>Details 详情</span><span class="bar"></span>
+          <span class="step"><span class="n">3</span>Publish 发布</span>
+        </div>
+        <h3>Details</h3>
+        <div class="sub">Everything here is optional — you can already save. 以下皆为选填，随时可保存。</div>
+        <div class="fgrid2">
+          <div class="fld full"><label>DESCRIPTION</label><textarea rows="2">Weekly long run, 10–16 miles with paced groups. Bagels after.</textarea></div>
+          <div class="fld full"><label>中文描述</label><textarea rows="2">每周长跑，10–16 英里，分组配速，跑后有贝果。</textarea></div>
+          <div class="upload">📷 <b>20250719_long_run.jpg</b><span class="prog"><i></i></span><span>72% — uploads now, not at Save</span></div>
+          <div class="fld"><label>SIGNUP LINK</label><input class="bad" value="htp:/heylo.group/newbee"><span class="err">Not a valid URL — inline validation, no snackbar 链接格式错误</span></div>
+          <div class="fld"><label>EVENT TYPE</label><select><option>Standard</option><option>Heylo</option><option selected>Race</option></select></div>
+          <div class="fld"><label>WECHAT QR 微信群二维码</label><input placeholder="Upload QR…"></div>
+          <div class="fld"><label>&nbsp;</label><span class="hint">Step 3 handles status, highlight &amp; recurrence, and shows this same preview one last time before publishing.</span></div>
+        </div>
+        <div class="cfoot"><button class="ghostbtn">← Back 上一步</button><button class="pill">Continue 下一步 →</button></div>
+      </div>
+
+      <div class="cpreview">
+        <div class="cap">LIVE PREVIEW — WHAT MEMBERS WILL SEE<span>会员所见预览</span></div>
+        <div class="ecard" style="flex-direction:column">
+          <div class="img" style="height:150px">
+            <img src="../ProjectCode/client/public/images/2025/20250620_queens_10k.jpg" alt="">
+            <div class="bubble"><b>19</b><span>JUL</span></div>
+          </div>
+          <div class="body">
+            <div class="chiprow"><span class="chip upcoming">UPCOMING</span><span class="chip race">RACE</span></div>
+            <h3>Saturday Long Run <small>周六长跑</small></h3>
+            <div class="meta"><span><i>⏰</i>Sat 8:00 AM</span><span><i>📍</i>Engineers' Gate</span></div>
+            <div class="cta"><button class="pill" style="width:100%">Sign Up<small>报名</small></button></div>
+          </div>
+        </div>
+        <div class="devnote">The preview renders the <b>actual EventCard component</b> with the form state — committee sees exactly what will appear on the Calendar page before saving. Fixes the "publish and check" loop.</div>
+      </div>
+    </div>
+    <p class="note">Step 1 (Basics) is just name / date / time / location — enough to save. One composer mounted from CalendarPage, AdminPanel and the detail modal; the three divergent editors are deleted.</p>
+  </div>
+
+</div>
+</body>
+</html>

--- a/design-mockups/events-c-calendar-first.html
+++ b/design-mockups/events-c-calendar-first.html
@@ -1,0 +1,275 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Events C — Calendar-First + Quick Create · NewBee Running Club</title>
+<link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;600;700;900&family=Noto+Sans+SC:wght@400;500;700&display=swap" rel="stylesheet">
+<style>
+  /* PROPOSAL C: the /calendar page becomes an actual calendar. Month grid
+     as the primary view, "This Week" card strip above it, committee
+     quick-create by clicking an empty day, recurring series shown as series. */
+  :root{
+    --orange:#FFA500; --orange-dark:#F29400; --orange-bg:#FFF6E8;
+    --ink:#212121; --muted:#757575; --line:#EEE7DC;
+    --green:#2e7d32; --green-bg:#e8f5e9; --blue:#1565c0; --blue-bg:#e3f2fd;
+  }
+  *{margin:0;padding:0;box-sizing:border-box}
+  body{font-family:Roboto,'Noto Sans SC',sans-serif;background:#FFFDFA;color:var(--ink)}
+  .container{max-width:1180px;margin:0 auto;padding:0 16px}
+
+  .explain{background:var(--orange-bg);border-bottom:1px solid var(--line);padding:14px 0}
+  .explain b{font-size:14px}
+  .explain p{font-size:12.5px;color:var(--muted);margin-top:3px}
+
+  .sechead{display:flex;align-items:baseline;gap:10px;margin:30px 2px 14px}
+  .sechead h2{font-size:20px;font-weight:700}
+  .sechead span{font-size:14px;color:var(--muted);font-family:'Noto Sans SC'}
+
+  /* this-week strip */
+  .strip{display:grid;grid-template-columns:repeat(3,1fr);gap:16px}
+  .ecard{background:#fff;border:1px solid var(--line);border-radius:12px;overflow:hidden;cursor:pointer;
+      box-shadow:0 2px 4px rgba(0,0,0,.08);transition:all .2s;display:flex;position:relative;min-height:118px}
+  .ecard:hover{transform:translateY(-3px);box-shadow:0 8px 24px rgba(255,165,0,.35)}
+  .ecard .img{width:118px;flex-shrink:0}
+  .ecard .img img{width:100%;height:100%;object-fit:cover;display:block}
+  .ecard .body{padding:12px 14px;display:flex;flex-direction:column;gap:5px;min-width:0}
+  .chip{display:inline-flex;align-items:center;gap:4px;font-size:10.5px;font-weight:700;padding:2px 9px;border-radius:99px}
+  .chip.upcoming{background:var(--green-bg);color:var(--green)}
+  .chip.race{background:var(--blue-bg);color:var(--blue)}
+  .chip.repeat{background:var(--orange-bg);color:var(--orange)}
+  .ecard h3{font-size:14.5px;font-weight:600;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+  .ecard h3 small{font-size:12px;color:var(--muted);font-weight:400;font-family:'Noto Sans SC';margin-left:6px}
+  .ecard .meta{font-size:12px;color:var(--muted)}
+  .ecard .meta i{font-style:normal;color:var(--orange);margin-right:3px}
+  .ecard .go{margin-top:auto;font-size:12.5px;font-weight:700;color:var(--orange)}
+
+  /* calendar */
+  .calhead{display:flex;align-items:center;gap:14px;margin:8px 2px 12px}
+  .calhead h2{font-size:22px;font-weight:800}
+  .calhead h2 span{font-size:14px;color:var(--muted);font-weight:400;font-family:'Noto Sans SC';margin-left:8px}
+  .calhead .nav{display:flex;gap:6px}
+  .calhead .nav button{width:32px;height:32px;border-radius:50%;border:1px solid var(--line);background:#fff;
+      cursor:pointer;font-size:14px;color:var(--muted)}
+  .calhead .nav button:hover{background:var(--orange-bg);color:var(--orange)}
+  .calhead .today{font-size:12.5px;font-weight:600;border:1px solid var(--line);background:#fff;
+      padding:7px 16px;border-radius:99px;cursor:pointer;color:var(--muted)}
+  .calhead .addbtn{margin-left:auto;background:var(--orange);color:#fff;font-weight:600;font-size:13px;
+      padding:9px 20px;border-radius:99px;border:none;cursor:pointer;box-shadow:0 2px 6px rgba(255,165,0,.3)}
+
+  .cal{background:#fff;border:1px solid var(--line);border-radius:14px;overflow:hidden;
+      box-shadow:0 2px 4px rgba(0,0,0,.05);margin-bottom:10px}
+  .cal .dow{display:grid;grid-template-columns:repeat(7,1fr);border-bottom:1px solid var(--line);background:#fffdf8}
+  .cal .dow div{padding:10px;font-size:11.5px;font-weight:700;color:var(--muted);letter-spacing:.05em;text-align:center}
+  .cal .dow div span{display:block;font-size:10.5px;font-weight:400;font-family:'Noto Sans SC'}
+  .cal .week{display:grid;grid-template-columns:repeat(7,1fr)}
+  .cal .day{min-height:104px;border-right:1px solid var(--line);border-bottom:1px solid var(--line);
+      padding:6px;position:relative;cursor:pointer;transition:background .12s}
+  .cal .day:nth-child(7n){border-right:none}
+  .cal .week:last-child .day{border-bottom:none}
+  .cal .day:hover{background:#fffaf1}
+  .cal .day .n{font-size:12px;font-weight:600;color:var(--muted);padding:2px 5px}
+  .cal .day.dim .n{color:#c9c2b6}
+  .cal .day.today .n{background:var(--orange);color:#fff;border-radius:99px;display:inline-block}
+  .ev{display:block;font-size:11px;font-weight:600;padding:3px 7px;border-radius:6px;margin-top:3px;
+      white-space:nowrap;overflow:hidden;text-overflow:ellipsis;cursor:pointer}
+  .ev.run{background:var(--orange-bg);color:var(--orange-dark)}
+  .ev.race{background:var(--blue-bg);color:var(--blue)}
+  .ev.social{background:var(--green-bg);color:var(--green)}
+  .ev .r{font-weight:800;margin-right:2px}
+  .cal .day .addghost{display:none;position:absolute;inset:auto 6px 6px 6px;text-align:center;
+      font-size:11px;font-weight:700;color:var(--orange);background:var(--orange-bg);
+      border:1px dashed var(--orange);border-radius:6px;padding:3px}
+  .cal .day:hover .addghost{display:block}
+
+  /* quick-create popover pinned to Jul 21 */
+  .daywrap{position:relative}
+  .qc{position:absolute;top:100%;left:50%;transform:translateX(-50%);margin-top:8px;width:280px;z-index:30;
+      background:#fff;border:1px solid var(--line);border-radius:12px;box-shadow:0 16px 40px rgba(0,0,0,.2);padding:16px}
+  .qc::before{content:'';position:absolute;top:-6px;left:50%;transform:translateX(-50%) rotate(45deg);
+      width:12px;height:12px;background:#fff;border-left:1px solid var(--line);border-top:1px solid var(--line)}
+  .qc h4{font-size:13px;font-weight:700;margin-bottom:2px}
+  .qc .d{font-size:11.5px;color:var(--muted);margin-bottom:10px}
+  .qc input{width:100%;font:inherit;font-size:13px;padding:8px 11px;border:1px solid #d9d2c6;border-radius:8px;margin-bottom:8px}
+  .qc input:focus{outline:2px solid var(--orange);border-color:transparent}
+  .qc .row2{display:flex;gap:8px}
+  .qc .row2 input{flex:1}
+  .qc .foot{display:flex;align-items:center;margin-top:4px}
+  .qc .more{font-size:11.5px;font-weight:600;color:var(--muted);cursor:pointer}
+  .qc .more:hover{color:var(--orange)}
+  .qc .save{margin-left:auto;background:var(--orange);color:#fff;font-weight:600;font-size:12.5px;
+      padding:7px 18px;border-radius:99px;border:none;cursor:pointer}
+
+  /* series edit prompt */
+  .seriesbox{max-width:460px;margin:26px auto 0;background:#fff;border:1px solid var(--line);border-radius:14px;
+      box-shadow:0 12px 36px rgba(0,0,0,.14);padding:20px 22px}
+  .seriesbox h4{font-size:14.5px;font-weight:700}
+  .seriesbox p{font-size:12.5px;color:var(--muted);margin:4px 0 14px;font-family:'Noto Sans SC'}
+  .seriesbox .opt{display:flex;align-items:center;gap:10px;border:1px solid var(--line);border-radius:10px;
+      padding:11px 14px;font-size:13px;font-weight:600;cursor:pointer;margin-bottom:8px}
+  .seriesbox .opt:hover{border-color:var(--orange);background:var(--orange-bg)}
+  .seriesbox .opt .dot{width:16px;height:16px;border-radius:50%;border:2px solid #d9d2c6}
+  .seriesbox .opt.on .dot{border-color:var(--orange);background:var(--orange);box-shadow:inset 0 0 0 3px #fff}
+  .seriesbox .opt small{display:block;font-size:11px;color:var(--muted);font-weight:400}
+
+  .legend{display:flex;gap:18px;font-size:12px;color:var(--muted);margin:6px 2px 40px;flex-wrap:wrap}
+  .legend i{display:inline-block;width:10px;height:10px;border-radius:3px;margin-right:5px;font-style:normal}
+  .legend .o{background:var(--orange-bg);border:1px solid var(--orange)}
+  .legend .b{background:var(--blue-bg);border:1px solid var(--blue)}
+  .legend .g{background:var(--green-bg);border:1px solid var(--green)}
+
+  .twocol{display:grid;grid-template-columns:1fr 1fr;gap:24px;margin-bottom:56px}
+  .twocol .cap{font-size:12px;font-weight:700;color:var(--muted);letter-spacing:.05em;margin-bottom:10px;text-align:center}
+
+  @media(max-width:900px){
+    .strip{grid-template-columns:1fr}
+    .cal .day{min-height:64px}
+    .ev{display:none}
+    .cal .day .dots{display:flex;gap:3px;padding:2px 5px}
+    .twocol{grid-template-columns:1fr}
+  }
+</style>
+</head>
+<body>
+
+<div class="explain">
+  <div class="container">
+    <b>Proposal C — Calendar-First + Quick Create · 日历为主 + 快速创建</b>
+    <p>/calendar becomes a real month calendar. "This Week" strip on top, browsable past months, recurring series marked with ⟳ and edited as series. Committee clicks any empty day → 3-field quick-create popover; "More options" opens the full composer.</p>
+  </div>
+</div>
+
+<div class="container">
+
+  <div class="sechead"><h2>This Week</h2><span>本周活动</span></div>
+  <div class="strip">
+    <div class="ecard">
+      <div class="img"><img src="../ProjectCode/client/public/images/2025/20250604_9th_anniversary_run.jpg" alt=""></div>
+      <div class="body">
+        <div><span class="chip upcoming">TUE 7/15</span> <span class="chip repeat">⟳</span></div>
+        <h3>Track Tuesday <small>周二训练</small></h3>
+        <div class="meta"><i>⏰</i>6:30 PM · <i>📍</i>East River Track</div>
+        <div class="go">View Details 详情 →</div>
+      </div>
+    </div>
+    <div class="ecard">
+      <div class="img"><img src="../ProjectCode/client/public/images/2025/20250620_queens_10k.jpg" alt=""></div>
+      <div class="body">
+        <div><span class="chip upcoming">SAT 7/19</span> <span class="chip repeat">⟳</span></div>
+        <h3>Saturday Long Run <small>周六长跑</small></h3>
+        <div class="meta"><i>⏰</i>8:00 AM · <i>📍</i>Engineers' Gate</div>
+        <div class="go">View Details 详情 →</div>
+      </div>
+    </div>
+    <div class="ecard">
+      <div class="img"><img src="../ProjectCode/client/public/images/2025/20250727_team_champ.jpg" alt=""></div>
+      <div class="body">
+        <div><span class="chip upcoming">SUN 7/27</span> <span class="chip race">RACE</span></div>
+        <h3>Team Championship <small>团队锦标赛</small></h3>
+        <div class="meta"><i>⏰</i>7:30 AM · <i>📍</i>Central Park</div>
+        <div class="go">Sign Up 报名 →</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="sechead" style="margin-top:34px">
+    <div class="calhead" style="margin:0;flex:1">
+      <div class="nav"><button>‹</button><button>›</button></div>
+      <h2>July 2026<span>2026年7月</span></h2>
+      <button class="today">Today 今天</button>
+      <button class="addbtn">+ Add Event 添加活动</button>
+    </div>
+  </div>
+
+  <div class="cal">
+    <div class="dow">
+      <div>SUN<span>日</span></div><div>MON<span>一</span></div><div>TUE<span>二</span></div>
+      <div>WED<span>三</span></div><div>THU<span>四</span></div><div>FRI<span>五</span></div><div>SAT<span>六</span></div>
+    </div>
+    <div class="week">
+      <div class="day dim"><span class="n">28</span></div>
+      <div class="day dim"><span class="n">29</span></div>
+      <div class="day dim"><span class="n">30</span><span class="ev run"><span class="r">⟳</span>Track Tuesday</span></div>
+      <div class="day"><span class="n">1</span></div>
+      <div class="day"><span class="n">2</span></div>
+      <div class="day"><span class="n">3</span></div>
+      <div class="day"><span class="n">4</span><span class="ev social">🎆 July 4 Fun Run</span><span class="ev run"><span class="r">⟳</span>Long Run</span></div>
+    </div>
+    <div class="week">
+      <div class="day"><span class="n">5</span></div>
+      <div class="day"><span class="n">6</span></div>
+      <div class="day"><span class="n">7</span><span class="ev run"><span class="r">⟳</span>Track Tuesday</span></div>
+      <div class="day"><span class="n">8</span></div>
+      <div class="day"><span class="n">9</span></div>
+      <div class="day"><span class="n">10</span></div>
+      <div class="day"><span class="n">11</span><span class="ev run"><span class="r">⟳</span>Long Run</span></div>
+    </div>
+    <div class="week">
+      <div class="day today"><span class="n">12</span></div>
+      <div class="day"><span class="n">13</span></div>
+      <div class="day"><span class="n">14</span></div>
+      <div class="day"><span class="n">15</span><span class="ev run"><span class="r">⟳</span>Track Tuesday</span></div>
+      <div class="day"><span class="n">16</span></div>
+      <div class="day"><span class="n">17</span></div>
+      <div class="day"><span class="n">18</span></div>
+    </div>
+    <div class="week" style="position:relative">
+      <div class="day"><span class="n">19</span><span class="ev run"><span class="r">⟳</span>Long Run</span></div>
+      <div class="day"><span class="n">20</span></div>
+      <div class="day daywrap" style="background:#fffaf1"><span class="n">21</span>
+        <span class="addghost">+ Add 添加</span>
+        <div class="qc">
+          <h4>Quick create · 快速创建</h4>
+          <div class="d">Tuesday, July 21 — date is set from the day you clicked</div>
+          <input placeholder="Event name 活动名称" value="Bridge Run Social">
+          <div class="row2"><input type="time" value="18:30"><input placeholder="Location 地点" value="Brooklyn Bridge"></div>
+          <div class="foot"><span class="more">More options 更多选项 →</span><button class="save">Create 创建</button></div>
+        </div>
+      </div>
+      <div class="day"><span class="n">22</span><span class="ev run"><span class="r">⟳</span>Track Tuesday</span></div>
+      <div class="day"><span class="n">23</span></div>
+      <div class="day"><span class="n">24</span></div>
+      <div class="day"><span class="n">25</span><span class="ev run"><span class="r">⟳</span>Long Run</span></div>
+    </div>
+    <div class="week">
+      <div class="day"><span class="n">26</span></div>
+      <div class="day"><span class="n">27</span><span class="ev race">🏁 Team Championship</span></div>
+      <div class="day"><span class="n">28</span><span class="ev run"><span class="r">⟳</span>Track Tuesday</span></div>
+      <div class="day"><span class="n">29</span></div>
+      <div class="day"><span class="n">30</span></div>
+      <div class="day"><span class="n">31</span></div>
+      <div class="day dim"><span class="n">1</span><span class="ev run"><span class="r">⟳</span>Long Run</span></div>
+    </div>
+  </div>
+  <div class="legend">
+    <span><i class="o"></i>Club runs 例行跑（⟳ = recurring series）</span>
+    <span><i class="b"></i>Races 比赛</span>
+    <span><i class="g"></i>Social 社交活动</span>
+    <span style="margin-left:auto">Past months are browsable — past events finally reachable outside Highlights</span>
+  </div>
+
+  <div class="twocol">
+    <div>
+      <div class="cap">EDITING A RECURRING INSTANCE · 编辑重复活动</div>
+      <div class="seriesbox" style="margin-top:0">
+        <h4>Edit "Saturday Long Run"</h4>
+        <p>这是每周重复活动。要修改哪些？</p>
+        <div class="opt on"><span class="dot"></span><span>This event only · 仅此次<small>Jul 19 — e.g. moved to Prospect Park this week</small></span></div>
+        <div class="opt"><span class="dot"></span><span>This and following events · 此次及以后<small>Changes the series from Jul 19 onward</small></span></div>
+        <div class="opt"><span class="dot"></span><span>All events in the series · 整个系列<small>Every Saturday instance, past and future</small></span></div>
+      </div>
+    </div>
+    <div>
+      <div class="cap">DUPLICATE = FASTEST CREATION · 复制活动</div>
+      <div class="seriesbox" style="margin-top:0">
+        <h4>⧉ Duplicate "Queens 10K Team Outing"</h4>
+        <p>大多数活动都是往年的翻版——复制后只改日期。</p>
+        <div class="opt on"><span class="dot"></span><span>Copy everything, pick a new date<small>Name, descriptions, image, signup link carried over — opens Quick Create pre-filled with only Date empty</small></span></div>
+        <div class="opt"><span class="dot"></span><span>Copy as template (clear image &amp; link)<small>For similar-but-different events</small></span></div>
+      </div>
+    </div>
+  </div>
+
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- One `EventCard` component (grid/row densities, status/type/recurring chips, date bubble, time+location always visible, engagement bar, context-aware Sign Up 报名 / View Details 查看详情 CTA) replaces the five divergent card designs on Calendar and Highlights
- One `EventComposer` 3-step create/edit dialog with live card preview replaces the three divergent editors (CalendarPage dialog, AdminPanel dialog, EventDetailModal inline form) — immediate S3 image upload, real time picker, inline validation, WeChat QR folded in, recurrence sync
- Shared `theme/tokens.js` + `helpers/eventDate.js`; dead Calendar filters and quick-QR dialog removed; missing images fall back to the placeholder
- Frontend-only: no backend, no migration

## Test plan
- Full jest suite: 82 suites / 1,225 tests passing
- Playwright end-to-end against local servers: card rendering, Sign Up new-tab, detail modal via CTA and deep link, bogus deep link, Highlights, no-image fallback — all verified with screenshots

🤖 Generated with [Claude Code](https://claude.com/claude-code)