### PR TITLE
Deploy: donation thank-you feature + homepage tile updates

### DIFF
--- a/ProjectCode/client/src/api/donors.js
+++ b/ProjectCode/client/src/api/donors.js
@@ -180,6 +180,22 @@ export async function sendThankYou(donationId, { email, subject, message, attach
 }
 
 /**
+ * Mark a donation as already thanked (e.g. a card mailed or a call made
+ * outside the app) without sending an email. Just stamps thank_you_sent_at.
+ * @param {number} donationId - Donation ID
+ * @param {string} [note] - Optional note for the audit trail
+ * @param {string} firebaseUid - Committee/admin Firebase UID
+ * @returns {Promise<Object>} Updated ledger entry
+ */
+export async function markThankYouSent(donationId, note, firebaseUid) {
+  return api.post(`/api/donors/donations/${donationId}/mark-thank-you-sent`, {
+    note: note || undefined,
+  }, {
+    'X-Firebase-UID': firebaseUid,
+  });
+}
+
+/**
  * The rendered letter for a donation, for review/editing in the send dialog.
  * Auto-matches a template by amount; pass templateId to render a specific
  * one (0 = built-in default).

--- a/ProjectCode/client/src/components/DonationLedger.js
+++ b/ProjectCode/client/src/components/DonationLedger.js
@@ -15,7 +15,7 @@ import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../context';
 import {
   getDonationLedger, approveDonation, dismissDonation, sendThankYou,
-  getThankYouPreview, getThankYouTemplates, createThankYouTemplate,
+  markThankYouSent, getThankYouPreview, getThankYouTemplates, createThankYouTemplate,
   updateThankYouTemplate, deleteThankYouTemplate, downloadReceipt,
   updateDonor, runGmailSync, downloadTaxReport
 } from '../api/donors';
@@ -154,6 +154,7 @@ export default function DonationLedger({ onLedgerChange }) {
   const [thankTemplates, setThankTemplates] = useState([]);
   const [thankAttach, setThankAttach] = useState(true);
   const [sendingThanks, setSendingThanks] = useState(false);
+  const [markingThankedId, setMarkingThankedId] = useState(null);
   const [ignoredOpen, setIgnoredOpen] = useState(false);
   const [receiptingId, setReceiptingId] = useState(null);
 
@@ -285,6 +286,20 @@ export default function DonationLedger({ onLedgerChange }) {
       setError('Failed to send the thank-you email. / 发送感谢邮件失败。');
     } finally {
       setSendingThanks(false);
+    }
+  };
+
+  const handleMarkThankYouSent = async (donation) => {
+    setMarkingThankedId(donation.donation_id);
+    setError('');
+    try {
+      await markThankYouSent(donation.donation_id, undefined, firebaseUid);
+      await fetchLedger();
+    } catch (err) {
+      console.error('Error marking thank-you as sent:', err);
+      setError('Failed to mark as already thanked. / 标记为已致谢失败。');
+    } finally {
+      setMarkingThankedId(null);
     }
   };
 
@@ -674,13 +689,30 @@ export default function DonationLedger({ onLedgerChange }) {
                           ✓ Sent {formatDate(donation.thank_you_sent_at)}
                         </Typography>
                       ) : (
-                        <Button
-                          size="small"
-                          onClick={() => openThankDialog(donation)}
-                          sx={{ ...pillButtonSx(false), fontSize: '0.6875rem', py: 0.25 }}
-                        >
-                          Send thank-you 发送感谢
-                        </Button>
+                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
+                          <Button
+                            size="small"
+                            onClick={() => openThankDialog(donation)}
+                            sx={{ ...pillButtonSx(false), fontSize: '0.6875rem', py: 0.25 }}
+                          >
+                            Send thank-you 发送感谢
+                          </Button>
+                          <Tooltip title="Already thanked outside the app (call, card, prior email) — just clear this flag, no email is sent. / 已在系统外致谢过（电话、卡片、之前的邮件）——只清除此标记，不发送邮件。">
+                            <span>
+                              <Button
+                                size="small"
+                                onClick={() => handleMarkThankYouSent(donation)}
+                                disabled={markingThankedId === donation.donation_id}
+                                startIcon={markingThankedId === donation.donation_id
+                                  ? <CircularProgress size={12} sx={{ color: MUTED }} />
+                                  : undefined}
+                                sx={{ textTransform: 'none', fontSize: '0.6875rem', fontWeight: 700, color: MUTED, py: 0.25, px: 1, minWidth: 0, '&:hover': { color: GREEN, backgroundColor: 'transparent' } }}
+                              >
+                                Already sent 已发送
+                              </Button>
+                            </span>
+                          </Tooltip>
+                        </Box>
                       )}
                     </TableCell>
                     <TableCell sx={{ whiteSpace: 'nowrap', width: 130 }}>

--- a/ProjectCode/client/src/components/DonationLedger.test.js
+++ b/ProjectCode/client/src/components/DonationLedger.test.js
@@ -6,6 +6,7 @@ import {
   approveDonation,
   dismissDonation,
   sendThankYou,
+  markThankYouSent,
   getThankYouPreview,
   getThankYouTemplates,
   createThankYouTemplate,
@@ -30,6 +31,7 @@ jest.mock('../api/donors', () => ({
   approveDonation: jest.fn(),
   dismissDonation: jest.fn(),
   sendThankYou: jest.fn(),
+  markThankYouSent: jest.fn(),
   getThankYouPreview: jest.fn(),
   getThankYouTemplates: jest.fn(),
   createThankYouTemplate: jest.fn(),
@@ -123,6 +125,7 @@ beforeEach(() => {
   approveDonation.mockResolvedValue({});
   dismissDonation.mockResolvedValue({});
   sendThankYou.mockResolvedValue({});
+  markThankYouSent.mockResolvedValue({});
   getThankYouPreview.mockResolvedValue({
     subject: 'Thank you for supporting NewBee Running Club!',
     body: 'Dear donor, thank you for your generous donation.',
@@ -249,6 +252,25 @@ test('thank-you column shows sent state or an enabled send button', async () => 
   expect(sendButton).toBeEnabled();
 });
 
+test('the "Already sent" button marks a donation as thanked without opening the send dialog', async () => {
+  render(<DonationLedger />);
+  await screen.findByText('Golden Wheat Bakery');
+
+  fireEvent.click(screen.getByText('Already sent 已发送'));
+  await waitFor(() => expect(markThankYouSent).toHaveBeenCalledWith(12, undefined, 'admin-uid'));
+  expect(screen.queryByText('✉ Send thank-you email 发送感谢邮件')).not.toBeInTheDocument();
+  await waitFor(() => expect(getDonationLedger).toHaveBeenCalledTimes(2));
+});
+
+test('shows an error when marking a donation as already-thanked fails', async () => {
+  markThankYouSent.mockRejectedValue(new Error('boom'));
+  render(<DonationLedger />);
+  await screen.findByText('Golden Wheat Bakery');
+
+  fireEvent.click(screen.getByText('Already sent 已发送'));
+  expect(await screen.findByText('Failed to mark as already thanked. / 标记为已致谢失败。')).toBeInTheDocument();
+});
+
 test('send dialog prefills the matched letter and sends the edited version', async () => {
   render(<DonationLedger />);
   await screen.findByText('Golden Wheat Bakery');
@@ -270,6 +292,9 @@ test('send dialog prefills the matched letter and sends the edited version', asy
   expect(sendBtn).toBeEnabled();
 
   // Edit the letter before sending
+  fireEvent.change(screen.getByLabelText(/Subject 邮件标题/), {
+    target: { value: 'Edited subject line' },
+  });
   fireEvent.change(screen.getByLabelText(/Message 正文/), {
     target: { value: 'Edited letter body' },
   });
@@ -277,7 +302,7 @@ test('send dialog prefills the matched letter and sends the edited version', asy
   fireEvent.click(sendBtn);
   await waitFor(() => expect(sendThankYou).toHaveBeenCalledWith(12, {
     email: 'baker@example.com',
-    subject: 'Thank you for supporting NewBee Running Club!',
+    subject: 'Edited subject line',
     message: 'Edited letter body',
     attachReceipt: true,
   }, 'admin-uid'));
@@ -562,6 +587,228 @@ test('shows an error when the tax download fails', async () => {
   fireEvent.click(screen.getByText('Generate Tax File 生成税务文件'));
   fireEvent.click(screen.getByText('⬇ Generate & Download 生成并下载'));
   expect(await screen.findByText(/Failed to generate tax file/)).toBeInTheDocument();
+});
+
+test('cancel closes the send thank-you dialog without sending', async () => {
+  render(<DonationLedger />);
+  await screen.findByText('Golden Wheat Bakery');
+  fireEvent.click(screen.getByText('Send thank-you 发送感谢'));
+  await screen.findByText('✉ Send thank-you email 发送感谢邮件');
+  await screen.findByDisplayValue(/Dear donor, thank you/); // preview loaded
+
+  fireEvent.click(screen.getByText('Cancel 取消'));
+  await waitFor(() =>
+    expect(screen.queryByText('✉ Send thank-you email 发送感谢邮件')).not.toBeInTheDocument()
+  );
+  expect(sendThankYou).not.toHaveBeenCalled();
+});
+
+test('shows an error when the letter preview fails to load', async () => {
+  getThankYouPreview.mockRejectedValue(new Error('boom'));
+  render(<DonationLedger />);
+  await screen.findByText('Golden Wheat Bakery');
+  fireEvent.click(screen.getByText('Send thank-you 发送感谢'));
+  expect(await screen.findByText('Failed to load the letter preview. / 加载感谢信预览失败。')).toBeInTheDocument();
+});
+
+test('shows an error when switching templates fails', async () => {
+  getThankYouTemplates.mockResolvedValue([
+    { id: 5, name: 'Major donor', min_amount: '300', subject: 'S', body: 'B' },
+  ]);
+  getThankYouPreview
+    .mockResolvedValueOnce({
+      subject: 'Auto subject', body: 'Auto body', template_name: null, template_id: 0,
+    })
+    .mockRejectedValueOnce(new Error('boom'));
+
+  render(<DonationLedger />);
+  await screen.findByText('Golden Wheat Bakery');
+  fireEvent.click(screen.getByText('Send thank-you 发送感谢'));
+  await screen.findByDisplayValue('Auto body');
+
+  fireEvent.mouseDown(screen.getByLabelText('Template 模板').closest('[role="combobox"]') || screen.getAllByRole('combobox')[0]);
+  fireEvent.click(await screen.findByText(/Major donor · ≥ \$300\.00/));
+
+  expect(await screen.findByText('Failed to load that template. / 切换模板失败。')).toBeInTheDocument();
+});
+
+test('shows an error when the receipt download fails', async () => {
+  downloadReceipt.mockRejectedValue(new Error('boom'));
+  render(<DonationLedger />);
+  await screen.findByText('Golden Wheat Bakery');
+  fireEvent.click(screen.getAllByLabelText('Receipt 收据')[0]);
+  expect(await screen.findByText('Failed to generate the receipt. / 生成收据失败。')).toBeInTheDocument();
+});
+
+test('close button closes the templates dialog', async () => {
+  render(<DonationLedger />);
+  await screen.findByText('Golden Wheat Bakery');
+  fireEvent.click(screen.getByText('✉ Templates 模板'));
+  await screen.findByText('✉ Thank-you templates 感谢信模板');
+  fireEvent.click(screen.getByText('Close 关闭'));
+  await waitFor(() =>
+    expect(screen.queryByText('✉ Thank-you templates 感谢信模板')).not.toBeInTheDocument()
+  );
+});
+
+test('shows an error when the templates list fails to load', async () => {
+  getThankYouTemplates.mockRejectedValue(new Error('boom'));
+  render(<DonationLedger />);
+  await screen.findByText('Golden Wheat Bakery');
+  fireEvent.click(screen.getByText('✉ Templates 模板'));
+  expect(await screen.findByText('Failed to load templates. / 加载模板失败。')).toBeInTheDocument();
+});
+
+test('edit button opens the template form pre-filled; cancel discards it', async () => {
+  getThankYouTemplates.mockResolvedValue([
+    { id: 5, name: 'Major donor', min_amount: '300', subject: 'S', body: 'B' },
+  ]);
+  render(<DonationLedger />);
+  await screen.findByText('Golden Wheat Bakery');
+  fireEvent.click(screen.getByText('✉ Templates 模板'));
+  fireEvent.click(await screen.findByText('✎ Edit 编辑'));
+  expect(screen.getByDisplayValue('Major donor')).toBeInTheDocument();
+
+  fireEvent.click(screen.getByText('Cancel 取消'));
+  expect(screen.queryByDisplayValue('Major donor')).not.toBeInTheDocument();
+});
+
+test('editing an existing template saves via update, not create', async () => {
+  getThankYouTemplates.mockResolvedValue([
+    { id: 5, name: 'Major donor', min_amount: '300', subject: 'S', body: 'B' },
+  ]);
+  render(<DonationLedger />);
+  await screen.findByText('Golden Wheat Bakery');
+  fireEvent.click(screen.getByText('✉ Templates 模板'));
+  fireEvent.click(await screen.findByText('✎ Edit 编辑'));
+
+  fireEvent.change(screen.getByLabelText(/Template name 模板名称/), { target: { value: 'Major donor v2' } });
+  fireEvent.click(screen.getByText('Save 保存'));
+
+  await waitFor(() => expect(updateThankYouTemplate).toHaveBeenCalledWith(
+    5, { name: 'Major donor v2', min_amount: '300', subject: 'S', body: 'B' }, 'admin-uid'
+  ));
+  expect(createThankYouTemplate).not.toHaveBeenCalled();
+});
+
+test('shows an error when saving a template fails', async () => {
+  createThankYouTemplate.mockRejectedValue(new Error('boom'));
+  getThankYouTemplates.mockResolvedValue([]);
+  render(<DonationLedger />);
+  await screen.findByText('Golden Wheat Bakery');
+  fireEvent.click(screen.getByText('✉ Templates 模板'));
+  fireEvent.click(await screen.findByText('＋ Add template 添加模板'));
+  fireEvent.change(screen.getByLabelText(/Template name 模板名称/), { target: { value: 'Major donor' } });
+  fireEvent.change(screen.getByLabelText(/Subject 邮件标题/), { target: { value: 'S' } });
+  fireEvent.change(screen.getByLabelText(/Body 正文/), { target: { value: 'B' } });
+  fireEvent.click(screen.getByText('Save 保存'));
+  expect(await screen.findByText('Failed to save the template. / 保存模板失败。')).toBeInTheDocument();
+});
+
+test('shows an error when deleting a template fails', async () => {
+  deleteThankYouTemplate.mockRejectedValue(new Error('boom'));
+  getThankYouTemplates.mockResolvedValue([
+    { id: 5, name: 'Major donor', min_amount: '300', subject: 'S', body: 'B' },
+  ]);
+  render(<DonationLedger />);
+  await screen.findByText('Golden Wheat Bakery');
+  fireEvent.click(screen.getByText('✉ Templates 模板'));
+  fireEvent.click(await screen.findByText('Delete 删除'));
+  expect(await screen.findByText('Failed to delete the template. / 删除模板失败。')).toBeInTheDocument();
+});
+
+test('cancel discards notes edits without saving', async () => {
+  render(<DonationLedger />);
+  const row = (await screen.findByText('Ming Zhao')).closest('tr');
+  fireEvent.click(row);
+  fireEvent.click(await screen.findByText('✎ Edit 编辑'));
+  fireEvent.change(screen.getByLabelText('Notes 备注'), { target: { value: 'draft that should be discarded' } });
+  fireEvent.click(screen.getByText('Cancel 取消'));
+  expect(screen.queryByLabelText('Notes 备注')).not.toBeInTheDocument();
+  expect(updateDonor).not.toHaveBeenCalled();
+});
+
+test('shows an error when saving notes fails', async () => {
+  updateDonor.mockRejectedValue(new Error('boom'));
+  render(<DonationLedger />);
+  const row = (await screen.findByText('Ming Zhao')).closest('tr');
+  fireEvent.click(row);
+  fireEvent.click(await screen.findByText('✎ Edit 编辑'));
+  fireEvent.change(screen.getByLabelText('Notes 备注'), { target: { value: 'updated note' } });
+  fireEvent.click(screen.getByText('Save 保存'));
+  expect(await screen.findByText('Failed to save notes. / 保存备注失败。')).toBeInTheDocument();
+});
+
+test('editing the tax date range updates the from/to fields', async () => {
+  render(<DonationLedger />);
+  await screen.findByText('Ming Zhao');
+  fireEvent.click(screen.getByText('Generate Tax File 生成税务文件'));
+  await screen.findByText(/Time range 时间范围/);
+
+  fireEvent.change(screen.getByLabelText('From 从'), { target: { value: `${currentYear - 3}-02-01` } });
+  fireEvent.change(screen.getByLabelText('To 至'), { target: { value: `${currentYear - 3}-02-28` } });
+  fireEvent.click(screen.getByText('⬇ Generate & Download 生成并下载'));
+
+  await waitFor(() => expect(downloadTaxReport).toHaveBeenCalledWith(
+    { startDate: `${currentYear - 3}-02-01`, endDate: `${currentYear - 3}-02-28`, format: 'pdf' },
+    'admin-uid'
+  ));
+});
+
+test('cancel closes the tax dialog without generating a report', async () => {
+  render(<DonationLedger />);
+  await screen.findByText('Ming Zhao');
+  fireEvent.click(screen.getByText('Generate Tax File 生成税务文件'));
+  await screen.findByText(/Time range 时间范围/);
+
+  fireEvent.click(screen.getByText('Cancel 取消'));
+  await waitFor(() => expect(screen.queryByText(/Time range 时间范围/)).not.toBeInTheDocument());
+  expect(downloadTaxReport).not.toHaveBeenCalled();
+});
+
+test('the error alert can be dismissed', async () => {
+  approveDonation.mockRejectedValue(new Error('nope'));
+  render(<DonationLedger />);
+  await screen.findByText('Ming Zhao');
+  fireEvent.click(screen.getAllByText('Approve 确认')[0]);
+  expect(await screen.findByText(/Failed to approve donation/)).toBeInTheDocument();
+
+  fireEvent.click(screen.getByLabelText('Close'));
+  expect(screen.queryByText(/Failed to approve donation/)).not.toBeInTheDocument();
+});
+
+test('pressing Escape closes the send thank-you dialog', async () => {
+  render(<DonationLedger />);
+  await screen.findByText('Golden Wheat Bakery');
+  fireEvent.click(screen.getByText('Send thank-you 发送感谢'));
+  await screen.findByText('✉ Send thank-you email 发送感谢邮件');
+
+  fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Escape', code: 'Escape' });
+  await waitFor(() =>
+    expect(screen.queryByText('✉ Send thank-you email 发送感谢邮件')).not.toBeInTheDocument()
+  );
+});
+
+test('pressing Escape closes the templates dialog', async () => {
+  render(<DonationLedger />);
+  await screen.findByText('Golden Wheat Bakery');
+  fireEvent.click(screen.getByText('✉ Templates 模板'));
+  await screen.findByText('✉ Thank-you templates 感谢信模板');
+
+  fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Escape', code: 'Escape' });
+  await waitFor(() =>
+    expect(screen.queryByText('✉ Thank-you templates 感谢信模板')).not.toBeInTheDocument()
+  );
+});
+
+test('pressing Escape closes the tax dialog', async () => {
+  render(<DonationLedger />);
+  await screen.findByText('Ming Zhao');
+  fireEvent.click(screen.getByText('Generate Tax File 生成税务文件'));
+  await screen.findByText(/Time range 时间范围/);
+
+  fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Escape', code: 'Escape' });
+  await waitFor(() => expect(screen.queryByText(/Time range 时间范围/)).not.toBeInTheDocument());
 });
 
 test('renders nothing to fetch without a logged-in user', () => {

--- a/ProjectCode/server/models.py
+++ b/ProjectCode/server/models.py
@@ -143,6 +143,13 @@ class SendThankYouRequest(BaseModel):
     attach_receipt: bool = False
 
 
+class MarkThankYouSentRequest(BaseModel):
+    """Stamp a donation as already thanked (e.g. a committee member sent a
+    physical card or an off-system email) without sending anything from
+    the app. Optional note is appended to the audit trail."""
+    note: Optional[str] = Field(None, max_length=1000)
+
+
 class ThankYouTemplateBase(BaseModel):
     """Thank-you letter template, tiered by donation amount"""
     name: str = Field(..., max_length=100)

--- a/ProjectCode/server/routes/donors.py
+++ b/ProjectCode/server/routes/donors.py
@@ -15,8 +15,8 @@ from models import (
     DonorCreate, DonorUpdate, DonorResponse, DonorsListResponse, DonationSummary,
     DonorPublicResponse, DonorLinkMemberRequest, DonorLedgerEntry,
     DonationLedgerStats, DonationSyncStatus, DonationLedgerResponse,
-    ApproveDonationRequest, SendThankYouRequest, ThankYouTemplateCreate,
-    ThankYouTemplateUpdate, ThankYouTemplateResponse
+    ApproveDonationRequest, SendThankYouRequest, MarkThankYouSentRequest,
+    ThankYouTemplateCreate, ThankYouTemplateUpdate, ThankYouTemplateResponse
 )
 from utils.auth import get_current_admin, get_current_committee_or_admin
 
@@ -495,6 +495,47 @@ def send_thank_you(
     send_acknowledgment(db, donor, request.email,
                         subject=request.subject, message=request.message,
                         attach_receipt=request.attach_receipt)
+    db.commit()
+    db.refresh(donor)
+    return donor
+
+
+@router.post("/donations/{donation_id}/mark-thank-you-sent", response_model=DonorLedgerEntry)
+def mark_thank_you_sent(
+    donation_id: int,
+    request: MarkThankYouSentRequest,
+    db: Session = Depends(get_db),
+    current_admin: Member = Depends(get_current_committee_or_admin)
+):
+    """Stamp a donation as already thanked without sending anything from the
+    app — for donations an operator already thanked outside the system
+    (a phone call, a handwritten card, an email sent before this feature
+    existed). Only clears the "Thank-you not sent" flag; no email is sent.
+    """
+    donor = db.query(Donor).filter(Donor.donation_id == donation_id).first()
+    if not donor:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Donation {donation_id} not found"
+        )
+    if donor.status != "confirmed":
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Only confirmed donations can be marked as thanked"
+        )
+
+    admin_name = (current_admin.display_name or
+                  f"{current_admin.first_name or ''} {current_admin.last_name or ''}".strip() or
+                  current_admin.username)
+    sent_at = datetime.utcnow()
+    donor.thank_you_sent_at = sent_at
+    ack_record = (
+        f"—— Marked as already thanked 已标记为已致谢 ——\n"
+        f"By {admin_name} on {sent_at.strftime('%b %d, %Y %H:%M')} UTC"
+        + (f"\n{request.note.strip()}" if request.note and request.note.strip() else "")
+    )
+    donor.notes = f"{donor.notes}\n\n{ack_record}" if donor.notes else ack_record
+
     db.commit()
     db.refresh(donor)
     return donor

--- a/ProjectCode/server/seed_demo_data.py
+++ b/ProjectCode/server/seed_demo_data.py
@@ -93,6 +93,8 @@ SECTIONS = [
          image_url='/AboutUs.png', display_order=5),
     dict(title_en='Training With Us', title_cn='与我们训练', link_path='/training',
          image_url=f'{IMG}/20250503_bk_half_preview_run.jpg', display_order=6),
+    dict(title_en='Donors', title_cn='捐赠者', link_path='/sponsors',
+         image_url=f'{IMG}/20250620_queens_10k.jpg', display_order=7),
 ]
 
 DONORS = [

--- a/ProjectCode/server/seed_demo_data.py
+++ b/ProjectCode/server/seed_demo_data.py
@@ -91,10 +91,9 @@ SECTIONS = [
          image_url=f'{IMG}/20250620_queens_10k.jpg', display_order=4),
     dict(title_en='Join NewBee', title_cn='加入新蜂', link_path='/join',
          image_url='/AboutUs.png', display_order=5),
-    dict(title_en='Training With Us', title_cn='与我们训练', link_path='/training',
-         image_url=f'{IMG}/20250503_bk_half_preview_run.jpg', display_order=6),
+    # Training tile intentionally omitted — the page is hidden on prod
     dict(title_en='Donors', title_cn='捐赠者', link_path='/sponsors',
-         image_url=f'{IMG}/20250620_queens_10k.jpg', display_order=7),
+         image_url=f'{IMG}/20250503_bk_half_preview_run.jpg', display_order=6),
 ]
 
 DONORS = [

--- a/ProjectCode/server/tests/test_donation_ledger.py
+++ b/ProjectCode/server/tests/test_donation_ledger.py
@@ -377,6 +377,64 @@ def test_send_thank_you_502_when_email_fails(client, db_session, committee_membe
     assert donor.thank_you_sent_at is None
 
 
+def test_mark_thank_you_sent_requires_auth(client, db_session):
+    donor = seed_donation(db_session, 'C1')
+    resp = client.post(f'/api/donors/donations/{donor.donation_id}/mark-thank-you-sent',
+                       json={})
+    assert resp.status_code == 401
+
+
+def test_mark_thank_you_sent_unknown_donation_404(client, committee_member):
+    resp = client.post('/api/donors/donations/99999/mark-thank-you-sent',
+                       json={}, headers=auth(committee_member))
+    assert resp.status_code == 404
+
+
+def test_mark_thank_you_sent_rejects_unconfirmed(client, db_session, committee_member):
+    donor = seed_donation(db_session, 'P1', status='pending')
+    resp = client.post(f'/api/donors/donations/{donor.donation_id}/mark-thank-you-sent',
+                       json={}, headers=auth(committee_member))
+    assert resp.status_code == 400
+
+
+def test_mark_thank_you_sent_stamps_without_emailing(client, db_session, committee_member, monkeypatch):
+    import email_service
+    send_calls = []
+    monkeypatch.setattr(
+        email_service.EmailService, 'send_email',
+        staticmethod(lambda *a, **k: send_calls.append((a, k)) or True),
+    )
+
+    donor = seed_donation(db_session, 'C1', name='Kevin Gu')
+    resp = client.post(f'/api/donors/donations/{donor.donation_id}/mark-thank-you-sent',
+                       json={}, headers=auth(committee_member))
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body['thank_you_sent_at'] is not None
+    assert send_calls == []  # no email sent
+    assert 'Marked as already thanked' in body['notes']
+    assert 'Test Committee' in body['notes']  # committee_member.display_name
+
+
+def test_mark_thank_you_sent_appends_note_and_preserves_existing_notes(client, db_session, committee_member):
+    donor = seed_donation(db_session, 'C1', notes='Zelle Transaction #24271147625')
+    resp = client.post(f'/api/donors/donations/{donor.donation_id}/mark-thank-you-sent',
+                       json={'note': 'Thanked by phone on 7/20'},
+                       headers=auth(committee_member))
+    assert resp.status_code == 200
+    notes = resp.json()['notes']
+    assert notes.startswith('Zelle Transaction #24271147625')
+    assert 'Marked as already thanked' in notes
+    assert 'Thanked by phone on 7/20' in notes
+
+
+def test_mark_thank_you_sent_does_not_require_a_note(client, db_session, committee_member):
+    donor = seed_donation(db_session, 'C1')
+    resp = client.post(f'/api/donors/donations/{donor.donation_id}/mark-thank-you-sent',
+                       json={}, headers=auth(committee_member))
+    assert resp.status_code == 200
+
+
 # ---------------------------------------------------------------- public filtering
 
 def test_pending_and_dismissed_hidden_from_public_endpoints(client, db_session):


### PR DESCRIPTION
Promotes dev to prod.

Includes:
- Seed a Donors homepage tile linking to /sponsors
- Drop the hidden Training tile from seeds; give Donors tile its own photo
- Let committee mark a donation as already thanked; close test coverage gaps (#86)

🤖 Generated with [Claude Code](https://claude.com/claude-code)