### PR TITLE
Fix Add/Edit/Delete Donor auth + new template placeholders

### DIFF
--- a/ProjectCode/client/src/api/donors.js
+++ b/ProjectCode/client/src/api/donors.js
@@ -33,10 +33,15 @@ export async function getDonorById(donorId) {
 /**
  * Create a new donor
  * @param {Object} donorData - Donor data
+ * @param {string} [firebaseUid] - Committee/admin Firebase UID
  * @returns {Promise<Object>} Created donor
  */
-export async function createDonor(donorData) {
-  return api.post('/api/donors', donorData);
+export async function createDonor(donorData, firebaseUid) {
+  return api.post(
+    '/api/donors',
+    donorData,
+    firebaseUid ? { 'X-Firebase-UID': firebaseUid } : {}
+  );
 }
 
 /**

--- a/ProjectCode/client/src/api/donors.test.js
+++ b/ProjectCode/client/src/api/donors.test.js
@@ -56,7 +56,13 @@ test('getDonorById GETs donor by id', async () => {
 test('createDonor POSTs donor data', async () => {
   const data = { name: 'Alice', amount: 100 };
   await expect(createDonor(data)).resolves.toBe('POST');
-  expect(api.post).toHaveBeenCalledWith('/api/donors', data);
+  expect(api.post).toHaveBeenCalledWith('/api/donors', data, {});
+});
+
+test('createDonor passes the auth header when a uid is given', async () => {
+  const data = { name: 'Alice', amount: 100 };
+  await createDonor(data, 'uid-1');
+  expect(api.post).toHaveBeenCalledWith('/api/donors', data, { 'X-Firebase-UID': 'uid-1' });
 });
 
 test('updateDonor PUTs donor data', async () => {

--- a/ProjectCode/client/src/components/DonationLedger.js
+++ b/ProjectCode/client/src/components/DonationLedger.js
@@ -1002,6 +1002,8 @@ export default function DonationLedger({ onLedgerChange }) {
             {' '}<Chip size="small" label="{name}" sx={{ fontFamily: 'monospace', fontSize: '0.6875rem', height: 20, backgroundColor: '#e8f0fe', color: BLUE }} />
             {' '}<Chip size="small" label="{amount}" sx={{ fontFamily: 'monospace', fontSize: '0.6875rem', height: 20, backgroundColor: '#e8f0fe', color: BLUE }} />
             {' '}<Chip size="small" label="{date}" sx={{ fontFamily: 'monospace', fontSize: '0.6875rem', height: 20, backgroundColor: '#e8f0fe', color: BLUE }} />
+            {' '}<Chip size="small" label="{date_cn}" sx={{ fontFamily: 'monospace', fontSize: '0.6875rem', height: 20, backgroundColor: '#e8f0fe', color: BLUE }} />
+            {' '}<Chip size="small" label="{payment_method}" sx={{ fontFamily: 'monospace', fontSize: '0.6875rem', height: 20, backgroundColor: '#e8f0fe', color: BLUE }} />
           </Typography>
 
           {templates.map((template) => (

--- a/ProjectCode/client/src/pages/SponsorsPage.js
+++ b/ProjectCode/client/src/pages/SponsorsPage.js
@@ -4,7 +4,7 @@ import DeleteIcon from '@mui/icons-material/Delete';
 import AddIcon from '@mui/icons-material/Add';
 import InfoIcon from '@mui/icons-material/Info';
 import { useEffect, useState } from 'react';
-import { useAdmin } from '../context';
+import { useAdmin, useAuth } from '../context';
 import { useAutoFillOnTab } from '../hooks';
 import DonationLedger from '../components/DonationLedger';
 import DonationHeroCard from '../components/DonationHeroCard';
@@ -22,6 +22,8 @@ const MUTED = '#757575';
 
 export default function SponsorsPage() {
   const { adminModeEnabled } = useAdmin();
+  const { currentUser } = useAuth();
+  const firebaseUid = currentUser?.uid;
   const [individualDonors, setIndividualDonors] = useState([]);
   const [enterpriseDonors, setEnterpriseDonors] = useState([]);
   const [selectedTab, setSelectedTab] = useState(0);
@@ -158,7 +160,7 @@ export default function SponsorsPage() {
           notes: donorFormData.notes || null,
           hide_name: donorFormData.hide_name,
           hide_message: donorFormData.hide_message
-        });
+        }, firebaseUid);
       } else {
         // Create new donor
         const donorType = selectedTab === 0 ? 'individual' : 'enterprise';
@@ -175,7 +177,7 @@ export default function SponsorsPage() {
           notes: donorFormData.notes || null,
           hide_name: donorFormData.hide_name,
           hide_message: donorFormData.hide_message
-        });
+        }, firebaseUid);
       }
       handleCloseEditDialog();
       fetchDonors(); // Refresh the list
@@ -195,7 +197,7 @@ export default function SponsorsPage() {
   const handleConfirmDelete = async () => {
     setSaving(true);
     try {
-      await deleteDonor(editingDonor.donor_id);
+      await deleteDonor(editingDonor.donor_id, firebaseUid);
       setDeleteDialogOpen(false);
       setEditingDonor(null);
       fetchDonors(); // Refresh the list

--- a/ProjectCode/client/src/pages/SponsorsPage.test.js
+++ b/ProjectCode/client/src/pages/SponsorsPage.test.js
@@ -1,7 +1,7 @@
 import { render, screen, fireEvent, waitFor, within, act } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import SponsorsPage from './SponsorsPage';
-import { useAdmin } from '../context';
+import { useAdmin, useAuth } from '../context';
 import {
   getAllDonors,
   getPublicDonors,
@@ -14,6 +14,7 @@ import {
 
 jest.mock('../context', () => ({
   useAdmin: jest.fn(),
+  useAuth: jest.fn(),
 }));
 let mockAutoFillOptions = null;
 jest.mock('../hooks', () => ({
@@ -74,6 +75,7 @@ const renderPage = () =>
 beforeEach(() => {
   jest.clearAllMocks();
   useAdmin.mockReturnValue({ adminModeEnabled: false });
+  useAuth.mockReturnValue({ currentUser: { uid: 'admin-uid' } });
   getPublicDonors.mockResolvedValue(publicDonors);
   getAllDonors.mockResolvedValue(adminDonors);
   getHideAmounts.mockResolvedValue({ hide_amounts: false });
@@ -210,7 +212,8 @@ describe('admin view', () => {
           hide_name: true,
           hide_message: true,
           quantity: 1,
-        })
+        }),
+        'admin-uid'
       )
     );
     await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
@@ -229,7 +232,8 @@ describe('admin view', () => {
     fireEvent.click(within(dialog).getByText('Save / 保存'));
     await waitFor(() =>
       expect(createDonor).toHaveBeenCalledWith(
-        expect.objectContaining({ name: 'Big Co', donor_type: 'enterprise', amount: 1000 })
+        expect.objectContaining({ name: 'Big Co', donor_type: 'enterprise', amount: 1000 }),
+        'admin-uid'
       )
     );
   });
@@ -268,7 +272,8 @@ describe('admin view', () => {
     await waitFor(() =>
       expect(updateDonor).toHaveBeenCalledWith(
         'IND_1',
-        expect.objectContaining({ name: 'Jane Zhang', amount: 275, notes: 'via check', hide_name: false })
+        expect.objectContaining({ name: 'Jane Zhang', amount: 275, notes: 'via check', hide_name: false }),
+        'admin-uid'
       )
     );
   });
@@ -304,7 +309,7 @@ describe('admin view', () => {
     const dialog = await screen.findByRole('dialog');
     expect(within(dialog).getByText(/Are you sure you want to delete donor "Jane Zhang"\?/)).toBeInTheDocument();
     fireEvent.click(within(dialog).getByText('Delete / 删除'));
-    await waitFor(() => expect(deleteDonor).toHaveBeenCalledWith('IND_1'));
+    await waitFor(() => expect(deleteDonor).toHaveBeenCalledWith('IND_1', 'admin-uid'));
     await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
     await waitFor(() => expect(getAllDonors).toHaveBeenCalledTimes(2));
   });

--- a/ProjectCode/server/routes/donors.py
+++ b/ProjectCode/server/routes/donors.py
@@ -412,12 +412,34 @@ def _select_template(db: Session, donor):
     return None
 
 
+def _payment_method_label(source: str) -> str:
+    """Human-readable payment method for the {payment_method} placeholder,
+    matching the provider labels shown in the ledger UI."""
+    lowered = (source or "").lower()
+    if "venmo" in lowered:
+        return "Venmo"
+    if "zelle" in lowered:
+        return "Zelle"
+    if "check" in lowered:
+        return "Check"
+    if "ach" in lowered:
+        return "ACH"
+    if "cash" in lowered:
+        return "Cash"
+    return "Manual"
+
+
 def _render_placeholders(text: str, donor) -> str:
     amount = f"${donor.amount:,.2f}"
     date_str = donor.donation_date.strftime('%B %d, %Y') if donor.donation_date else ''
+    # Chinese convention omits the leading zero on month/day (七月 not 07月)
+    date_cn = (f"{donor.donation_date.year}年{donor.donation_date.month}月{donor.donation_date.day}日"
+               if donor.donation_date else '')
     return (text.replace('{name}', donor.name)
                 .replace('{amount}', amount)
-                .replace('{date}', date_str))
+                .replace('{date_cn}', date_cn)
+                .replace('{date}', date_str)
+                .replace('{payment_method}', _payment_method_label(donor.source)))
 
 
 def _text_to_html(text: str) -> str:

--- a/ProjectCode/server/tests/test_thankyou_templates.py
+++ b/ProjectCode/server/tests/test_thankyou_templates.py
@@ -116,6 +116,27 @@ def test_preview_renders_placeholders(client, db_session, committee_member):
     assert preview['template_name'] == 'Standard'
 
 
+def test_preview_renders_payment_method_and_chinese_date(client, db_session, committee_member):
+    seed_template(db_session, 'Standard', min_amount=0,
+                  subject='Thanks {name}!',
+                  body='{payment_method} gift of {amount} on {date_cn} ({date}).')
+    donor = seed_donation(db_session, 'D1', name='Yue Ma', amount=20,
+                          donation_date=date(2026, 7, 14), source='Venmo (Yue Ma)')
+
+    preview = client.get(f'/api/donors/donations/{donor.donation_id}/thank-you-preview',
+                         headers=auth(committee_member)).json()
+    assert preview['body'] == 'Venmo gift of $20.00 on 2026年7月14日 (July 14, 2026).'
+
+
+def test_payment_method_defaults_to_manual_for_unrecognized_source(client, db_session, committee_member):
+    seed_template(db_session, 'Standard', min_amount=0, body='Paid via {payment_method}.')
+    donor = seed_donation(db_session, 'D1', source='Manual entry')
+
+    preview = client.get(f'/api/donors/donations/{donor.donation_id}/thank-you-preview',
+                         headers=auth(committee_member)).json()
+    assert preview['body'] == 'Paid via Manual.'
+
+
 def test_preview_falls_back_to_builtin_without_templates(client, db_session, committee_member):
     donor = seed_donation(db_session, 'D1')
     preview = client.get(f'/api/donors/donations/{donor.donation_id}/thank-you-preview',


### PR DESCRIPTION
## Summary
- **Bug fix**: Add/Edit/Delete Donor on the Sponsors admin panel silently failed — none of the three calls sent the `X-Firebase-UID` header the backend requires, so every attempt hit a 401.
- **Feature**: adds `{payment_method}` and `{date_cn}` thank-you template placeholders, needed for a bilingual receipt-style letter template.

## Test plan
- [x] Backend: 893 passed
- [x] Frontend: 1248 passed (52 in the two touched files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)