### PR TITLE
Remember donor emails between thank-yous

### DIFF
--- a/ProjectCode/client/src/components/DonationLedger.js
+++ b/ProjectCode/client/src/components/DonationLedger.js
@@ -233,7 +233,7 @@ export default function DonationLedger({ onLedgerChange }) {
 
   const openThankDialog = async (donation) => {
     setThankTarget(donation);
-    setThankEmail('');
+    setThankEmail(donation.email || '');
     setThankSubject('');
     setThankMessage('');
     setThankTemplateId(0);
@@ -957,7 +957,9 @@ export default function DonationLedger({ onLedgerChange }) {
             fullWidth
             value={thankEmail}
             onChange={(e) => setThankEmail(e.target.value)}
-            helperText="Payment emails don't include the donor's address — enter it here. / 付款邮件不含捐赠者邮箱，请填写。"
+            helperText={thankTarget?.email
+              ? 'Remembered from a previous thank-you — edit if it changed. / 已记住上次填写的邮箱，如有变化可修改。'
+              : "Payment emails don't include the donor's address — enter it here. It's remembered for next time. / 付款邮件不含捐赠者邮箱，请填写；系统会记住以便下次使用。"}
           />
           <FormControlLabel
             control={

--- a/ProjectCode/client/src/components/DonationLedger.test.js
+++ b/ProjectCode/client/src/components/DonationLedger.test.js
@@ -312,6 +312,27 @@ test('send dialog prefills the matched letter and sends the edited version', asy
   expect(getDonationLedger).toHaveBeenCalledTimes(2);
 });
 
+test('send dialog prefills a remembered donor email from the directory', async () => {
+  getDonationLedger.mockResolvedValue({
+    ...ledgerData,
+    donations: ledgerData.donations.map((d) =>
+      d.donation_id === 12 ? { ...d, email: 'baker@example.com' } : d
+    ),
+  });
+  render(<DonationLedger />);
+  await screen.findByText('Golden Wheat Bakery');
+
+  fireEvent.click(screen.getByText('Send thank-you 发送感谢'));
+  await screen.findByText('✉ Send thank-you email 发送感谢邮件');
+
+  expect(screen.getByDisplayValue('baker@example.com')).toBeInTheDocument();
+  expect(screen.getByText(/Remembered from a previous thank-you/)).toBeInTheDocument();
+  // Send is already enabled — no need to retype the email
+  await screen.findByDisplayValue(/Dear donor, thank you/); // preview loaded
+  const sendBtn = screen.getByText('Send 发送').closest('button');
+  expect(sendBtn).toBeEnabled();
+});
+
 test('switching templates in the send dialog refills the letter', async () => {
   getThankYouTemplates.mockResolvedValue([
     { id: 5, name: 'Major donor', min_amount: '300', subject: 'S', body: 'B' },

--- a/ProjectCode/server/models.py
+++ b/ProjectCode/server/models.py
@@ -87,6 +87,9 @@ class DonorLedgerEntry(DonorResponse):
     status: str = "confirmed"  # pending | confirmed | dismissed
     thank_you_sent_at: Optional[datetime] = None
     email_excerpt: Optional[str] = None
+    # Remembered from the donor directory (name -> email), for prefilling
+    # the send-thank-you dialog — not a Donor column, set dynamically
+    email: Optional[str] = None
     # Two-layer bookkeeping (finance module)
     income_type: Optional[str] = None  # donation | event_revenue | pass_through | NULL=unclassified
     event_code: Optional[int] = None

--- a/ProjectCode/server/routes/donors.py
+++ b/ProjectCode/server/routes/donors.py
@@ -3,6 +3,7 @@ import csv
 import io
 import json
 import os
+import re
 from datetime import date, datetime
 
 from fastapi import APIRouter, Depends, HTTPException, Response, status
@@ -10,7 +11,7 @@ from sqlalchemy.orm import Session
 from sqlalchemy import func, or_
 from typing import List, Optional
 
-from database import get_db, Donor, Member, SiteSetting, ThankYouTemplate
+from database import get_db, Donor, Member, SiteSetting, ThankYouTemplate, DonorDirectoryEntry
 from models import (
     DonorCreate, DonorUpdate, DonorResponse, DonorsListResponse, DonationSummary,
     DonorPublicResponse, DonorLinkMemberRequest, DonorLedgerEntry,
@@ -21,6 +22,12 @@ from models import (
 from utils.auth import get_current_admin, get_current_committee_or_admin
 
 router = APIRouter(prefix="/api/donors", tags=["donors"])
+
+
+def _normalize_donor_name(name: str) -> str:
+    """Matches the normalization the Finance module's donor directory uses,
+    so a name looked up here finds entries saved from either surface."""
+    return re.sub(r"\s+", " ", (name or "").strip()).lower()
 
 
 # Main endpoint for SponsorsPage - replaces CSV fetching
@@ -165,6 +172,13 @@ def get_donation_ledger(db: Session = Depends(get_db), current_admin: Member = D
     ).all()
     # Pending reviews float to the top; sort is stable so date order is kept
     donations.sort(key=lambda d: d.status != "pending")
+
+    # Suggest a remembered email for each donor (from the Finance directory,
+    # shared with the send-thank-you dialog) — not a Donor column, so it's
+    # set as a transient attribute for the response model to pick up.
+    directory = {e.name: e.email for e in db.query(DonorDirectoryEntry).all()}
+    for d in donations:
+        d.email = directory.get(_normalize_donor_name(d.name))
 
     confirmed = [d for d in donations if d.status == "confirmed"]
     current_year = date.today().year
@@ -571,6 +585,17 @@ def send_acknowledgment(db: Session, donor, email: str, subject=None,
             status_code=status.HTTP_502_BAD_GATEWAY,
             detail="Failed to send the email — check the server email configuration"
         )
+
+    # Remember this email against the donor's name — the send-thank-you
+    # dialog prefills from this next time, and it's the same directory the
+    # Finance module uses for batch acknowledgments/year-end statements.
+    normalized_name = _normalize_donor_name(donor.name)
+    directory_entry = db.query(DonorDirectoryEntry).filter(
+        DonorDirectoryEntry.name == normalized_name).first()
+    if directory_entry:
+        directory_entry.email = email
+    else:
+        db.add(DonorDirectoryEntry(name=normalized_name, email=email))
 
     sent_at = datetime.utcnow()
     donor.thank_you_sent_at = sent_at

--- a/ProjectCode/server/tests/test_donation_ledger.py
+++ b/ProjectCode/server/tests/test_donation_ledger.py
@@ -22,7 +22,7 @@ from sqlalchemy.pool import StaticPool
 import fetch_historical_data
 import migrate_donation_ledger
 import sync_zelle_donations as szd
-from database import Donor, SiteSetting
+from database import Donor, DonorDirectoryEntry, SiteSetting
 from tests.conftest import auth
 
 
@@ -197,6 +197,22 @@ def test_ledger_includes_email_excerpt_and_thank_you(client, db_session, committ
     assert entry['thank_you_sent_at'] is None
 
 
+def test_ledger_suggests_email_from_directory(client, db_session, committee_member):
+    db_session.add(DonorDirectoryEntry(name='kevin gu', email='kevin@example.com'))
+    db_session.commit()
+    seed_donation(db_session, 'C1', name='Kevin Gu')
+    resp = client.get('/api/donors/ledger', headers=auth(committee_member))
+    entry = resp.json()['donations'][0]
+    assert entry['email'] == 'kevin@example.com'
+
+
+def test_ledger_email_is_null_when_donor_not_in_directory(client, db_session, committee_member):
+    seed_donation(db_session, 'C1', name='Stranger Donor')
+    resp = client.get('/api/donors/ledger', headers=auth(committee_member))
+    entry = resp.json()['donations'][0]
+    assert entry['email'] is None
+
+
 # ---------------------------------------------------------------- approve / dismiss
 
 def test_approve_requires_auth(client, db_session):
@@ -345,6 +361,40 @@ def test_send_thank_you_sends_and_stamps(client, db_session, committee_member, m
     assert 'Sent to kevin@example.com' in body['notes']
     assert sent['subject'] in body['notes']
     assert sent['text'] in body['notes']
+
+
+def test_send_thank_you_remembers_email_for_next_time(client, db_session, committee_member, monkeypatch):
+    import email_service
+    monkeypatch.setattr(email_service.EmailService, 'send_email',
+                        staticmethod(lambda *a, **k: True))
+
+    donor = seed_donation(db_session, 'C1', name='Kevin Gu')
+    resp = client.post(f'/api/donors/donations/{donor.donation_id}/send-thank-you',
+                       json={'email': 'kevin@example.com'},
+                       headers=auth(committee_member))
+    assert resp.status_code == 200
+
+    entry = db_session.query(DonorDirectoryEntry).filter_by(name='kevin gu').first()
+    assert entry is not None
+    assert entry.email == 'kevin@example.com'
+
+
+def test_send_thank_you_updates_a_stale_directory_email(client, db_session, committee_member, monkeypatch):
+    import email_service
+    monkeypatch.setattr(email_service.EmailService, 'send_email',
+                        staticmethod(lambda *a, **k: True))
+    db_session.add(DonorDirectoryEntry(name='kevin gu', email='old@example.com'))
+    db_session.commit()
+
+    donor = seed_donation(db_session, 'C1', name='Kevin Gu')
+    resp = client.post(f'/api/donors/donations/{donor.donation_id}/send-thank-you',
+                       json={'email': 'new@example.com'},
+                       headers=auth(committee_member))
+    assert resp.status_code == 200
+
+    entries = db_session.query(DonorDirectoryEntry).filter_by(name='kevin gu').all()
+    assert len(entries) == 1  # updated in place, not duplicated
+    assert entries[0].email == 'new@example.com'
 
 
 def test_send_thank_you_appends_ack_to_existing_notes(client, db_session, committee_member, monkeypatch):


### PR DESCRIPTION
## Summary
- The send-thank-you dialog always started with a blank email field, even for a donor already thanked before — Zelle/Venmo payment notification emails don't carry an address, so the committee retyped it every time.
- Reuses the `donor_directory` table the Finance module already maintains (name → email, used for batch acknowledgments and year-end statements) instead of adding a parallel one.

**Prefill**: `GET /api/donors/ledger` now includes a suggested `email` per donation, looked up by normalized donor name. The send-thank-you dialog prefills from it and shows a "Remembered from a previous thank-you" hint when it did.

**Remember**: after a thank-you email actually sends (from the single-send dialog, Finance's batch ack queue, or the weekly auto-send job — all three share `send_acknowledgment`), the address is saved/updated in the directory automatically.

## Test plan
- [x] Backend: `pytest -q --cov=. --cov-report=term-missing` — 891 passed, `routes/donors.py` 99.5%
- [x] Frontend: `react-scripts test --coverage --watchAll=false` — 1247 passed, `DonationLedger.js` 98.5%/90%/100%/99.7% (stmts/branch/funcs/lines)
- [x] New tests: ledger includes/omits the directory email correctly, a sent thank-you creates a new directory entry, a sent thank-you updates a stale one in place (not duplicated), dialog prefills and shows the "remembered" hint

🤖 Generated with [Claude Code](https://claude.com/claude-code)