### PR TITLE
Deploy: fix Venmo dedup false-positive

### DIFF
--- a/ProjectCode/server/sync_zelle_donations.py
+++ b/ProjectCode/server/sync_zelle_donations.py
@@ -356,8 +356,14 @@ def parse_venmo_email(raw_email):
     memo = _extract_venmo_memo(text) if text else None
 
     # Transaction id: the "Transaction ID" field in the body, else the id in
-    # the "See transaction" link, else the email Message-ID
-    txn_match = re.search(r'Transaction\s+ID\s*\n\s*(\d+)', text, re.IGNORECASE)
+    # the "See transaction" link, else the email Message-ID. IDs are
+    # numeric on the standard "paid you" notification but alphanumeric
+    # (PayPal-style, e.g. "7R4007699Y124851X") on the "paid $Y to your
+    # Venmo account" notification — a digits-only pattern here truncates
+    # the latter to its leading digit or two, which then spuriously
+    # dedup-matches against unrelated donations sharing that short digit
+    # string in their notes.
+    txn_match = re.search(r'Transaction\s+ID\s*\n\s*([A-Za-z0-9]+)', text, re.IGNORECASE)
     if not txn_match:
         txn_match = re.search(
             r'venmo\.com/(?:story|payment)s?/([A-Za-z0-9_\-]+)', body or ''
@@ -398,6 +404,13 @@ def auto_ignore_keyword(memo):
     return None
 
 
+#  Real transaction numbers are always well above this — Zelle ~11 digits,
+# Venmo numeric IDs ~19 digits, Venmo alphanumeric IDs ~17 chars. A short
+# value here means a parsing regex grabbed a fragment, not a real ID; used
+# for substring dedup, a short value matches almost any unrelated note.
+MIN_TRANSACTION_NUMBER_LENGTH = 6
+
+
 def is_duplicate(session, transaction_number):
     """
     Check if a donation with this transaction number already exists.
@@ -409,7 +422,7 @@ def is_duplicate(session, transaction_number):
     Returns:
         True if duplicate found
     """
-    if not transaction_number:
+    if not transaction_number or len(transaction_number) < MIN_TRANSACTION_NUMBER_LENGTH:
         return False
 
     existing = session.query(Donor).filter(

--- a/ProjectCode/server/tests/test_zelle_sync.py
+++ b/ProjectCode/server/tests/test_zelle_sync.py
@@ -173,6 +173,16 @@ def test_parse_venmo_email_prefers_transaction_id_field():
     assert parsed['transaction_number'] == '4611697894323507636'
 
 
+def test_parse_venmo_email_alphanumeric_transaction_id():
+    # The "paid $Y to your Venmo account" notification's Transaction ID is
+    # PayPal-style alphanumeric (e.g. "7R4007699Y124851X"), unlike the
+    # standard notification's purely numeric ID. A digits-only pattern here
+    # truncates it to a leading digit or two — a near-guaranteed false
+    # dedup match against unrelated donations.
+    parsed = zelle.parse_venmo_email(make_venmo_email(txn_text='7R4007699Y124851X'))
+    assert parsed['transaction_number'] == '7R4007699Y124851X'
+
+
 def test_parse_venmo_email_falls_back_to_message_id_for_dedup():
     parsed = zelle.parse_venmo_email(make_venmo_email(txn_link=None))
     assert parsed['transaction_number'] == 'venmo-abc-123@venmo.com'
@@ -404,6 +414,21 @@ def test_is_duplicate_matches_transaction_number(db_session):
     assert zelle.is_duplicate(db_session, '555000111') is True
     assert zelle.is_duplicate(db_session, '999999999') is False
     assert zelle.is_duplicate(db_session, None) is False
+
+
+def test_is_duplicate_ignores_short_transaction_numbers(db_session):
+    # A short "transaction number" is a sign a parsing regex grabbed a
+    # fragment, not a real ID — substring-matching it against notes would
+    # false-positive on almost any unrelated donation (e.g. one whose real
+    # transaction number, amount, or date happens to contain "7")
+    db_session.add(Donor(
+        donor_id='IND_1', name='Li Chen', donor_type='individual', amount=100,
+        notes='Zelle Transaction #5550700111',
+    ))
+    db_session.commit()
+
+    assert zelle.is_duplicate(db_session, '7') is False
+    assert zelle.is_duplicate(db_session, '07') is False
 
 
 def test_record_sync_status_writes_and_updates_settings(db_session, monkeypatch):


### PR DESCRIPTION
Promotes dev to prod.

- Fix false-positive dedup from truncated Venmo transaction IDs (#94)

🤖 Generated with [Claude Code](https://claude.com/claude-code)