### PR TITLE
Fix two silent gaps in the Gmail donation sync

### DIFF
--- a/ProjectCode/server/sync_zelle_donations.py
+++ b/ProjectCode/server/sync_zelle_donations.py
@@ -96,6 +96,12 @@ def search_venmo_emails(mail, since_date=None):
     """
     Search for incoming Venmo payment notification emails.
 
+    Venmo sends two different subject formats for a real incoming payment,
+    seemingly depending on where the money lands (instant transfer vs the
+    Venmo balance): "X paid you $Y" and "X paid $Y to your Venmo account.
+    Leave it in Venmo or transfer it to your bank account." — both must be
+    searched for, or the second form is silently invisible to sync.
+
     Args:
         mail: IMAP connection (with the Venmo folder selected)
         since_date: Optional date string (DD-Mon-YYYY) to filter emails
@@ -103,9 +109,10 @@ def search_venmo_emails(mail, since_date=None):
     Returns:
         List of email IDs
     """
-    criteria = '(FROM "venmo@venmo.com" SUBJECT "paid you")'
+    subject_or = '(OR (SUBJECT "paid you") (SUBJECT "to your Venmo account"))'
+    criteria = f'(FROM "venmo@venmo.com") {subject_or}'
     if since_date:
-        criteria = f'(FROM "venmo@venmo.com" SUBJECT "paid you" SINCE {since_date})'
+        criteria = f'(FROM "venmo@venmo.com") (SINCE {since_date}) {subject_or}'
 
     print(f"Searching emails with criteria: {criteria}")
     status, data = mail.search(None, criteria)
@@ -201,8 +208,11 @@ def parse_zelle_email(raw_email):
     if "sent you" not in text.lower():
         return None
 
-    # Extract sender name: "FIRSTNAME LASTNAME sent you"
-    sender_match = re.search(r'([A-Z][A-Z\s\-\'\.]+?)\s+sent\s+you', text)
+    # Extract sender name: "FIRSTNAME LASTNAME sent you". Chase doesn't
+    # consistently render this in caps — "JIAN SHEN", "Kanglin Yu", and
+    # "JINLING zhang" all occur — so the match must be case-insensitive or
+    # any non-uppercase name silently fails to parse.
+    sender_match = re.search(r'([A-Z][A-Z\s\-\'\.]+?)\s+sent\s+you', text, re.IGNORECASE)
     if not sender_match:
         return None
     sender_name = sender_match.group(1).strip().title()
@@ -313,9 +323,14 @@ def parse_venmo_email(raw_email):
     """
     Parse a raw Venmo payment notification email into structured data.
 
-    Venmo puts the payer and amount in the subject ("Xiao Yang paid you
-    $15.00") and the payment note in the body. Dedup uses the transaction id
-    from the "See transaction" link, falling back to the email Message-ID.
+    Venmo puts the payer and amount in the subject and the payment note in
+    the body. Two subject formats carry a real incoming payment — which one
+    arrives seems to depend on whether the money lands as an instant
+    transfer or in the Venmo balance: "Xiao Yang paid you $15.00", or
+    "Xiao Yang paid $15.00 to your Venmo account. Leave it in Venmo or
+    transfer it to your bank account." Both must be tried, or the second
+    form silently returns no donation. Dedup uses the transaction id from
+    the "See transaction" link, falling back to the email Message-ID.
 
     Args:
         raw_email: Raw email bytes
@@ -327,6 +342,10 @@ def parse_venmo_email(raw_email):
 
     subject = _decode_subject(msg)
     subject_match = re.search(r'(.+?)\s+paid\s+you\s+\$([\d,]+\.?\d*)', subject)
+    if not subject_match:
+        subject_match = re.search(
+            r'(.+?)\s+paid\s+\$([\d,]+\.?\d*)\s+to\s+your\s+Venmo\s+account', subject
+        )
     if not subject_match:
         return None
     sender_name = subject_match.group(1).strip()

--- a/ProjectCode/server/tests/test_donation_ledger.py
+++ b/ProjectCode/server/tests/test_donation_ledger.py
@@ -820,6 +820,27 @@ def test_search_zelle_emails_failure_returns_empty():
     assert szd.search_zelle_emails(FakeSearchMail(status='NO')) == []
 
 
+def test_search_venmo_emails_matches_both_subject_formats():
+    # "paid you $Y" and "paid $Y to your Venmo account" are both real
+    # incoming payments — the OR must cover both or the second is invisible
+    mail = FakeSearchMail()
+    assert szd.search_venmo_emails(mail) == [b'1', b'2', b'3']
+    assert 'SUBJECT "paid you"' in mail.criteria
+    assert 'SUBJECT "to your Venmo account"' in mail.criteria
+    assert 'OR' in mail.criteria
+    assert 'SINCE' not in mail.criteria
+
+    mail = FakeSearchMail()
+    szd.search_venmo_emails(mail, since_date='01-Jan-2026')
+    assert 'SINCE 01-Jan-2026' in mail.criteria
+    assert 'SUBJECT "paid you"' in mail.criteria
+    assert 'SUBJECT "to your Venmo account"' in mail.criteria
+
+
+def test_search_venmo_emails_failure_returns_empty():
+    assert szd.search_venmo_emails(FakeSearchMail(status='NO')) == []
+
+
 # ---- strip_html
 
 def test_strip_html_removes_tags_and_decodes_entities():
@@ -866,9 +887,13 @@ def test_parse_rejects_non_incoming_payment():
     assert szd.parse_zelle_email(not_incoming_email()) is None
 
 
-def test_parse_rejects_lowercase_sender_name():
-    # "sent you" is present but the uppercase sender pattern cannot match
-    assert szd.parse_zelle_email(lowercase_sender_email()) is None
+def test_parse_accepts_lowercase_sender_name():
+    # Chase doesn't always render the sender name in caps — the match must
+    # be case-insensitive or a real donation silently fails to parse
+    parsed = szd.parse_zelle_email(lowercase_sender_email())
+    assert parsed is not None
+    assert parsed['sender_name'] == 'John Doe'
+    assert parsed['amount'] == Decimal('25.00')
 
 
 def test_parse_invalid_sent_on_date_falls_back_to_header():

--- a/ProjectCode/server/tests/test_zelle_sync.py
+++ b/ProjectCode/server/tests/test_zelle_sync.py
@@ -70,6 +70,19 @@ def test_parse_zelle_email_na_memo_ignored():
     assert parsed['memo'] is None
 
 
+def test_parse_zelle_email_handles_titlecase_sender_name():
+    # Chase doesn't consistently send names in caps — "Kanglin Yu" (Title
+    # Case) silently failed to parse before the regex was made case-insensitive
+    parsed = zelle.parse_zelle_email(make_zelle_email(sender='Kanglin Yu'))
+    assert parsed['sender_name'] == 'Kanglin Yu'
+
+
+def test_parse_zelle_email_handles_mixed_case_sender_name():
+    # "JINLING zhang" — first name caps, last name lowercase
+    parsed = zelle.parse_zelle_email(make_zelle_email(sender='JINLING zhang'))
+    assert parsed['sender_name'] == 'Jinling Zhang'
+
+
 # ---------------------------------------------------------------- record builder
 
 def test_build_donor_record_defaults_to_pending_with_excerpt():
@@ -211,6 +224,30 @@ def test_parse_venmo_email_encoded_subject():
     parsed = zelle.parse_venmo_email(msg.as_bytes())
     assert parsed['sender_name'] == '王小'
     assert parsed['amount'] == Decimal('88.00')
+
+
+def test_parse_venmo_email_alternate_subject_format():
+    # Venmo sometimes sends "X paid $Y to your Venmo account. Leave it in
+    # Venmo or transfer it to your bank account." instead of "X paid you
+    # $Y" — the body still carries a "paid you" heading either way.
+    html = """
+    <html><body>
+      <p>Chengcheng Zhao paid you $20.00 Chengcheng Zhao paid you $20.00</p>
+      <p>Chengcheng Zhao paid you</p>
+      <p>$</p><p>20</p><p>. 00</p>
+      <a href="https://venmo.com/story/4611697894995121600">See transaction</a>
+      <p>Money credited to your Venmo account.</p>
+    </body></html>
+    """
+    msg = MIMEText(html, 'html', 'utf-8')
+    msg['Subject'] = ('Chengcheng Zhao paid $20.00 to your Venmo account. '
+                      'Leave it in Venmo or transfer it to your bank account.')
+    msg['Date'] = 'Tue, 14 Jul 2026 13:57:20 -0400'
+    parsed = zelle.parse_venmo_email(msg.as_bytes())
+    assert parsed is not None
+    assert parsed['sender_name'] == 'Chengcheng Zhao'
+    assert parsed['amount'] == Decimal('20.00')
+    assert parsed['transaction_number'] == '4611697894995121600'
 
 
 def test_build_donor_record_venmo_provider_strings():


### PR DESCRIPTION
## Summary
Investigated against the real Gmail account and the club's donation-tracking sheet after confirmed donations weren't appearing in the ledger despite clicking "Sync now". Found two independent, silent parsing/search bugs:

1. **Zelle**: sender-name regex required ALL CAPS. Chase actually sends Title Case ("Kanglin Yu") and mixed case ("JINLING zhang") too — now case-insensitive.
2. **Venmo**: search only looked for `SUBJECT "paid you"`. Venmo also sends `"X paid $Y to your Venmo account..."` for some real payments — a different subject the search never retrieved at all. Now searches both via IMAP `OR`.

The weekly scheduler job (Mon 4:30 AM UTC) already exists and runs reliably — no change to the 30-day lookback window, since that's fine given weekly re-runs. The gap was entirely in what each run could find/parse.

Verified against the live Gmail account: Zelle 19→21 parsed, Venmo 24→31 found/31 parsed (0 failures), for the last 30 days alone.

## Test plan
- [x] Backend: 898 passed
- [x] New tests for both fixes, plus an old test that had encoded the Zelle bug as expected behavior (updated to assert the correct behavior)
- [x] Verified live against Gmail via SSH before and after the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)