### PR TITLE
Fix "Payment" leaking into every Zelle donor name

### DIFF
--- a/ProjectCode/server/sync_zelle_donations.py
+++ b/ProjectCode/server/sync_zelle_donations.py
@@ -212,7 +212,16 @@ def parse_zelle_email(raw_email):
     # consistently render this in caps — "JIAN SHEN", "Kanglin Yu", and
     # "JINLING zhang" all occur — so the match must be case-insensitive or
     # any non-uppercase name silently fails to parse.
-    sender_match = re.search(r'([A-Z][A-Z\s\-\'\.]+?)\s+sent\s+you', text, re.IGNORECASE)
+    #
+    # The character class uses a literal space, NOT \s, deliberately: every
+    # real email's body reads "Zelle (r) payment\n{NAME} sent you money" —
+    # with \s (which matches newlines) and IGNORECASE together, "payment"
+    # itself satisfies [A-Z], and since re.search returns the leftmost
+    # match, the engine prefers starting at "payment" and bridges the
+    # newline straight into the real name (e.g. "Payment\n Juan Du"
+    # instead of "Juan Du"). A newline can never appear inside a real
+    # sender name, so excluding it keeps the match on a single line.
+    sender_match = re.search(r'([A-Z][A-Z \-\'\.]+?)\s+sent\s+you', text, re.IGNORECASE)
     if not sender_match:
         return None
     sender_name = sender_match.group(1).strip().title()

--- a/ProjectCode/server/tests/test_zelle_sync.py
+++ b/ProjectCode/server/tests/test_zelle_sync.py
@@ -83,6 +83,27 @@ def test_parse_zelle_email_handles_mixed_case_sender_name():
     assert parsed['sender_name'] == 'Jinling Zhang'
 
 
+def test_parse_zelle_email_does_not_leak_payment_heading_into_name():
+    # Real Chase emails read "Zelle (r) payment\n{NAME} sent you money" —
+    # with the sender regex case-insensitive, "payment" itself satisfies
+    # [A-Z], and since re.search takes the leftmost match, an \s-based
+    # character class (which also matches \n) bridges straight from
+    # "payment" across the newline into the real name, corrupting it to
+    # "Payment\n Juan Du" instead of "Juan Du".
+    text = (
+        'zelle_auto_accept_receiver_chase_email \n'
+        ' Zelle ® payment\n'
+        ' JUAN DU sent you money\n'
+        ' Here are the details:\n'
+        ' Amount\n $200.00\n'
+        ' Sent on\n May 18, 2026\n'
+        ' Transaction number\n 29265937883\n'
+    )
+    msg = MIMEText(text, 'plain')
+    parsed = zelle.parse_zelle_email(msg.as_bytes())
+    assert parsed['sender_name'] == 'Juan Du'
+
+
 # ---------------------------------------------------------------- record builder
 
 def test_build_donor_record_defaults_to_pending_with_excerpt():


### PR DESCRIPTION
## Summary
Second follow-up to #92. Every real Chase email body reads `Zelle (r) payment\n{NAME} sent you money`. Making the sender regex case-insensitive meant "payment" itself now satisfies `[A-Z]`, and since `re.search` returns the leftmost match, the `\s`-based character class (which matches `\n`) let the match start at "payment" and bridge across the newline into the real name — corrupting **every** newly-parsed Zelle name to `"Payment\n {Name}"`.

Found 56 corrupted rows in production (all still `pending`/`dismissed`, never approved/public) — will clean those up directly after this deploys.

Root cause: `\s` inside the capture's character class matches `\n`. Real sender names never contain a newline, so the class now uses a literal space instead, which can't cross a line boundary.

## Test plan
- [x] Backend: 901 passed
- [x] New regression test replicating the exact real email structure (heading + newline + name)
- [x] Verified against the live corrupted record via SSH before fixing

🤖 Generated with [Claude Code](https://claude.com/claude-code)